### PR TITLE
Replace translation of `warp` skill in Kor & Jap

### DIFF
--- a/data/local/lng/strings/skills.json
+++ b/data/local/lng/strings/skills.json
@@ -35810,10 +35810,10 @@
         "esES": "Teletransporte",
         "frFR": "Téléportation",
         "itIT": "Teletrasporto",
-        "koKR": "순간이동",
+        "koKR": "워프",
         "plPL": "Teleportacja",
         "esMX": "Teletransporte",
-        "jaJP": "テレポート",
+        "jaJP": "ワープ",
         "ptBR": "Teleporte",
         "ruRU": "Телепортация",
         "zhCN": "传送"


### PR DESCRIPTION
all language strings except Eng are duplicated `Teleport` skill. Users couldn't know a item gives real teleport or warp before equip.

IMHO, `blink` is better match for other games's metaphor such as POE series and we could easily find better translation than `warp`.

(cus, it's already translated in POE2

- KR: `점멸`
- TW: `閃現`
- CN: `闪现`
- JP: `ブリンク`
- RU: `Скачок`
- PT: `Teleportar` ; IMO it's still teleport, it might be `piscar`?
- FR: `Transfert` ; similar PT; it might be `Trembloter`?
- DE: `Blinzeln`
- ES: `Parpadeo` )

or we should directly use `warp` transliteration.
(cus video game scene, warp is common word.)

in this patch only apply `warp` transliteration to kor/jap.