### PR TITLE
unique charm sprites

### DIFF
--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -116,12 +116,12 @@ Snakecord	113	0	1			1	1	16	12	vbl	Light Belt		5	5000	blac	blac						dmg-pois	75	
 Nightsmoke	114	0	1			1	1	27	20	mbl	Belt		5	5000	lyel	lyel						res-all		10	10	dmg-to-mana		50	50	mana		20	20	red-dmg		2	2	ac		15	15	ac%		30	50																										0
 Goldwrap	115	0	1			1	1	36	27	tbl	Heavy Belt		5	5000	lblu	lblu						mag%		30	30	light		2	2	ac		25	25	swing2		10	10	ac%		40	60	gold%		50	80																										0
 Bladebuckle	116	0	1			1	1	39	29	hbl	Girdle		5	5000	dyel	dyel						thorns		8	8	ac		30	30	red-dmg		3	3	str		5	5	dex		10	10	ac%		80	100	balance2		30	30																						0
-Nokozan Relic	117	0	1			7	1	14	10	amu	Amulet		5	5000	lgld							dmg-fire		3	6	res-fire-max		10	10	res-fire		50	50	light		3	3	balance2		20	20																														0
+Nokozan Relic	117	0	1			20	1	14	10	amu	Amulet		5	5000	lgld							dmg-fire		3	6	res-fire-max		10	10	res-fire		50	50	light		3	3	balance2		20	20																														0
 The Eye of Etlich	118	0	1			5	1	20	15	amu	Amulet		5	5000	dgld							ac-miss		10	40	light		1	5	allskills		1	1	lifesteal		3	7	cold-min		1	2	cold-max		3	5	cold-len		50	250																						0
-The Mahim-Oak Curio	119	0	1			7	1	34	25	amu	Amulet		5	5000	lpur							dex		10	10	str		10	10	enr		10	10	vit		10	10	ac		10	10	att%		10	10	res-all		10	10	ac%		10	10																		0
-Nagelring	120	0	1			7	1	10	7	rin	Ring		5	5000	dpur							red-mag		3	3	thorns		3	3	att		50	75	mag%		15	30																																		0
-Manald Heal	121	0	1			7	1	20	15	rin	Ring		5	5000	oran							manasteal		4	7	regen		5	8	hp		20	20	regen-mana		20	20																																		0
-The Stone of Jordan	122	0	1			2	1	39	29	rin	Ring		5	5000	whit							mana		20	20	mana%		25	25	ltng-min		25	25	allskills		1	1	ltng-max		50	50																													1	0
+The Mahim-Oak Curio	119	0	1			10	1	34	25	amu	Amulet		5	5000	lpur							dex		10	10	str		10	10	enr		10	10	vit		10	10	ac		10	10	att%		10	10	res-all		10	10	ac%		10	10																		0
+Nagelring	120	0	1			15	1	10	7	rin	Ring		5	5000	dpur							red-mag		3	3	thorns		3	3	att		50	75	mag%		15	30																																		0
+Manald Heal	121	0	1			15	1	20	15	rin	Ring		5	5000	oran							manasteal		4	7	regen		5	8	hp		20	20	regen-mana		20	20																																		0
+The Stone of Jordan	122	0	1			1	1	39	29	rin	Ring		5	5000	whit							mana		20	20	mana%		25	25	ltng-min		25	25	allskills		1	1	ltng-max		50	50																													1	0
 Amulet of the Viper	123	0	1			1	1	0	0	vip	Amulet		5	5000	lgry							mana		10	10	res-pois		25	25	hp		10	10			0	0			0	0			0	0			0	0																						0
 Staff of Kings	124	0	1			1	1	0	0	msf	Staff		5	5000	dgry							res-all		10	10	swing3		50	50			0	0			0	0			0	0			0	0			0	0																						0
 Horadric Staff	125	0	1			1	1	0	0	hst	Staff		5	5000	blac							mana		10	10	res-pois		25	25	hp		10	10	res-all		10	10	swing3		50	50			0	0			0	0																						0
@@ -263,20 +263,20 @@ Lightsabre	259	100	1			5	1	66	58	7cr	Phase Blade		5	5000	lblu			invcrsu				light
 Doombringer	260	100	1			1	1	75	69	7b7	Champion Sword		5	5000	dred	dred		invbswu				hp%		20	20	dmg%		180	250	att%		40	40	indestruct		1	1	dmg-norm		30	100	hit-skill	Weaken	8	3	lifesteal		5	7	oskill_hide	393	1	1																		0
 The Grandfather	261	100	1			1	1	85	81	7gd	Colossus Blade		5	5000	lyel	lyel		invgsdu				str		20	20	dex		20	20	vit		20	20	enr		20	20	att%		50	50	hp		80	80	dmg/lvl	20			indestruct		1	1	dmg%		150	250	oskill_hide	393	1	1										0
 Wizardspike	262	100	1			1	1	69	61	7dg	Bone Knife		5	5000	lgry	lgry						mana/lvl	16			regen-mana		15	15	mana%		15	15	res-all		75	75	indestruct		1	1	cast3		50	50	oskill_hide	393	1	1																						0
-Constricting Ring	263	100	1			2	1	95	95	rin	Ring		5	5000	cblu	cblu						res-all		40	40	regen		-30	-30	mag%		100	100	res-all-max		5	5										0																								0
+Constricting Ring	263	100	1			1	1	95	95	rin	Ring		5	5000	cblu	cblu						res-all		40	40	regen		-30	-30	mag%		100	100	res-all-max		5	5										0																								0
 Stormspire	264	100	1			1	1	78	70	7wc	Giant Thresher		5	5000	dblu	dblu						res-ltng		50	50	gethit-skill	Chain Lightning	5	5	dmg%		150	250	str		10	10	gethit-skill	Charged Bolt	2	0	swing2		30	30	indestruct		1	1	dmg-ltng		1	237	light-thorns		27	27	oskill_hide	393	1	1										0
 Eaglehorn	265	100	1			1	1	77	69	6l7	Crusader Bow		5	5000	dgld	dgld						ignore-ac		1	1	att/lvl	12			dmg%/lvl	16			dmg%		200	200	att-skill	Raven	18	33	dex		25	25	swing1		40	40	oskill_hide	393	1	1																		0
 Windforce	266	100	1			1	1	80	73	6lw	Hydra Bow		5	5000	dyel	dyel						dex		5	5	dmg/lvl	25			regen-stam		30	30	manasteal		6	8	knock		1	1	dmg%		250	250	swing2		20	20	str		10	10	oskill_hide	393	1	1														0
 Rings																																																																							0
-Bul-Kathos' Wedding Band	268	100	1			3	1	66	58	rin	Ring		5	5000	dpur	dpur						hp/lvl	4			allskills		1	1	lifesteal		3	5																																						0
+Bul-Kathos' Wedding Band	268	100	1			1	1	66	58	rin	Ring		5	5000	dpur	dpur						hp/lvl	4			allskills		1	1	lifesteal		3	5																																						0
 The Cat's Eye	269	100	1			5	1	58	50	amu	Amulet		5	5000	oran	oran						move2		30	30	swing2		20	20	ac		100	100	ac-miss		100	100	dex		25	25																														0
 The Rising Sun	270	100	1			5	1	73	65	amu	Amulet		5	5000	lgld	lgld						abs-fire/lvl	6			light		4	4	cast2		10	10	res-fire		15	30	fireskill		2	2	regen		10	10																										0
 Crescent Moon	271	100	1			5	1	68	68	amu	Amulet		5	5000	lblu	lblu						coldskill		2	2	extra-cold		5	10	light		4	4	mana		80	80	regen-mana		25	25																														0
-Mara's Kaleidoscope	272	100	1			3	1	80	67	amu	Amulet		5	5000	oran	oran						allskills		2	2	res-all		20	30	str		5	5	dex		5	5	vit		5	5	enr		5	5																										0
+Mara's Kaleidoscope	272	100	1			5	1	80	67	amu	Amulet		5	5000	oran	oran						allskills		2	2	res-all		20	30	str		5	5	dex		5	5	vit		5	5	enr		5	5																										0
 Atma's Scarab	273	100	1			5	1	60	60	amu	Amulet		5	5000	cgrn	cgrn						dmg-pois	100	102	102	res-pois		75	75	light		3	3	thorns		5	5	hit-skill	Amplify Damage	5	2	att%		20	20	mag%		15	30	res-all		10	15																		0
-Dwarf Star	274	100	1			5	1	53	45	rin	Ring		5	5000	dgry	dgry						fireskill		1	1	gold%		100	100	mana-kill		3	5	hp		40	40	extra-fire		3	5	abs-fire%		15	15																										0
-Raven Frost	275	100	1			5	1	53	45	rin	Ring		5	5000	cblu	cblu						nofreeze		1	1	dmg-cold	100	15	45	abs-cold%		20	20	mana		40	40	dex		15	20	att		150	250																										0
-Highlord's Wrath	276	100	1			3	1	73	65	amu	Amulet		5	5000	bwht	bwht						res-ltng		35	35	dmg-ltng		1	30	swing2		20	20	allskills		1	1	deadly/lvl	3			light-thorns		15	15																										0
+Dwarf Star	274	100	1			10	1	53	45	rin	Ring		5	5000	dgry	dgry						fireskill		1	1	gold%		100	100	mana-kill		3	5	hp		40	40	extra-fire		3	5	abs-fire%		15	15																										0
+Raven Frost	275	100	1			10	1	53	45	rin	Ring		5	5000	cblu	cblu						nofreeze		1	1	dmg-cold	100	15	45	abs-cold%		20	20	mana		40	40	dex		15	20	att		150	250																										0
+Highlord's Wrath	276	100	1			5	1	73	65	amu	Amulet		5	5000	bwht	bwht						res-ltng		35	35	dmg-ltng		1	30	swing2		20	20	allskills		1	1	deadly/lvl	3			light-thorns		15	15																										0
 Saracen's Chance	277	100	1			5	1	55	47	amu	Amulet		5	5000	dpur	dpur						res-all		15	25	gethit-skill	Iron Maiden	10	2	str		12	12	dex		12	12	enr		12	12	vit		12	12																										0
 Class Specific																																																																							0
 Arreat's Face	279	100	1			1	1	50	42	baa	Slayer Guard		5	5000								bar		2	2	skilltab	12	2	2	ac%		150	200	balance2		30	30	att%		20	20	str		20	20	dex		20	20	lifesteal		3	6	res-all		30	30														0
@@ -319,7 +319,7 @@ Executioner's Justice	315	100	1			1	1	83	75	7gi	glorious axe		5	5000	blac	blac		
 Stoneraven	316	100	1			1	1	72	64	amd	matriarchal spear		5	5000	dgry							dmg%		230	280	dmg-mag		101	187	res-all		30	50	ac		400	600	skilltab	2	1	3	oskill_hide	393	1	1																										0
 Leviathan	317	100	1			1	1	73	65	uld	kraken shell		5	5000	cgrn	cgrn						ac%		170	200	ac		100	150	red-dmg%		15	25	str		40	50	indestruct		1	1																														0
 Larzuk's Champion	318	100				1	1						5	5000	lgry		flphmr	invhfh																																																					0
-Wisp Projector	319	100	1			5	1	84	76	rin	ring		5	5000	bwht	bwht						abs-ltng%		10	20	hit-skill	Lightning	10	16	mag%		10	20	charged	Oak Sage	15	2	charged	Heart of Wolverine	13	5	charged	Spirit of Barbs	11	7																										0
+Wisp Projector	319	100	1			1	1	84	76	rin	ring		5	5000	bwht	bwht						abs-ltng%		10	20	hit-skill	Lightning	10	16	mag%		10	20	charged	Oak Sage	15	2	charged	Heart of Wolverine	13	5	charged	Spirit of Barbs	11	7																										0
 Gargoyle's Bite	320	100	1			1	1	78	70	7ts	winged harpoon		5	5000	cgrn	cgrn						dmg%		180	230	rep-quant	100			dmg-pois	250	300	300	lifesteal		9	15	charged	Plague Javelin	60	11	oskill_hide	393	1	1																										0
 Lacerator	321	100	1			1	1	76	68	7b8	winged axe		5	5000	blac	blac						dmg%		150	210	rep-quant	100			swing2		30	30	noheal		1	1	openwounds		33	33	howl		64	64	hit-skill	Amplify Damage	33	3	oskill_hide	393	1	1																		0
 Mang Song's Lesson	322	100	1			1	1	86	82	6ws	archon staff		5	5000	dgld	dgld		inv8wsu				allskills		5	5	extra-elem		20	30	pierce-elem		20	30	regen-mana		75	75	cast2		60	60	fireskill		2	2	coldskill		2	2	lightningskill		2	2	oskill_hide	393	1	1														0
@@ -359,7 +359,7 @@ Wolfhowl	355	100	1			1	1	85	79	bac	fury visor		3	5000	cred	cred						ac%		120	15
 Spirit Ward	356	100	1			1	1	76	68	uts	ward		3	5000	dblu	dblu		invgtsu				ac%		130	180	red-dmg%		10	10	res-all		30	40	block		20	30	block2		25	25	randclassskill	3	0	6	oskill_hide	393	1	1																						0
 Kira's Guardian	357	100	1			1	1	85	77	ci2	tiara		3	5000	blac	blac						ac		50	120	res-all		50	70	nofreeze		1	1	balance2		20	20																																		0
 Ormus' Robes	358	100	1			1	1	83	75	uui	dusk shroud		3	5000	blac	blac						ac		10	20	cast2		20	20	extra-fire		10	15	extra-cold		10	15	extra-ltng		10	15	regen-mana		10	15	skill-rand	3	36	60																						0
-Gheed's Fortune	359	100	1			1	1	60	55	cm3	charm	1	3	5000	lgld							mag%		50	75	gold%		100	200	cheap		10	10	charm-property		3	3																																		0
+Gheed's Fortune	359	100	1			1	1	60	55	cm3	charm	1	3	5000	lgld			invscm3				mag%		50	75	gold%		100	200	cheap		10	10	charm-property		3	3																																		0
 Stormlash	360	100	1			1	1	86	82	7fl	scourge		3	5000	dgry	dgry						dmg%		240	300	swing2		30	30	hit-skill	Static Field	15	10	hit-skill	Tornado	20	18	dmg-ltng		1	473	light-thorns		30	30	crush		33	33	abs-ltng		3	9	oskill_hide	393	1	1														0
 Halaberd's Reign	361	100	1			1	1	85	77	bae	conqueror crown		3	5000								ac%		140	170	skilltab	13	1	1	bar		2	2	balance2		20	20	regen		15	23	skill	Battle Orders	1	2	skill	Battle Command	1	2																						0
 Warriv's Warder	362	100				1	1						3	5000																																																									0
@@ -375,10 +375,10 @@ Heaven's Light	371	100	1			1	1	69	61	7sc	mighty scepter		5	5000	cblu	cblu						d
 Merman's Sprocket	372	100					1																																																																0
 Arachnid Mesh	373	100	1			1	1	87	80	ulc	spiderweb sash		5	5000	blac	blac						ac%		90	120	cast2		20	20	charged	Venom	11	3	allskills		1	1	slow		10	10	mana%		5	5																										0
 Nosferatu's Coil	374	100	1			1	1	68	51	uvc	vampirefang belt		5	5000								str		15	15	mana-kill		2	2	slow		10	10	lifesteal		5	7	swing2		10	10	light		-3	-3																										0
-Metalgrid	375	100	1			7	1	85	81	amu	amulet		5	5000								ac		300	350	res-all		25	35	att		400	450	charged	IronGolem	11	22	charged	Iron Maiden	20	12																														0
+Metalgrid	375	100	1			2	1	85	81	amu	amulet		5	5000								ac		300	350	res-all		25	35	att		400	450	charged	IronGolem	11	22	charged	Iron Maiden	20	12																														0
 Verdungo's Hearty Cord	376	100	1			1	1	71	63	umc	mithril coil		5	5000	blac	blac						ac%		90	140	vit		30	40					balance2		10	10	red-dmg%		10	15	regen		10	13																										0
 Siggard's Stealth	377	100				1	1						5	5000																																																									0
-Carrion Wind	378	100	1			5	1	67	60	rin	ring		3	5000								ac-miss		100	160	lifesteal		6	9	res-pois		55	55	gethit-skill	Poison Nova	10	10	charged	Plague Poppy	15	21	hit-skill	Twister	8	13	dmg-to-mana		10	10	dex		10	15																		0
+Carrion Wind	378	100	1			3	1	67	60	rin	ring		3	5000								ac-miss		100	160	lifesteal		6	9	res-pois		55	55	gethit-skill	Poison Nova	10	10	charged	Plague Poppy	15	21	hit-skill	Twister	8	13	dmg-to-mana		10	10	dex		10	15																		0
 Giant Skull	379	100	1			1	1	73	65	uh9	bone visage		3	5000	lgry	lgry		invbhm				ac		250	320	str		25	35	oskill	stun	5	5	healperhit		2	4	att		180	220																														0
 Astreon's Iron Ward	380	100	1			1	1	68	60	7ws	caduceus		3	5000	blac	blac						dmg%		240	290	slow		25	25	att%		150	200	swing2		10	10	dmg-mag		80	240	red-dmg		4	7	dmg		40	85	skilltab	9	2	4	crush		33	33	oskill_hide	393	1	1										0
 Annihilus	381	100	1			1		110	75	cm1	charm		3	5000			flpmss	invmss	item_gem	12	item_gem	allskills		1	1	all-stats		10	10	res-all		10	10	addxp		5	5	charm-property		1	1	uberstone-property		1	1																										0
@@ -395,11 +395,11 @@ Steelrend	391	100	1			1	1	78	70	uhg	ogre gauntlets		3	5000								ac		170	210	st
 Spring Facet	392	100	1			1	1	85	49	jew	jewel		3	5000								dmg-ltng		1	74	pierce-ltng		3	5	extra-ltng		3	5	death-skill	Chain Lightning	100	47																																		0
 Winter Facet	393	100	1			1	1	85	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	death-skill	Blizzard	100	37																																		0
 Summer Facet	394	100	1			1	1	85	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	death-skill	Meteor	100	31																																		0
-Autumn Facet	395	100	1			1	1	85	49	jew	jewel		3	5000								pierce-pois		3	5	extra-pois		3	5	death-skill	Poison Nova	100	51																																						0
+Autumn Facet	395	100	1			1	1	85	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	death-skill	Poison Nova	100	51																																		0
 Thunder Facet	396	100	1			1	1	85	49	jew	jewel		3	5000								dmg-ltng		1	74	pierce-ltng		3	5	extra-ltng		3	5	levelup-skill	Nova	100	41																																		0
 Rime Facet	397	100	1			1	1	85	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	levelup-skill	Frost Nova	100	43																																		0
 Burnt Facet	398	100	1			1	1	85	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	levelup-skill	Blaze	100	29																																		0
-Toxic Facet	399	100	1			1	1	85	49	jew	jewel		3	5000								pierce-pois		3	5	extra-pois		3	5	levelup-skill	Venom	100	23																																						0
+Toxic Facet	399	100	1			1	1	85	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	levelup-skill	Venom	100	23																																		0
 Hellfire Torch	400	100	0			1		75	75	cm2	charm		3	5000			flptrch	invtrch	item_gem	12	item_gem	allskills		2	2	all-stats		10	10	res-all		10	10	charm-property		2	2	ubertorch-property		1	1																														0
 Talonrage		0																																																																					0
 Auburn Fire	401	100	1			1	1	18	18	hax	hand axe		5	5000	cred	cred						dmg-min		10	15	dmg-max		35	45	dmg-fire		35	50	dmg-ltng		25	50	res-ltng		15	25	oskill_hide	393	1	1																										0
@@ -800,7 +800,7 @@ Cadin'Sor	795	100	1			1	1	28	33	glv	glaive		5	5000	blac	blac						dmg%		80	100	d
 Sting of Humiliation	796	100	1			3	1	16	28	glv	glaive		5	5000								dmg%		160	200	rep-quant	100			stack		100	100	bar		1	1	skill	Double Throw	5	5	howl		129	129	res-all		35	35	oskill_hide	393	1	1																		0
 Mind Creche	797	100	1			5	1	12	24	glv	Glaive		5	5000	oran							dmg%		90	120	mana		40	40	ease		-35	-35	cast1		15	15	oskill	poison javelin	1	2	deadly		25	40	stupidity		1	1	rep-quant	100			oskill_hide	393	1	1														0
 Dancing Scarecrow	798	100	1			1	1	31	37	tsp	throwing spear		5	5000								dmg-norm		40	70	swing1		15	15	balance1		15	15	cast1		15	15	block1		15	15	att		200	200	knock		1	1	pierce		33	33	rep-quant	100			oskill_hide	393	1	1										0
-Splinterfreeze	799	100	1			3	1	18	32	tsp	throwing spear		5	5000	cblu	cblu		invjav1				dmg%		180	200	rep-quant	100			stack		125	125	hit-skill	CTC Frost Nova	5	1	aura	holy freeze	1	3	oskill	frozen orb	1	1	oskill	cold mastery	1	1	mana		75	75	oskill_hide	393	1	1														0
+Splinterfreeze	799	100	1			3	1	18	32	tsp	throwing spear		5	5000	cblu	cblu		invjav1				dmg%		180	200	rep-quant	100			stack		125	125	hit-skill	Frost Nova	100	6	aura	holy freeze	1	3	oskill	frozen orb	1	1	oskill	cold mastery	1	1	mana		75	75	oskill_hide	393	1	1														0
 Baba Yaga's Needle	800	100	1			5	1	16	29	tsp	Throwing Spear		5	5000								dmg%		100	145	rep-quant	100			lifesteal		6	8	res-pois		25	40	move2		25	25	stack		40	40	abs-mag		3	7	oskill_hide	393	1	1																		0
 Aiel Javelins	801	100	1			1	1	55	54	9ja	war javelin		5	5000								dmg%		100	125	dmg-norm		35	70	dmg/lvl	4			rep-quant	100			swing2		20	20	pierce		25	25	reduce-ac		15	15	oskill_hide	393	1	1																		0
 Rhyme of the Bard	802	100	1			3	1	28	37	9ja	war javelin		5	5000	lpur	lpur						dmg%		200	250	rep-quant	100			stack		60	60	charged	Battle Orders	200	3	charged	Shout	200	3	charged	War Cry	200	2	swing3		35	35	oskill_hide	393	1	1																		0
@@ -1322,42 +1322,42 @@ Skaadi's Claws	1317	100	1			1	1	85	88	7tw	runic talons		5	5000	oran	oran						dm
 Sin Sister	1318	100	1			3	1	28	45	7tw	Runic Talons		5	5000	blac	blac						dmg%		200	300	swing2		30	30	sock		3	3	dmg/lvl	7			oskill_hide	393	1	1																														0
 Avalanche Strike	1319	100	1			1	1	15	35	7qr	scissors suwayyah		5	5000	cblu	cblu						dmg%		300	400	dmg-cold	300	200	250	hit-skill	Glacial Spike	50	4	res-cold		45	45	rep-dur	15			lifesteal		6	8	manasteal		6	8	oskill_hide	393	1	1																		0
 Torturer's Trust	1320	100	1			3	1	79	83	7qr	Scissors Suwayyah		5	5000								dmg%		225	300	allskills		2	2	skilltab	20	1	3	res-all		30	50	skill-rand	7	251	280	regen		15	20	gold%		100	100	mag%		25	50	att%		100	100	oskill_hide	393	1	1										0
-Ring of Engagement	1321	100	1			7	1	1	3	rin	ring		5	5000				invring1				dmg-max		2	5	hp		10	20	str		5	5	aura	98	1	1																																		0
-Nameless Fear	1322	100	1			7	1	1	11	rin	ring		5	5000				invring3				dmg%		10	15	swing1		10	10	howl		45	45	noheal		1	1																																		0
-Elven Heartband	1323	100	1			7	1	1	18	rin	ring		5	5000				invring5				addxp		3	5	hp		20	30	red-dmg%		5	5	mag%		15	25	lifesteal		4	6																														0
-Knell of Discord	1324	100	1			7	1	2	20	rin	ring		5	5000				invring6				lifesteal		5	7	slow		15	15	knock		3	3	enr		10	10																																		0
-Vampiric Regeneration	1325	100	1			5	1	8	28	rin	ring		5	5000				invring8				hp		35	35	regen		8	12	regen-mana		35	35	regen-stam		20	20	manasteal		3	5	lifesteal		5	7																										0
-Golem's Might	1326	100	1			7	1	24	24	rin	ring		5	5000				invring10				str		25	25	dmg-norm		10	15	res-all		8	15	heal-kill		5	8	swing1		10	10																														0
+Ring of Engagement	1321	100	1			9	1	1	3	rin	ring		5	5000				invring1				dmg-max		2	5	hp		10	20	str		5	5	aura	98	1	1																																		0
+Nameless Fear	1322	100	1			9	1	1	11	rin	ring		5	5000				invring3				dmg%		10	15	swing1		10	10	howl		45	45	noheal		1	1																																		0
+Elven Heartband	1323	100	1			8	1	1	18	rin	ring		5	5000				invring5				addxp		3	5	hp		20	30	red-dmg%		5	5	mag%		15	25	lifesteal		4	6																														0
+Knell of Discord	1324	100	1			8	1	2	20	rin	ring		5	5000				invring6				lifesteal		5	7	slow		15	15	knock		3	3	enr		10	10																																		0
+Vampiric Regeneration	1325	100	1			7	1	8	28	rin	ring		5	5000				invring8				hp		35	35	regen		8	12	regen-mana		35	35	regen-stam		20	20	manasteal		3	5	lifesteal		5	7																										0
+Golem's Might	1326	100	1			6	1	24	24	rin	ring		5	5000				invring10				str		25	25	dmg-norm		10	15	res-all		8	15	heal-kill		5	8	swing1		10	10																														0
 Plantar Enlightenment	1327	100	1			2	1	23	23	rin	ring		5	5000				invring12				allskills		1	1	res-all		8	15	hp		35	50	gold%		65	65	enr		20	20	addxp		3	5	cheap		8	10																						0
-Thief of Dreams	1328	100	1			2	1	50	50	rin	ring		5	5000				invring13				mag%		33	50	res-fire		25	35	mana		65	80	cast1		15	15	addxp		3	3																														0
-Jackal's Laughter	1329	100	1			2	1	64	64	rin	ring		5	5000				invring16				allskills		1	1	lifesteal		8	11	manasteal		7	8	hp		55	80	oskill	terror	6	6	deadly/lvl	3																												0
+Thief of Dreams	1328	100	1			5	1	50	50	rin	ring		5	5000				invring13				mag%		33	50	res-fire		25	35	mana		65	80	cast1		15	15	addxp		3	3																														0
+Jackal's Laughter	1329	100	1			3	1	64	64	rin	ring		5	5000				invring16				allskills		1	1	lifesteal		8	11	manasteal		7	8	hp		55	80	oskill	terror	6	6	deadly/lvl	3																												0
 Fellowship's Hope	1330	100	1			2	1	73	73	rin	ring		5	5000				invring18				allskills		1	1	mag%		25	35	res-all		15	15	red-dmg		5	8	red-mag		5	8	move1		10	10	cast1		10	10	block1		10	10																		0
-Faerie Ring	1331	100	1			2	1	82	82	rin	ring		5	5000				invring20				allskills		1	1	hp%		15	15	mana%		15	15	light		7	7	fade		1	1	block		15	20	mag%		25	50	balance2		20	20																		0
+Faerie Ring	1331	100	1			1	1	82	82	rin	ring		5	5000				invring20				allskills		1	1	hp%		15	15	mana%		15	15	light		7	7	fade		1	1	block		15	20	mag%		25	50	balance2		20	20																		0
 Jordan's Sigil	1332	100	1			1	1	85	85	rin	ring		5	5000				invring21				allskills		2	2	mana%		40	40	cast1		15	15	dmg-ltng		10	100																																		0
-Eye of Kahn	1333	100	1			7	1	3	3	amu	amulet		5	5000				invammy7				hp		25	35	mana		25	35	dex		5	10	str		5	10	dmg-max		3	6																														0
-Psyche Shroud	1334	100	1			7	1	6	6	amu	amulet		5	5000				invammy5				move2		15	15	res-ltng		20	20	hp		20	30	enr		10	10																																		0
+Eye of Kahn	1333	100	1			9	1	3	3	amu	amulet		5	5000				invammy7				hp		25	35	mana		25	35	dex		5	10	str		5	10	dmg-max		3	6																														0
+Psyche Shroud	1334	100	1			9	1	6	6	amu	amulet		5	5000				invammy5				move2		15	15	res-ltng		20	20	hp		20	30	enr		10	10																																		0
 Amulet of Warding	1335	100	1			7	1	12	12	amu	amulet		5	5000				invammy2				red-dmg		5	8	res-all		10	15	red-mag		4	6	block		5	12	ac		35	50																														0
-Cryptking	1336	100	1			5	1	27	27	amu	amulet		5	5000				invammy8				oskill	skeleton mastery	5	10	oskill	raise skeletal mage	3	5	dmg-undead		200	200	allskills		1	1	regen		6	8	regen-mana		25	50																										0
-Sequence of Seasons	1337	100	1			5	1	30	30	amu	amulet		5	5000				invammy4				allskills		1	1	dmg-cold	100	15	25	dmg-ltng		1	70	dmg-fire		30	50	aura	103	1	1	regen		6	8																										0
-Rat Lord's Curse	1338	100	1			5	1	38	38	amu	amulet		5	5000				invammy1				dmg-demon		100	100	hp		35	50	str		15	25	dex		15	25	red-dmg%		10	10	red-mag		6	9																										0
+Cryptking	1336	100	1			6	1	27	27	amu	amulet		5	5000				invammy8				oskill	skeleton mastery	5	10	oskill	raise skeletal mage	3	5	dmg-undead		200	200	allskills		1	1	regen		6	8	regen-mana		25	50																										0
+Sequence of Seasons	1337	100	1			6	1	30	30	amu	amulet		5	5000				invammy4				allskills		1	1	dmg-cold	100	15	25	dmg-ltng		1	70	dmg-fire		30	50	aura	103	1	1	regen		6	8																										0
+Rat Lord's Curse	1338	100	1			6	1	38	38	amu	amulet		5	5000				invammy1				dmg-demon		100	100	hp		35	50	str		15	25	dex		15	25	red-dmg%		10	10	red-mag		6	9																										0
 Luck Sigil	1339	100	1			5	1	45	45	amu	amulet		5	5000				invammy3				allskills		1	1	mag%/lvl	12			gold%/lvl	16			att%		10	10	fade		1	1																														0
 The Vanquisher	1340	100	1			3	1	85	81	amu	amulet		5	5000				invammy9				dmg%		150	200	cast2		20	20	lifesteal		8	8	manasteal		8	8	swing2		20	20	dmg-norm		15	25																										0
 Foul Sigil	1341	100	1			3	1	78	78	amu	amulet		5	5000				invammy13				allskills		1	2	all-stats		15	25	regen		-3	-3	res-pois		65	65	swing1		15	15	block		15	15	nofreeze		1	1																						0
 Sigil of Hope	1342	100	1			1	1	85	85	amu	amulet		5	5000				invammy6				allskills		2	2	block		10	15	kill-skill	corpse explosion	5	15	mag%		35	50	gold%/lvl	16			att%		25	25	res-all-max		5	5	res-all		30	50																		0
-Autumn's Avatar	1343	100	1			3	1	12	12	cm1	charm	1	5	5000				invscm1				hp		20	30	mana		20	30	dmg-max		5	10	str		3	5	charm-property		1	1																														0
-Remembrance of Glory	1344	100	1			1	1	81	80	cm1	charm	1	5	5000				invscm1				hp		50	100	mana		50	100	res-all		5	10	dex		10	10	charm-property		1	1																														0
-Argo's Anchor	1345	100	1			3	1	48	48	cm1	charm	1	5	5000				invscm1				dmg-max		10	15	mag%		15	25	block		5	10	att		50	75	charm-property		1	1																														0
+Autumn's Avatar	1343	100	1			5	1	12	12	cm1	charm	1	5	5000				invscm1				hp		20	30	mana		20	30	dmg-max		5	10	str		3	5	charm-property		1	1																														0
+Remembrance of Glory	1344	100	1			4	1	81	80	cm1	charm	1	5	5000				invscm1	item_scroll			hp		50	100	mana		50	100	res-all		5	10	dex		10	10	charm-property		1	1																														0
+Argo's Anchor	1345	100	1			3	1	48	48	cm1	charm	1	5	5000				invscm1	item_jewel			dmg-max		10	15	mag%		15	25	block		5	10	att		50	75	charm-property		1	1																														0
 Ogre King's Bowl	1346	100	1			2	1	60	60	cm2	charm	1	5	5000				invscm2				lifesteal		5	7	manasteal		5	7	regen		8	12	regen-mana		25	50	charm-property		2	2																														0
-Peacemaker	1347	100	1			3	1	15	15	cm1	charm	1	5	5000				invscm2				hp		20	30	mana		20	30	str		5	5	dex		5	5	charm-property		1	1																														0
-Life & Death	1348	100	1			2	1	55	55	cm2	charm	1	5	5000				invscm2				allskills		1	1	mag%		30	30	gold%		50	75	thorns		50	100	charm-property		2	2																														0
-Throne of Power	1349	100	1			1	1	81	81	cm2	charm	1	5	5000	dred	dred		invscm2				hp		30	50	mana		30	50	dmg-max		10	15	res-all		5	8	addxp		3	5	charm-property		2	2																										0
-Nightshade	1350	100	1			2	1	6	6	cm3	charm	1	5	5000				invscm3				hp		20	30	dmg-cold	200	5	15	freeze		1	2	move1		15	15	charm-property		3	3																														0
+Peacemaker	1347	100	1			5	1	15	15	cm1	charm	1	5	5000				invscm2	item_monsterbone			hp		20	30	mana		20	30	str		5	5	dex		5	5	charm-property		1	1																														0
+Life and Death	1348	100	1			3	1	55	55	cm2	charm	1	5	5000				invscm2	item_book			allskills		1	1	mag%		30	30	gold%		50	75	thorns		50	100	charm-property		2	2																														0
+Throne of Power	1349	100	1			1	1	81	81	cm2	charm	1	5	5000				invscm2	item_smallmetalweapon			hp		30	50	mana		30	50	dmg-max		10	15	res-all		5	8	addxp		3	5	charm-property		2	2																										0
+Nightshade	1350	100	1			5	1	6	6	cm3	charm	1	5	5000				invscm3				hp		20	30	dmg-cold	200	5	15	freeze		1	2	move1		15	15	charm-property		3	3																														0
 Queen's Call	1351	100	1			1	1	81	85	cm3	charm	1	5	5000				invscm3				allskills		1	2	hp		50	75	res-all		10	15	block1		10	10	move1		10	10	swing1		10	10	charm-property		3	3																						0
-Tiger Eye	1352	100	1			1	1	58	58	jew	jewel		3	5000								dmg%		40	40	dmg-min		10	10	dmg-max		20	20																																						0
-Jade Facet	1353	100	1			2	1	58	58	jew	jewel		3	5000		lgrn						dmg-min		10	15	dmg-max		25	30	openwounds		3	5																																						0
-Topaz Facet	1354	100	1			2	1	49	49	jew	jewel		3	5000		lyel						dmg-ltng		1	140	mag%		24	28	res-ltng		25	35	res-ltng-max		1	1																																		0
-Emerald Facet	1355	100	1			2	1	38	38	jew	jewel		3	5000		cgrn						extra-pois		3	5	dex		10	15	res-pois		25	35	res-pois-max		1	1																																		0
-Quartz Facet	1356	100	1			2	1	43	43	jew	jewel		3	5000								hp		30	40	mana		25	35	cast1		10	10																																						0
+Tiger Eye	1352	100	1			5	1	58	58	jew	jewel		3	5000								dmg%		40	40	dmg-min		15	15	deadly		5	8																																						0
+Jade Facet	1353	100	1			5	1	58	58	jew	jewel		3	5000		lgrn						dmg%		40	40	dmg-max		15	15	crush		5	8																																						0
+Topaz Facet	1354	100	1			5	1	49	49	jew	jewel		3	5000		lyel						dmg-ltng		1	140	mag%		24	28	res-ltng		25	35	res-ltng-max		1	1																																		0
+Emerald Facet	1355	100	1			5	1	38	38	jew	jewel		3	5000		cgrn						extra-pois		3	5	dex		10	15	res-pois		25	35	res-pois-max		1	1																																		0
+Quartz Facet	1356	100	1			5	1	43	43	jew	jewel		3	5000								hp		30	40	mana		25	35	cast1		10	10																																						0
 Rainbow Facet	1357	100	0			1	1	49	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	death-skill	Blizzard	100	37																																		0
 Rainbow Facet	1358	100	0			1	1	49	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	death-skill	Meteor	100	31																																		0
 Rainbow Facet	1359	100	0			1	1	49	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	death-skill	Poison Nova	100	51																																		0
@@ -1365,11 +1365,11 @@ Rainbow Facet	1360	100	0			1	1	49	49	jew	jewel		3	5000								dmg-ltng		1	74	pie
 Rainbow Facet	1361	100	0			1	1	49	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	levelup-skill	Frost Nova	100	43																																		0
 Rainbow Facet	1362	100	0			1	1	49	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	levelup-skill	Blaze	100	29																																		0
 Rainbow Facet	1363	100	0			1	1	49	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	levelup-skill	Venom	100	23																																		0
-Sapphire Facet	1364	100	1			2	1	58	58	jew	jewel		3	5000		cblu						dmg-cold	3	60	80	mana		35	40	res-cold		25	35	res-cold-max		1	1	mana%		2	2																														0
-Spinel Facet	1365	100	1			2	1	58	58	jew	jewel		3	5000		cblu						dmg%		40	40	att		50	50																																										0
+Sapphire Facet	1364	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg-cold	3	60	80	mana		35	40	res-cold		25	35	res-cold-max		1	1	mana%		2	2																														0
+Spinel Facet	1365	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg%		40	40	dmg-min		15	15	pierce		5	8																																						0
 Diamond Facet	1366	100	1			1	1	67	67	jew	jewel		3	5000		whit						res-all		12	15	cast1		10	10	red-dmg%		3	5	block		6	8																																		0
 Adamantine Facet	1367	100	1			1	1	71	71	jew	jewel		3	5000								red-dmg%		5	7	red-dmg		8	12	red-mag		8	10	ac%		25	35																																		0
-Star Facet	1368	100	1			1	1	76	76	jew	jewel		3	5000								dmg%		45	50	swing1		15	15	all-stats		5	5																																						0
+Star Facet	1368	100	1			1	1	76	76	jew	jewel		3	5000								dmg%		40	40	swing1		15	15	dmg-max		15	15																																						0
 Heaven Facet	1369	100	1			1	1	85	85	jew	jewel		3	5000								allskills		1	1	hp%		5	5	mana%		5	5																																						0
 t1 Splash Charm	1370	100	1			1	1	1	1	cm4	charm	1	1	1			flpmss	invmss	item_gem	12	item_gem	splash	proc_SplashDamage	100	1	dmg2%		-40	-40	charm-property		1	1																																						0
 t2 Splash Charm	1371	100	0			1	1	1	10	cm4	charm	1	1	1			flpmss	invmss	item_gem	12	item_gem	splashtwo	proc_SplashDamage_Two	100	1	dmg2%		-35	-40	charm-property		1	1																																						0
@@ -1392,7 +1392,7 @@ t5 Splash Charm	1418	100	0			1	1	1	40	cm4	charm	1	1	1			flpmss	invmss	item_gem	1
 t6 Splash Charm	1419	100	0			1	1	1	50	cm4	charm	1	1	1			flpmss	invmss	item_gem	12	item_gem	splashthree	proc_SplashDamage_Three	100	1	dmg2%		-15	-20	charm-property		1	1																																						0
 t7 Splash Charm	1420	100	0			1	1	1	60	cm4	charm	1	1	1			flpmss	invmss	item_gem	12	item_gem	splashfour	proc_SplashDamage_Four	100	1	dmg2%		-10	-15	charm-property		1	1																																						0
 t8 Splash Charm	1421	100	0			1	1	1	75	cm4	charm	1	1	1			flpmss	invmss	item_gem	12	item_gem	splashfour	proc_SplashDamage_Four	100	1	dmg2%		-5	-10	charm-property		1	1																																						0
-t9 Splash Charm	1422	100	1			1	1	1	90	cm5	charm	1	1	1			flpmss	invmss	item_gem	12	item_gem	splashfive	proc_SplashDamage_Five	100	1	charm-property		1	1																																										0
+Collin's Destruction	1422	100	1			1	1	1	90	cm5	charm	1	1	1			flpmss	invmss	item_gem	12	item_gem	splashfive	proc_SplashDamage_Five	100	1	charm-property		1	1																																										0
 Cold Rupture	1423	100	0	2	2	1		69	75	cm3	charm		3	5000	lblu	lblu						pierce-immunity-cold		300	300	res-cold		-50	-50	charm-property		3	3																																						0
 Flame Rift	1424	100	0	2	2	1		69	75	cm3	charm		3	5000	lred	lred						pierce-immunity-fire		300	300	res-fire		-50	-50	charm-property		3	3																																						0
 Crack of the Heavens	1425	100	0	2	2	1		69	75	cm3	charm		3	5000	lyel	lyel						pierce-immunity-light		300	300	res-ltng		-50	-50	charm-property		3	3																																						0
@@ -1405,10 +1405,10 @@ Bolt Case of Amplified Slaying	1431	100	1			1	1	1	85	z02	Bolts		5	5000	blac	blac
 Bolt Case of Resistance Slaying	1432	100	1			1	1	1	85	z02	Bolts		5	5000	blac	blac						dmg-norm		10	25	swing1		20	20	pierce		25	25	skilltab	0	2	2	rep-quant	100			hit-skill	91	20	5	oskill_hide	393	1	1																						0
 Black Soulstone	1433	100	0			1	1	85	85	cm1	charm		3	5000			flpmss	invmss	item_gem	12	item_gem	allskills		2	2	all-stats		20	20	res-all		20	20	oskill	Teleport	1	1	addxp		10	10	charm-property		1	1	uberstone-property		1	1																						0
 Obsidian Beacon	1434	100	0			1	1	85	85	cm3	charm		3	5000			flptrch	invtrch	item_gem	12	item_gem	allskills		4	4	all-stats		25	25	res-all		25	25	move3		25	25	charm-property		3	3	ubertorch-property		1	1																										0
-Valknut	1435	100	1			3	1	20	24	cm2	charm	1	5	5000	lgry			invscm2				all-stats		5	5	regen		10	10	regen-mana		10	10	addxp		3	5	charm-property		2	2																														0
-Triskelion	1436	100	1			1	1	30	32	cm3	charm	1	5	5000	lblu			invscm3				cast3		15	15	swing3		15	15	move3		15	15	charm-property		3	3																																		0
-Web of Wyrd	1437	100	1			1	1	50	56	cm3	charm	1	5	5000	blac			invscm3				red-dmg%		8	8	block		10	10	hp%		8	8	vit		15	15	charm-property		3	3																														0
-Conclave of Elements	1438	100	1			1	1	81	80	cm3	charm	1	5	5000	oran			invscm3				dmg-elem		63	511	charm-property		3	3																																										0
+Valknut	1435	100	1			1	1	20	24	cm2	charm	1	5	5000	lgry			invscm2				all-stats		5	5	regen		10	10	regen-mana		10	10	addxp		3	5	charm-property		2	2																														0
+Triskelion	1436	100	1			1	1	30	32	cm3	charm	1	5	5000				invscm3				cast3		15	15	swing3		15	15	move3		15	15	charm-property		3	3																																		0
+Web of Wyrd	1437	100	1			1	1	50	56	cm3	charm	1	5	5000				invscm3				red-dmg%		8	8	block		10	10	hp%		8	8	vit		15	15	charm-property		3	3																														0
+Conclave of Elements	1438	100	1			1	1	81	80	cm3	charm	1	5	5000				invscm3				dmg-elem		63	511	charm-property		3	3																																										0
 Rune Pliers	1439	100	0			1	1	1	1	rup	Rune Pliers		1	1					item_rune		item_rune																																																		0
 Jewel Pliers	1440	100	0			1	1	1	1	jwp	Jewel Pliers		1	1					item_gem		item_gem																																																		0
 Quiver of Pestilence	1441	100	1			1	1	1	85	z01	Arrows		5	5000	cgrn	cgrn		invarro3				pierce-pois		10	10	extra-pois		10	10	swing1		20	20	pierce		25	25	rep-quant	100			hit-skill	74	5	10	oskill_hide	393	1	1																						0

--- a/data/hd/global/ui/items/misc/uniquecharm/argos_anchor.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/argos_anchor.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80dd7ede4ad2a869f3b5151ff548019de7f757b9e43e608bd1f2560c6bc51a27
+size 9644

--- a/data/hd/global/ui/items/misc/uniquecharm/argos_anchor.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/argos_anchor.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cacae1928b1bdeb0247de8aaa25495757f71e3765036a5e40287d09ad5ff48d8
+size 38456

--- a/data/hd/global/ui/items/misc/uniquecharm/autumns_avatar.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/autumns_avatar.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7d5e566f3b698ac28e695d285186e0ad8706baa75ef9acebf2115ef90cbb9dd
+size 9644

--- a/data/hd/global/ui/items/misc/uniquecharm/autumns_avatar.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/autumns_avatar.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53782ead5920c919c06d356492d717b908dbf8c641b25d5193415f8f0b9b1e78
+size 38456

--- a/data/hd/global/ui/items/misc/uniquecharm/collins_destruction.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/collins_destruction.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fe8f523c5f90cb5266b1dba9592c33d6de5c5e6157b55d839dd3cd0aa250efc
+size 9644

--- a/data/hd/global/ui/items/misc/uniquecharm/collins_destruction.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/collins_destruction.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6114b56c3179e7fc40fae7f2d87d8c85401df0e63b4fd10bb71b64609b42ef77
+size 38456

--- a/data/hd/global/ui/items/misc/uniquecharm/conclave_of_elements.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/conclave_of_elements.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d65501e92cd2076c31601217a104d090a888ab5176d0d58a3f8e60897943bee4
+size 28852

--- a/data/hd/global/ui/items/misc/uniquecharm/conclave_of_elements.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/conclave_of_elements.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d8f36bc53d5d7b4d547e4d1dd8aa075bb848f23eaea9f25dad2b28d5e9b749a
+size 115288

--- a/data/hd/global/ui/items/misc/uniquecharm/gheeds_fortune.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/gheeds_fortune.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e144bd0607e2e63acd6b16543e47c0265ef502beb4a98e607ea22c5d44e4dc7
+size 28852

--- a/data/hd/global/ui/items/misc/uniquecharm/gheeds_fortune.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/gheeds_fortune.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79dfa829cb403f3111ef7c1e1550e185b8ce845c0e3ff272042289cb518eeb7a
+size 115288

--- a/data/hd/global/ui/items/misc/uniquecharm/life_and_death.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/life_and_death.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d804c95f2df6f05b88f1821724d09aca20dba3a2eb12578c5454d848d7d13f7e
+size 19248

--- a/data/hd/global/ui/items/misc/uniquecharm/life_and_death.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/life_and_death.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4932af368bc5deb1248c0c903bdcb7330e62bdc721786460890c6f1d5fd2e17
+size 76872

--- a/data/hd/global/ui/items/misc/uniquecharm/nightshade.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/nightshade.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b8b450b1cf5c1caa137bd61b3e782aa64e71e1e7ed7b35770c9f1f707513d1e
+size 27872

--- a/data/hd/global/ui/items/misc/uniquecharm/nightshade.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/nightshade.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:859f3b31706645a991a5a2fa4cd84db43f36b969dfe92de3af5b626be0e6957e
+size 111368

--- a/data/hd/global/ui/items/misc/uniquecharm/ogre_kings_bowl.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/ogre_kings_bowl.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf856944f96e41fefeffc84393b4412d05a6713687772456a369ae1b8f906782
+size 19248

--- a/data/hd/global/ui/items/misc/uniquecharm/ogre_kings_bowl.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/ogre_kings_bowl.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b42d2f23507d1de73c85751432a5e6e53e1f2e1144e0955781c87e0d530ce3de
+size 76872

--- a/data/hd/global/ui/items/misc/uniquecharm/peacemaker.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/peacemaker.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4614053cbf3943bcaaf2baa2bac221ec0ed302d46d48ea1b4a68b548e86ad6a3
+size 9644

--- a/data/hd/global/ui/items/misc/uniquecharm/peacemaker.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/peacemaker.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b65ac5fa07cf069cf967126c0f0924bcfc965d0d746efdcad395f10dbd24709
+size 38456

--- a/data/hd/global/ui/items/misc/uniquecharm/queens_call.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/queens_call.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9757d35fb0db96e022c5bf31906ec8340e26bb13438c623e8ae7bdfd793f2a93
+size 28852

--- a/data/hd/global/ui/items/misc/uniquecharm/queens_call.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/queens_call.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:194c99fde6da7ffd2b9be331ef2ed62e827f7669b30a5c597d09af9f152d13a0
+size 115288

--- a/data/hd/global/ui/items/misc/uniquecharm/remembrance_of_glory.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/remembrance_of_glory.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f61a84c3581a4c9b8094532b593a94cd753c601cc16e34b506e8ae964e1c7a3
+size 9644

--- a/data/hd/global/ui/items/misc/uniquecharm/remembrance_of_glory.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/remembrance_of_glory.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d390e9afaeb0329b29941b5460a86fb772d33e5dd816989f54ea4d74ad7b8766
+size 38456

--- a/data/hd/global/ui/items/misc/uniquecharm/throne_of_power.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/throne_of_power.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ec6227fed6ab9e907953073eeb4c3293f068d9916e5c2be44842484bb22c437
+size 19248

--- a/data/hd/global/ui/items/misc/uniquecharm/throne_of_power.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/throne_of_power.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1af0a98e6a4a7b0c137ad88e3a44967cc635e1f754a7fa84ea201b543d444817
+size 76872

--- a/data/hd/global/ui/items/misc/uniquecharm/triskelion.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/triskelion.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab1678adf32fb049dc80d4dce86eaddff36513c5bc72f079f705481ecac4f0c9
+size 28852

--- a/data/hd/global/ui/items/misc/uniquecharm/triskelion.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/triskelion.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:574bf699b7de5a445ba8d6e2857e6b4ad31502e403ff20e3eba302b70c8a513c
+size 115288

--- a/data/hd/global/ui/items/misc/uniquecharm/valknut.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/valknut.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52801d32058064effca7bc6b04c1eb9587b4cd23ea50fe225e8451688775c093
+size 19248

--- a/data/hd/global/ui/items/misc/uniquecharm/valknut.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/valknut.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bfe2555f600273e9b4cfd4899468d12f1d796acade41931acdde207f2d2ce24
+size 76872

--- a/data/hd/global/ui/items/misc/uniquecharm/web_of_wyrd.lowend.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/web_of_wyrd.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32dcaeedcbcb3bcea39774dd37404e354e73ca8913526845a50ea95c75be9640
+size 28852

--- a/data/hd/global/ui/items/misc/uniquecharm/web_of_wyrd.sprite
+++ b/data/hd/global/ui/items/misc/uniquecharm/web_of_wyrd.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b433c98b5aae3d5cfbfe411c5b2b434b36423424b6af8f0eef1d3af8efddf9c0
+size 115288

--- a/data/hd/items/misc/uniquecharm/argos_anchor.json
+++ b/data/hd/items/misc/uniquecharm/argos_anchor.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/autumns_avatar.json
+++ b/data/hd/items/misc/uniquecharm/autumns_avatar.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/collins_destruction.json
+++ b/data/hd/items/misc/uniquecharm/collins_destruction.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/conclave_of_elements.json
+++ b/data/hd/items/misc/uniquecharm/conclave_of_elements.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/gheeds_fortune.json
+++ b/data/hd/items/misc/uniquecharm/gheeds_fortune.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/life_and_death.json
+++ b/data/hd/items/misc/uniquecharm/life_and_death.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/nightshade.json
+++ b/data/hd/items/misc/uniquecharm/nightshade.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/ogre_kings_bowl.json
+++ b/data/hd/items/misc/uniquecharm/ogre_kings_bowl.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/peacemaker.json
+++ b/data/hd/items/misc/uniquecharm/peacemaker.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/queens_call.json
+++ b/data/hd/items/misc/uniquecharm/queens_call.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/remembrance_of_glory.json
+++ b/data/hd/items/misc/uniquecharm/remembrance_of_glory.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/throne_of_power.json
+++ b/data/hd/items/misc/uniquecharm/throne_of_power.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/triskelion.json
+++ b/data/hd/items/misc/uniquecharm/triskelion.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/valknut.json
+++ b/data/hd/items/misc/uniquecharm/valknut.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/misc/uniquecharm/web_of_wyrd.json
+++ b/data/hd/items/misc/uniquecharm/web_of_wyrd.json
@@ -1,0 +1,108 @@
+{
+  "dependencies": {
+    "particles": [],
+    "models": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/charm_small.model"
+      }
+    ],
+    "skeletons": [
+      {
+        "path": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+      }
+    ],
+    "animations": [],
+    "textures": [
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ALB.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_NRM.texture"
+      },
+      {
+        "path": "data/hd/items/misc/charm/charm_small/misc_charm_small_ORM.texture"
+      }
+    ],
+    "physics": [],
+    "json": [
+      {
+        "path": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json"
+      }
+    ],
+    "variantdata": [],
+    "objecteffects": [],
+    "other": []
+  },
+  "type": "UnitDefinition",
+  "name": "charm_small",
+  "entities": [
+    {
+      "type": "Entity",
+      "name": "entity_root",
+      "id": 713262390,
+      "components": [
+        {
+          "type": "UnitRootComponent",
+          "name": "component_root",
+          "state_machine_filename": "data/hd/items/dropped_items/dropped_items_helms_flip_ne.json",
+          "doNotInheritRotation": false,
+          "rotationOverride": {
+            "x": 0,
+            "y": 0.3826834,
+            "z": 0,
+            "w": 0.9238795
+          },
+          "doNotUseHDHeight": false,
+          "hideAllMeshWhenInOpenedMode": false,
+          "onCreateEventName": "",
+          "animations": []
+        },
+        {
+          "type": "SkeletonDefinitionComponent",
+          "name": "component_skeleton",
+          "filename": "data/hd/items/dropped_items/skeleton/dropped_items.skeleton"
+        },
+        {
+          "type": "TransformDefinitionComponent",
+          "name": "entity_root_TransformDefinition",
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "orientation": {
+            "x": 0,
+            "y": -0.398749083,
+            "z": 0,
+            "w": 0.9170601
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "inheritOnlyPosition": false
+        }
+      ]
+    },
+    {
+      "type": "Entity",
+      "name": "entity_model",
+      "id": 996691434,
+      "components": [
+        {
+          "type": "ModelDefinitionComponent",
+          "name": "component_model_charm_small",
+          "filename": "data/hd/items/misc/charm/charm_small/charm_small.model",
+          "visibleLayers": 1,
+          "lightMask": 19,
+          "shadowMask": 3,
+          "ghostShadows": false,
+          "floorModel": false,
+          "terrainBlendEnableYUpBlend": false,
+          "terrainBlendMode": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/hd/items/uniques.json
+++ b/data/hd/items/uniques.json
@@ -2423,9 +2423,9 @@
   },
   {
     "gheeds_fortune": {
-      "normal": "charm/charm_large",
-      "uber": "charm/charm_large",
-      "ultra": "charm/charm_large"
+      "normal": "uniquecharm/gheeds_fortune",
+      "uber": "uniquecharm/gheeds_fortune",
+      "ultra": "uniquecharm/gheeds_fortune"
     }
   },
   {
@@ -2734,6 +2734,104 @@
       "normal": "knife/warshrike",
       "uber": "knife/warshrike",
       "ultra": "knife/warshrike"
+    }
+  },
+  {
+    "autumns_avatar": {
+      "normal": "uniquecharm/autumns_avatar",
+      "uber": "uniquecharm/autumns_avatar",
+      "ultra": "uniquecharm/autumns_avatar"
+    }
+  },
+  {
+    "collins_destruction": {
+      "normal": "uniquecharm/collins_destruction",
+      "uber": "uniquecharm/collins_destruction",
+      "ultra": "uniquecharm/collins_destruction"
+    }
+  },
+  {
+    "argos_anchor": {
+      "normal": "uniquecharm/argos_anchor",
+      "uber": "uniquecharm/argos_anchor",
+      "ultra": "uniquecharm/argos_anchor"
+    }
+  },
+  {
+    "peacemaker": {
+      "normal": "uniquecharm/peacemaker",
+      "uber": "uniquecharm/peacemaker",
+      "ultra": "uniquecharm/peacemaker"
+    }
+  },
+  {
+    "remembrance_of_glory": {
+      "normal": "uniquecharm/remembrance_of_glory",
+      "uber": "uniquecharm/remembrance_of_glory",
+      "ultra": "uniquecharm/remembrance_of_glory"
+    }
+  },
+  {
+    "valknut": {
+      "normal": "uniquecharm/valknut",
+      "uber": "uniquecharm/valknut",
+      "ultra": "uniquecharm/valknut"
+    }
+  },
+  {
+    "life_and_death": {
+      "normal": "uniquecharm/life_and_death",
+      "uber": "uniquecharm/life_and_death",
+      "ultra": "uniquecharm/life_and_death"
+    }
+  },
+  {
+    "ogre_kings_bowl": {
+      "normal": "uniquecharm/ogre_kings_bowl",
+      "uber": "uniquecharm/ogre_kings_bowl",
+      "ultra": "uniquecharm/ogre_kings_bowl"
+    }
+  },
+  {
+    "throne_of_power": {
+      "normal": "uniquecharm/throne_of_power",
+      "uber": "uniquecharm/throne_of_power",
+      "ultra": "uniquecharm/throne_of_power"
+    }
+  },
+  {
+    "nightshade": {
+      "normal": "uniquecharm/nightshade",
+      "uber": "uniquecharm/nightshade",
+      "ultra": "uniquecharm/nightshade"
+    }
+  },
+  {
+    "triskelion": {
+      "normal": "uniquecharm/triskelion",
+      "uber": "uniquecharm/triskelion",
+      "ultra": "uniquecharm/triskelion"
+    }
+  },
+  {
+    "web_of_wyrd": {
+      "normal": "uniquecharm/web_of_wyrd",
+      "uber": "uniquecharm/web_of_wyrd",
+      "ultra": "uniquecharm/web_of_wyrd"
+    }
+  },
+  {
+    "conclave_of_elements": {
+      "normal": "uniquecharm/conclave_of_elements",
+      "uber": "uniquecharm/conclave_of_elements",
+      "ultra": "uniquecharm/conclave_of_elements"
+    }
+  },
+  {
+    "queens_call": {
+      "normal": "uniquecharm/queens_call",
+      "uber": "uniquecharm/queens_call",
+      "ultra": "uniquecharm/queens_call"
     }
   }
 ]

--- a/data/local/lng/strings/item-names.json
+++ b/data/local/lng/strings/item-names.json
@@ -1,4 +1,4 @@
-﻿[
+[
     {
         "id": 1060,
         "Key": "qf1",
@@ -7075,7 +7075,7 @@
         "id": 2454,
         "Key": "whorl",
         "enUS": "Whorl",
-        "zhTW": "螺紋",
+        "zhTW": "旋螺",
         "deDE": "Spindel",
         "esES": "[fs]Espira",
         "frFR": "[fs]Spire",
@@ -7086,7 +7086,7 @@
         "jaJP": "渦",
         "ptBR": "[ms]Caracol",
         "ruRU": "[ms]виток",
-        "zhCN": "螺纹"
+        "zhCN": "环盘"
     },
     {
         "id": 2455,
@@ -7477,7 +7477,7 @@
         "jaJP": "幽暗",
         "ptBR": "[fs]Vara",
         "ruRU": "[fs]жердь",
-        "zhCN": "苍白"
+        "zhCN": "栅木"
     },
     {
         "id": 2479,
@@ -12413,7 +12413,7 @@
         "id": 11152,
         "Key": "std",
         "enUS": "Standard of Heroes",
-        "zhTW": "ÿc8英雄旗幟ÿc1",
+        "zhTW": "英雄旗幟",
         "deDE": "Standarte der Helden",
         "esES": "Estandarte de los héroes",
         "frFR": "Étendard de héros",
@@ -12424,7 +12424,7 @@
         "jaJP": "英雄の旗",
         "ptBR": "[ms]Estandarte de Heróis",
         "ruRU": "Знамя героя",
-        "zhCN": "ÿc8英雄的旗帜ÿc1"
+        "zhCN": "英雄的旗帜"
     },
     {
         "id": 11153,
@@ -17660,7 +17660,7 @@
         "jaJP": "スパインリッパー",
         "ptBR": "Rasga-espinha",
         "ruRU": "Хребтолом",
-        "zhCN": "裂脊者"
+        "zhCN": "裂脊者 "
     },
     {
         "id": 21328,
@@ -19553,7 +19553,7 @@
         "id": 21440,
         "Key": "Bling Bling",
         "enUS": "Bling Bling",
-        "zhTW": "亮閃閃",
+        "zhTW": "閃亮亮",
         "deDE": "Bling-Bling",
         "esES": "Bling Bling",
         "frFR": "Colchoc",
@@ -19564,7 +19564,7 @@
         "jaJP": "ブリンブリン",
         "ptBR": "Extravagância",
         "ruRU": "Шик и роскошь",
-        "zhCN": "亮闪闪"
+        "zhCN": "Bling Bling"
     },
     {
         "id": 21441,
@@ -20873,7 +20873,7 @@
         "jaJP": "ハデスホーン",
         "ptBR": "Chifre de Hades",
         "ruRU": "Рог Аида",
-        "zhCN": "冥王号角"
+        "zhCN": "Hadeshorn"
     },
     {
         "id": 21519,
@@ -20975,7 +20975,7 @@
         "jaJP": "スピリット・シュラウド",
         "ptBR": "Mortalha Espiritual",
         "ruRU": "Призрачный покров",
-        "zhCN": "覆灵帷幕"
+        "zhCN": "覆灵尸衣"
     },
     {
         "id": 21525,
@@ -21593,7 +21593,7 @@
         "id": 21561,
         "Key": "Darkfear",
         "enUS": "Darkfear",
-        "zhTW": "黑暗驚懼",
+        "zhTW": "黑暗恐懼",
         "deDE": "Dunkelfurcht",
         "esES": "Miedo oscuro",
         "frFR": "Peur noire",
@@ -21604,7 +21604,7 @@
         "jaJP": "ダークフィアー",
         "ptBR": "Medo Sombrio",
         "ruRU": "Темный ужас",
-        "zhCN": "黑暗惊惧"
+        "zhCN": "黑暗恐惧"
     },
     {
         "id": 21562,
@@ -24908,7 +24908,7 @@
         "id": 21757,
         "Key": "Crest of Morn",
         "enUS": "Crest of Morn",
-        "zhTW": "黎明尖峰",
+        "zhTW": "黎明徽章",
         "deDE": "Gefieder des Morgens",
         "esES": "Cresta de la mañana",
         "frFR": "Lueur de l’aube",
@@ -25225,7 +25225,7 @@
         "jaJP": "タル・ラシャの外装",
         "ptBR": "Bandagens de Tal Rasha",
         "ruRU": "Одеяния Тал Раши",
-        "zhCN": "塔·拉夏的外袍"
+        "zhCN": "塔·拉夏的裹尸布"
     },
     {
         "id": 21816,
@@ -26166,7 +26166,7 @@
         "id": 50003,
         "Key": "ka3Description",
         "enUS": "ÿc410%% Brick (White)\n10%% Brick (Rare)\n25%% Nothing Happens\n55%% Success\nCorruption Chances:\n\npotentially add an additional affix\nCube with an item to",
-        "zhTW": "ÿc410%% 變磚（變白裝）\n10%% 變磚（變稀有）\n25%% 無事發生\n55%% 腐化成功\n腐化幾率：\n\n有可能增加一个附加屬性\n需要點擊兩次轉化\n與物品一同放入Cube",
+        "zhTW": "ÿc410%% 砖块（白色）\n10%% 砖块（稀有）\n25%% 一无所获\n55%% 成功\n腐败几率：\n\n有可能增加一个附加属性\n立方体与物品",
         "deDE": "ÿc410%% Ziegelstein (Weiß)\n10%% Ziegelstein (Selten)\n25%% Nichts passiert\n55%% Erfolg\nKorruptions-Chancen:\n\nMöglicherweise ein zusätzliches Affix hinzufügen\nWürfel mit einem Gegenstand zu",
         "esES": "ÿc410%% Ladrillo (Blanco)\n10%% Ladrillo (Raro)\n25%% No pasa nada\n55%% Éxito\nProbabilidades de Corrupción:\n\nAñadir potencialmente un afijo adicional\nCubo con un objeto para",
         "frFR": "ÿc410%% Brique (Blanche)\n10%% Brique (Rare)\n25%% Rien ne se passe\n55%% Succès\nChances de corruption :\n\najout potentiel d'un affixe supplémentaire\nCube avec un objet pour",
@@ -26177,13 +26177,13 @@
         "jaJP": "ÿc410%% レンガ（ホワイト）\n10%% レンガ（レア）\n25%% 何も起こらない\n55%% 成功\n腐敗の確率\n\nアフィックスが追加される可能性がある。\nアイテムでキューブを",
         "ptBR": "ÿc410%% Brick (Branco)\n10%% Tijolo (Raro)\n25%% Nada acontece\n55%% de sucesso\nChances de corrupção:\n\npotencialmente adicionar um afixo adicional\nCubo com um item para",
         "ruRU": "ÿc410%% Кирпич (белый)\n10%% Кирпич (редкий)\n25%% Ничего не происходит\n55%% Успех\nШансы коррупции:\n\nпотенциально добавляет дополнительный аффикс\nКуб с предметом, чтобы",
-        "zhCN": "ÿc410%% 变砖（变白装）\n10%% 变砖（变稀有）\n25%% 无事发生\n55%% 腐化成功\n腐化几率：\n\n有可能增加一个附加属性\n需要点击两次转化\n与物品一同放入Cube"
+        "zhCN": "ÿc410%% 砖块（白色）\n10%% 砖块（稀有）\n25%% 无事发生\n55%% 成功\n腐败几率：\n\n有可能增加一个附加属性\n立方体与物品"
     },
     {
         "id": 50004,
         "Key": "kch",
         "enUS": "ÿc8Keychain",
-        "zhTW": "ÿc8鑰匙串",
+        "zhTW": "ÿc8鑰匙圈",
         "deDE": "ÿc8Schlüsselanhänger",
         "esES": "ÿc8Llavero",
         "frFR": "ÿc8Porte-clés",
@@ -26194,13 +26194,13 @@
         "jaJP": "ÿc8キーチェーン",
         "ptBR": "ÿc8Chaveiro",
         "ruRU": "ÿc8Брелок",
-        "zhCN": "ÿc8钥匙串"
+        "zhCN": "ÿc8钥匙链"
     },
     {
         "id": 50005,
         "Key": "KeychainDescription",
         "enUS": "ÿc4\nKeychain + Grabber = Retrieve Key\nKeychain + Key(s) = Add Key(s)\nCube Recipes:\n\nÿc5A suitable shackle for Infernal Keys",
-        "zhTW": "ÿc4\n鑰匙串 + 鑰匙提取器 = 提取指定鑰匙\n鑰匙串 + 鑰匙 = 添加鑰匙\nCube公式：\n\nÿc5炎魔的鑰匙叮噹作響",
+        "zhTW": "ÿc4\n钥匙串 + 抓取器 = 找回钥匙\n钥匙串 + 钥匙 = 添加钥匙\n魔方配方：\n\nÿc5适合炎魔钥匙的枷锁",
         "deDE": "ÿc4\nSchlüsselbund + Greifer = Schlüssel abrufen\nSchlüsselbund + Taste(n) = Taste(n) hinzufügen\nWürfel-Rezepte:\n\nÿc5Ein passender Schäkel für Höllenschlüssel",
         "esES": "ÿc4\nLlavero + Grabber = Recuperar Llave\nLlavero + Llave(s) = Añadir Llave(s)\nRecetas Cubo:\n\nÿc5Un grillete adecuado para Llaves Infernales",
         "frFR": "ÿc4\nTrousseau + Grabber = Récupérer la clé\nTrousseau + Clé(s) = Ajouter une (des) clé(s)\nRecettes de cubes :\n\nÿc5Une manille adaptée aux clés infernales",
@@ -26211,13 +26211,13 @@
         "jaJP": "ÿc4\nキーチェーン + グラバー = キーの取得\nキーチェーン + キー = キーの追加\nキューブのレシピ\n\nÿc5インファナル・キーに適したシャックル",
         "ptBR": "ÿc4\nKeychain + Grabber = Recuperar chave\nKeychain + Key(s) = Adicionar chave(s)\nReceitas de cubos:\n\nÿc5Uma argola adequada para Chaves Infernais",
         "ruRU": "ÿc4\nБрелок + захват = извлечь ключ\nБрелок + Ключ(и) = Добавить ключ(и)\nРецепты кубов:\n\nÿc5Подходящая дужка для Инфернальных ключей",
-        "zhCN": "ÿc4\n钥匙串 + 钥匙提取器 = 提取指定钥匙\n钥匙串 + 钥匙 = 添加钥匙\nCube公式：\n\nÿc5炎魔的钥匙叮当作响"
+        "zhCN": "ÿc4\n钥匙串 + 抓取器 = 找回钥匙\n钥匙串 + 钥匙 = 添加钥匙\n魔方配方：\n\nÿc5适合炎魔钥匙的枷锁"
     },
     {
         "id": 50006,
         "Key": "stt",
         "enUS": "Item Grabber",
-        "zhTW": "物品提取器",
+        "zhTW": "物品選擇器",
         "deDE": "Gegenstandsgreifer",
         "esES": "Selector de objetos",
         "frFR": "Sélecteur d'objets",
@@ -26228,13 +26228,13 @@
         "jaJP": "アイテム選択ツール",
         "ptBR": "Seletor de Itens",
         "ruRU": "Захват предметов",
-        "zhCN": "物品提取器"
+        "zhCN": "物品选择器"
     },
     {
         "id": 50007,
         "Key": "Sun Tormenter",
         "enUS": "Sun Tormenter",
-        "zhTW": "烈日施虐者",
+        "zhTW": "太阳破坏者",
         "deDE": "Sonnenpeiniger",
         "esES": "Tormenta solar",
         "frFR": "Tourmenteur de soleil",
@@ -26245,13 +26245,13 @@
         "jaJP": "サン・トーメンター",
         "ptBR": "Atormentador do Sol",
         "ruRU": "Мучитель солнца",
-        "zhCN": "烈日施虐者"
+        "zhCN": "太阳破坏者"
     },
     {
         "id": 50008,
         "Key": "Safewarden",
         "enUS": "Safewarden",
-        "zhTW": "守護人",
+        "zhTW": "安全管理员",
         "deDE": "Safewarden",
         "esES": "Safewarden",
         "frFR": "Sauveteur",
@@ -26262,13 +26262,13 @@
         "jaJP": "セーフウォーデン",
         "ptBR": "Guardião de Segurança",
         "ruRU": "Safewarden",
-        "zhCN": "守护人"
+        "zhCN": "安全管理员"
     },
     {
         "id": 50009,
         "Key": "Griefspawn",
         "enUS": "Griefspawn",
-        "zhTW": "悔恨蔓延",
+        "zhTW": "Griefspawn",
         "deDE": "Griefspawn",
         "esES": "Griefspawn",
         "frFR": "Griefspawn",
@@ -26279,13 +26279,13 @@
         "jaJP": "グリーフスポーン",
         "ptBR": "Geração de Luto",
         "ruRU": "Griefspawn",
-        "zhCN": "悔恨蔓延"
+        "zhCN": "Griefspawn"
     },
     {
         "id": 50010,
         "Key": "Hellhunger",
         "enUS": "Hellhunger",
-        "zhTW": "飢餓地獄",
+        "zhTW": "地狱的胃口",
         "deDE": "Der Appetit der Hölle",
         "esES": "El apetito del infierno",
         "frFR": "L'appétit de l'enfer",
@@ -26296,13 +26296,13 @@
         "jaJP": "地獄の食欲",
         "ptBR": "Fome Infernal",
         "ruRU": "Адский аппетит",
-        "zhCN": "饥饿地狱"
+        "zhCN": "地狱的胃口"
     },
     {
         "id": 50011,
         "Key": "Stallion Hooves",
         "enUS": "Stallion Hooves",
-        "zhTW": "種馬之蹄",
+        "zhTW": "种马蹄子",
         "deDE": "Hengsthufe",
         "esES": "Pezuñas de semental",
         "frFR": "Sabots des étalons",
@@ -26313,13 +26313,13 @@
         "jaJP": "種馬の蹄",
         "ptBR": "Cascos do Garanhão",
         "ruRU": "Копыта жеребца",
-        "zhCN": "种马之蹄"
+        "zhCN": "种马蹄子"
     },
     {
         "id": 50012,
         "Key": "Lustwander",
         "enUS": "Lustwander",
-        "zhTW": "游蕩者",
+        "zhTW": "休闲散步",
         "deDE": "Lustwander",
         "esES": "Paseo",
         "frFR": "Randonnée d'agrément",
@@ -26330,13 +26330,13 @@
         "jaJP": "プレジャーウォーク",
         "ptBR": "Luxúria Vagueia",
         "ruRU": "Удовольственная прогулка",
-        "zhCN": "游荡者"
+        "zhCN": "休闲散步"
     },
     {
         "id": 50013,
         "Key": "Ecstacy of Ishtar",
         "enUS": "Ecstacy of Ishtar",
-        "zhTW": "伊什塔爾的迷幻",
+        "zhTW": "伊什塔尔的狂喜",
         "deDE": "Ekstase der Ishtar",
         "esES": "Extasis de Ishtar",
         "frFR": "L'extase d'Ishtar",
@@ -26347,13 +26347,13 @@
         "jaJP": "イシュタルの恍惚",
         "ptBR": "Êxtase de Ishtar",
         "ruRU": "Экстаз Иштар",
-        "zhCN": "伊什塔尔的迷幻"
+        "zhCN": "伊什塔尔的狂喜"
     },
     {
         "id": 50014,
         "Key": "Ogre's Embrace",
         "enUS": "Ogre's Embrace",
-        "zhTW": "食人魔之擁抱",
+        "zhTW": "食人魔的拥抱",
         "deDE": "Die Umarmung des Ogers",
         "esES": "El abrazo del ogro",
         "frFR": "L'étreinte de l'ogre",
@@ -26364,7 +26364,7 @@
         "jaJP": "オーガの抱擁",
         "ptBR": "Abraço de Ogro",
         "ruRU": "Объятия огра",
-        "zhCN": "食人魔之拥抱"
+        "zhCN": "食人魔的拥抱"
     },
     {
         "id": 50015,
@@ -26404,7 +26404,7 @@
         "id": 50017,
         "Key": "Shard of the North Star",
         "enUS": "Shard of the North Star",
-        "zhTW": "北極星碎片",
+        "zhTW": "北极星碎片",
         "deDE": "Scherbe des Nordsterns",
         "esES": "Fragmento de estrella polar",
         "frFR": "Éclat de l'étoile polaire",
@@ -26421,7 +26421,7 @@
         "id": 50018,
         "Key": "Pain Harvester",
         "enUS": "Pain Harvester",
-        "zhTW": "疼痛收割機",
+        "zhTW": "疼痛收割机",
         "deDE": "Pain Harvester",
         "esES": "Cosechadora de dolor",
         "frFR": "Moissonneur de douleur",
@@ -26438,7 +26438,7 @@
         "id": 50019,
         "Key": "Crescent of Secrets",
         "enUS": "Crescent of Secrets",
-        "zhTW": "隱秘之新月",
+        "zhTW": "秘密新月",
         "deDE": "Halbmond des Schreckens",
         "esES": "La Media Luna de los Secretos",
         "frFR": "Le Croissant des secrets",
@@ -26449,13 +26449,13 @@
         "jaJP": "秘密の三日月",
         "ptBR": "Segredos Crescente",
         "ruRU": "Полумесяц секретов",
-        "zhCN": "隐秘之新月"
+        "zhCN": "秘密新月"
     },
     {
         "id": 50020,
         "Key": "Aphrodite's Girdle",
         "enUS": "Aphrodite's Girdle",
-        "zhTW": "阿佛洛狄忒的腰帶",
+        "zhTW": "阿佛洛狄忒的腰带",
         "deDE": "Aphrodites Hüftgürtel",
         "esES": "Faja de Afrodita",
         "frFR": "Ceinture d'Aphrodite",
@@ -26472,7 +26472,7 @@
         "id": 50021,
         "Key": "Feathering Mithril",
         "enUS": "Feathering Mithril",
-        "zhTW": "羽化秘銀",
+        "zhTW": "羽化密特里尔",
         "deDE": "Federndes Mithril",
         "esES": "Mithril emplumado",
         "frFR": "Mithril à plumes",
@@ -26483,13 +26483,13 @@
         "jaJP": "フェザリング・ミスリル",
         "ptBR": "Pena de Mithril",
         "ruRU": "Оперение Митрила",
-        "zhCN": "羽化秘银"
+        "zhCN": "羽化密特里尔"
     },
     {
         "id": 50022,
         "Key": "Golden Lotus",
         "enUS": "Golden Lotus",
-        "zhTW": "金蓮花",
+        "zhTW": "金莲花",
         "deDE": "Golden Lotus",
         "esES": "Loto dorado",
         "frFR": "Lotus doré",
@@ -26506,7 +26506,7 @@
         "id": 50023,
         "Key": "Tarrasque Hide",
         "enUS": "Tarrasque Hide",
-        "zhTW": "泰拉斯奎的隱藏",
+        "zhTW": "塔拉斯克隐藏",
         "deDE": "Tarrasque Hide",
         "esES": "Piel Tarrasque",
         "frFR": "Tarrasque Hide",
@@ -26517,13 +26517,13 @@
         "jaJP": "タラスク・ヒデ",
         "ptBR": "Esconderijo de Tarrasque",
         "ruRU": "Тарраскская шкура",
-        "zhCN": "泰拉斯奎的隐藏"
+        "zhCN": "塔拉斯克隐藏"
     },
     {
         "id": 50024,
         "Key": "Gray God's Mantle",
         "enUS": "Gray God's Mantle",
-        "zhTW": "灰色的上帝衣鉢",
+        "zhTW": "灰色的上帝衣钵",
         "deDE": "Der graue Mantel Gottes",
         "esES": "Manto gris de Dios",
         "frFR": "Le manteau gris de Dieu",
@@ -26540,7 +26540,7 @@
         "id": 50025,
         "Key": "Trump of Jericho",
         "enUS": "Trump of Jericho",
-        "zhTW": "傑里科的王牌",
+        "zhTW": "杰里科的特朗普",
         "deDE": "Trump von Jericho",
         "esES": "El triunfo de Jericó",
         "frFR": "La trompette de Jéricho",
@@ -26551,7 +26551,7 @@
         "jaJP": "エリコの切り札",
         "ptBR": "Trump de Jericó",
         "ruRU": "Козырь Иерихона",
-        "zhCN": "杰里科的王牌"
+        "zhCN": "杰里科的特朗普"
     },
     {
         "id": 50026,
@@ -26574,7 +26574,7 @@
         "id": 50027,
         "Key": "Warbreeder",
         "enUS": "Warbreeder",
-        "zhTW": "戰爭販子",
+        "zhTW": "战争饲养员",
         "deDE": "Warbreeder",
         "esES": "Warbreeder",
         "frFR": "Warbreeder",
@@ -26585,13 +26585,13 @@
         "jaJP": "ウォーブリーダー",
         "ptBR": "Criador de Guerra",
         "ruRU": "Warbreeder",
-        "zhCN": "战争贩子"
+        "zhCN": "战争饲养员"
     },
     {
         "id": 50028,
         "Key": "Bowel Twister",
         "enUS": "Bowel Twister",
-        "zhTW": "絞腸",
+        "zhTW": "扭肠机",
         "deDE": "Darm-Twister",
         "esES": "Retorcedor intestinal",
         "frFR": "Tordeur d'intestins",
@@ -26602,7 +26602,7 @@
         "jaJP": "腸ツイスター",
         "ptBR": "Tornado Intestinal",
         "ruRU": "Твистер для кишечника",
-        "zhCN": "绞肠"
+        "zhCN": "扭肠机"
     },
     {
         "id": 50029,
@@ -26625,7 +26625,7 @@
         "id": 50030,
         "Key": "Summerstrike",
         "enUS": "Summerstrike",
-        "zhTW": "夏日風暴",
+        "zhTW": "夏日风暴",
         "deDE": "Sommerstreik",
         "esES": "Summerstrike",
         "frFR": "Summerstrike",
@@ -26642,7 +26642,7 @@
         "id": 50031,
         "Key": "Solstice Edge",
         "enUS": "Solstice Edge",
-        "zhTW": "至尊邊緣",
+        "zhTW": "至尊边缘",
         "deDE": "Solstice Kante",
         "esES": "Solstice Edge",
         "frFR": "Solstice Edge",
@@ -26659,7 +26659,7 @@
         "id": 50032,
         "Key": "Spleen Feaster",
         "enUS": "Spleen Feaster",
-        "zhTW": "怒氣盛宴",
+        "zhTW": "健脾器",
         "deDE": "Milzfühler",
         "esES": "Alimentador del bazo",
         "frFR": "Mangeur de rate",
@@ -26670,13 +26670,13 @@
         "jaJP": "脾臓フィースター",
         "ptBR": "Baço Festeiro",
         "ruRU": "Разжигатель селезенки",
-        "zhCN": "怒气盛宴"
+        "zhCN": "取脾器"
     },
     {
         "id": 50033,
         "Key": "Brainraver",
         "enUS": "Brainraver",
-        "zhTW": "脑力狂歡",
+        "zhTW": "脑力劳动者",
         "deDE": "Brainraver",
         "esES": "Brainraver",
         "frFR": "Brainraver",
@@ -26687,7 +26687,7 @@
         "jaJP": "ブレインレーバー",
         "ptBR": "Raver Cerebral",
         "ruRU": "Brainraver",
-        "zhCN": "脑力狂欢"
+        "zhCN": "脑力劳动者"
     },
     {
         "id": 50034,
@@ -26727,7 +26727,7 @@
         "id": 50036,
         "Key": "Werewolf Slayer",
         "enUS": "Werewolf Slayer",
-        "zhTW": "狼人殺手",
+        "zhTW": "狼人杀手",
         "deDE": "Werwolfjägerin",
         "esES": "Cazadora de hombres lobo",
         "frFR": "Tueuse de loups-garous",
@@ -26744,7 +26744,7 @@
         "id": 50037,
         "Key": "Kraken's Lash",
         "enUS": "Kraken's Lash",
-        "zhTW": "海怪的鞭笞",
+        "zhTW": "克拉肯的睫毛",
         "deDE": "Peitsche des Kraken",
         "esES": "Latigazo del Kraken",
         "frFR": "Cil de Kraken",
@@ -26755,13 +26755,13 @@
         "jaJP": "クラーケンズ・ラッシュ",
         "ptBR": "Lula Gigante",
         "ruRU": "Плеть Кракена",
-        "zhCN": "深海巨妖的鞭笞"
+        "zhCN": "克拉肯的睫毛"
     },
     {
         "id": 50038,
         "Key": "King's Bounty",
         "enUS": "King's Bounty",
-        "zhTW": "國王的賞金",
+        "zhTW": "国王的赏金",
         "deDE": "Königliche Prämie",
         "esES": "Recompensa del Rey",
         "frFR": "La prime du roi",
@@ -26778,7 +26778,7 @@
         "id": 50039,
         "Key": "Call Of Heroes",
         "enUS": "Call Of Heroes",
-        "zhTW": "英雄召喚",
+        "zhTW": "英雄召唤",
         "deDE": "Der Ruf der Helden",
         "esES": "La llamada de los héroes",
         "frFR": "Appel des héros",
@@ -26795,7 +26795,7 @@
         "id": 50040,
         "Key": "Blade Of Mythos",
         "enUS": "Blade Of Mythos",
-        "zhTW": "神話之刃",
+        "zhTW": "神话之刃",
         "deDE": "Klinge des Mythos",
         "esES": "Hoja de Mythos",
         "frFR": "Lame du Mythos",
@@ -26829,7 +26829,7 @@
         "id": 50042,
         "Key": "Holy Avenger",
         "enUS": "Holy Avenger",
-        "zhTW": "神聖復仇者",
+        "zhTW": "神圣复仇者",
         "deDE": "Heiliger Rächer",
         "esES": "Santo Vengador",
         "frFR": "Saint Vengeur",
@@ -26846,7 +26846,7 @@
         "id": 50043,
         "Key": "Fist of Lachdanan",
         "enUS": "Fist of Lachdanan",
-        "zhTW": "拉赫達南之拳",
+        "zhTW": "拉赫达南之拳",
         "deDE": "Die Faust von Lachdanan",
         "esES": "Puño de Lachdanan",
         "frFR": "Poing de Lachdanan",
@@ -26880,7 +26880,7 @@
         "id": 50045,
         "Key": "Fall Of Myth Drannor",
         "enUS": "Fall Of Myth Drannor",
-        "zhTW": "神話德蘭諾的沒落",
+        "zhTW": "神话德兰诺的没落",
         "deDE": "Der Fall des Mythos Drannor",
         "esES": "Caída de Myth Drannor",
         "frFR": "La chute de Myth Drannor",
@@ -26897,7 +26897,7 @@
         "id": 50046,
         "Key": "Breath Of Fire",
         "enUS": "Breath Of Fire",
-        "zhTW": "火之氣息",
+        "zhTW": "火的气息",
         "deDE": "Feueratem",
         "esES": "Aliento de fuego",
         "frFR": "Le souffle du feu",
@@ -26908,13 +26908,13 @@
         "jaJP": "ブレス・オブ・ファイヤー",
         "ptBR": "Sopro De Fogo",
         "ruRU": "Дыхание огня",
-        "zhCN": "火之气息"
+        "zhCN": "火的气息"
     },
     {
         "id": 50047,
         "Key": "Spirit Light",
         "enUS": "Spirit Light",
-        "zhTW": "靈魂之光",
+        "zhTW": "精神之光",
         "deDE": "Spirit Light",
         "esES": "Luz espiritual",
         "frFR": "Spirit Light",
@@ -26925,13 +26925,13 @@
         "jaJP": "スピリット・ライト",
         "ptBR": "Luz Espiritual",
         "ruRU": "Свет духа",
-        "zhCN": "灵魂之光"
+        "zhCN": "精神之光"
     },
     {
         "id": 50048,
         "Key": "Kydra's Judgement",
         "enUS": "Kydra's Judgement",
-        "zhTW": "凱德拉的判決",
+        "zhTW": "凯德拉的判决",
         "deDE": "Kydras Urteilsspruch",
         "esES": "Sentencia de Kydra",
         "frFR": "Le jugement de Kydra",
@@ -26948,7 +26948,7 @@
         "id": 50049,
         "Key": "Dreadfear",
         "enUS": "Dreadfear",
-        "zhTW": "深度驚懼",
+        "zhTW": "恐惧",
         "deDE": "Schreckensangst",
         "esES": "Dreadfear",
         "frFR": "Peur de la peur",
@@ -26959,13 +26959,13 @@
         "jaJP": "恐怖",
         "ptBR": "Medo",
         "ruRU": "Дредфаер",
-        "zhCN": "深度惊惧"
+        "zhCN": "恐惧"
     },
     {
         "id": 50050,
         "Key": "Jadrik's Torment",
         "enUS": "Jadrik's Torment",
-        "zhTW": "賈德里克的折磨",
+        "zhTW": "贾德里克的折磨",
         "deDE": "Jadriks Qualen",
         "esES": "El tormento de Jadrik",
         "frFR": "Le tourment de Jadrik",
@@ -26982,7 +26982,7 @@
         "id": 50051,
         "Key": "Gorgon Strength",
         "enUS": "Gorgon Strength",
-        "zhTW": "戈爾貢之力",
+        "zhTW": "高竿力量",
         "deDE": "Gorgonenstärke",
         "esES": "Fuerza Gorgona",
         "frFR": "La force des gorgones",
@@ -26993,13 +26993,13 @@
         "jaJP": "ゴルゴーンの強さ",
         "ptBR": "Força Das Górgonas",
         "ruRU": "Сила горгоны",
-        "zhCN": "戈尔工之力"
+        "zhCN": "高竿力量"
     },
     {
         "id": 50052,
         "Key": "Sanctuary",
         "enUS": "Sanctuary",
-        "zhTW": "避難所",
+        "zhTW": "避难所",
         "deDE": "Heiligtum",
         "esES": "Santuario",
         "frFR": "Sanctuaire",
@@ -27016,7 +27016,7 @@
         "id": 50053,
         "Key": "Darkmantle",
         "enUS": "Darkmantle",
-        "zhTW": "暗幕",
+        "zhTW": "Darkmantle",
         "deDE": "Darkmantle",
         "esES": "Darkmantle",
         "frFR": "Darkmantle",
@@ -27027,13 +27027,13 @@
         "jaJP": "ダークマントル",
         "ptBR": "Manto Negro",
         "ruRU": "Даркмантл",
-        "zhCN": "暗幕"
+        "zhCN": "Darkmantle"
     },
     {
         "id": 50054,
         "Key": "Spectral Image",
         "enUS": "Spectral Image",
-        "zhTW": "光譜圖像",
+        "zhTW": "光谱图像",
         "deDE": "Spektrales Bild",
         "esES": "Imagen espectral",
         "frFR": "Image spectrale",
@@ -27050,7 +27050,7 @@
         "id": 50055,
         "Key": "Black Widow",
         "enUS": "Black Widow",
-        "zhTW": "黑寡婦",
+        "zhTW": "黑寡妇",
         "deDE": "Schwarze Witwe",
         "esES": "Viuda Negra",
         "frFR": "Veuve noire",
@@ -27067,7 +27067,7 @@
         "id": 50056,
         "Key": "Razor Strike",
         "enUS": "Razor Strike",
-        "zhTW": "剃刀打擊",
+        "zhTW": "剃刀打击",
         "deDE": "Rasiermesser-Schlag",
         "esES": "Golpe de navaja",
         "frFR": "Coup de rasoir",
@@ -27084,7 +27084,7 @@
         "id": 50057,
         "Key": "Death Shade",
         "enUS": "Death Shade",
-        "zhTW": "死亡陰影",
+        "zhTW": "死亡阴影",
         "deDE": "Todesschatten",
         "esES": "Sombra de la Muerte",
         "frFR": "Ombre de la mort",
@@ -27101,7 +27101,7 @@
         "id": 50058,
         "Key": "Phantom Pegasus",
         "enUS": "Phantom Pegasus",
-        "zhTW": "幻影飛馬",
+        "zhTW": "幻影飞马",
         "deDE": "Phantom Pegasus",
         "esES": "Pegaso Fantasma",
         "frFR": "Pégase fantôme",
@@ -27118,7 +27118,7 @@
         "id": 50059,
         "Key": "Celestial Strike",
         "enUS": "Celestial Strike",
-        "zhTW": "天體打擊",
+        "zhTW": "天体打击",
         "deDE": "Himmelsstreich",
         "esES": "Golpe Celestial",
         "frFR": "Frappe céleste",
@@ -27135,7 +27135,7 @@
         "id": 50060,
         "Key": "Grey Render",
         "enUS": "Grey Render",
-        "zhTW": "灰色暈染",
+        "zhTW": "灰色渲染",
         "deDE": "Grauer Render",
         "esES": "Render gris",
         "frFR": "Rendu gris",
@@ -27146,7 +27146,7 @@
         "jaJP": "グレーレンダー",
         "ptBR": "Desenho Cinzento",
         "ruRU": "Серый рендер",
-        "zhCN": "灰色晕染"
+        "zhCN": "灰色渲染"
     },
     {
         "id": 50061,
@@ -27169,7 +27169,7 @@
         "id": 50062,
         "Key": "Luck Chaser",
         "enUS": "Luck Chaser",
-        "zhTW": "幸運追逐者",
+        "zhTW": "幸运追逐者",
         "deDE": "Glücksverfolger",
         "esES": "Perseguidor de la suerte",
         "frFR": "Chasseur de chance",
@@ -27186,7 +27186,7 @@
         "id": 50063,
         "Key": "Pridebreaker",
         "enUS": "Pridebreaker",
-        "zhTW": "驕傲破壞者",
+        "zhTW": "Pridebreaker",
         "deDE": "Stolzbrecher",
         "esES": "Pridebreaker",
         "frFR": "Briseur d'orgueil",
@@ -27197,13 +27197,13 @@
         "jaJP": "プライドブレーカー",
         "ptBR": "Orgulho Quebrado",
         "ruRU": "Pridebreaker",
-        "zhCN": "骄傲破坏者"
+        "zhCN": "Pridebreaker"
     },
     {
         "id": 50064,
         "Key": "Mind Creche",
         "enUS": "Mind Creche",
-        "zhTW": "心靈育所",
+        "zhTW": "心灵托儿所",
         "deDE": "Mind Creche",
         "esES": "Guardería Mind",
         "frFR": "Mind Creche",
@@ -27214,13 +27214,13 @@
         "jaJP": "マインド・クリーシュ",
         "ptBR": "Creche Mente",
         "ruRU": "Mind Creche",
-        "zhCN": "心灵育所"
+        "zhCN": "心灵托儿所"
     },
     {
         "id": 50065,
         "Key": "Baba Yaga's Needle",
         "enUS": "Baba Yaga's Needle",
-        "zhTW": "巴巴亞加之針",
+        "zhTW": "巴巴亚加之针",
         "deDE": "Die Nadel der Baba Yaga",
         "esES": "Baba Yaga's Needle",
         "frFR": "L'aiguille de Baba Yaga",
@@ -27237,7 +27237,7 @@
         "id": 50066,
         "Key": "Killing Spree",
         "enUS": "Killing Spree",
-        "zhTW": "殺人爲樂",
+        "zhTW": "杀人狂潮",
         "deDE": "Amoklauf",
         "esES": "Matanza",
         "frFR": "La folie meurtrière",
@@ -27248,13 +27248,13 @@
         "jaJP": "キリング・スリー",
         "ptBR": "Varias Mortes",
         "ruRU": "Шквал убийств",
-        "zhCN": "杀人为乐"
+        "zhCN": "杀人狂潮"
     },
     {
         "id": 50067,
         "Key": "Lunatic Fringe",
         "enUS": "Lunatic Fringe",
-        "zhTW": "瘋狂邊緣",
+        "zhTW": "疯子边缘",
         "deDE": "Lunatic Fringe",
         "esES": "Lunatic Fringe",
         "frFR": "Frange lunatique",
@@ -27265,13 +27265,13 @@
         "jaJP": "ルナティック・フリンジ",
         "ptBR": "Franja Lunática",
         "ruRU": "Лунатическая грань",
-        "zhCN": "疯狂边缘"
+        "zhCN": "疯子边缘"
     },
     {
         "id": 50068,
         "Key": "Pride of the Barony",
         "enUS": "Pride of the Barony",
-        "zhTW": "男爵的驕傲",
+        "zhTW": "男爵领地的骄傲",
         "deDE": "Stolz der Baronie",
         "esES": "Orgullo de la Baronía",
         "frFR": "Fierté de la baronnie",
@@ -27282,13 +27282,13 @@
         "jaJP": "バロニーの誇り",
         "ptBR": "Orgulho do Barão",
         "ruRU": "Гордость баронства",
-        "zhCN": "男爵的骄傲"
+        "zhCN": "男爵领地的骄傲"
     },
     {
         "id": 50069,
         "Key": "Slaver's Price",
         "enUS": "Slaver's Price",
-        "zhTW": "販奴者的出價",
+        "zhTW": "奴隶的代价",
         "deDE": "Sklavenhalterpreis",
         "esES": "El precio del esclavista",
         "frFR": "Prix de l'esclave",
@@ -27299,13 +27299,13 @@
         "jaJP": "スレイバーズ・プライス",
         "ptBR": "Preço da Escravidão",
         "ruRU": "Цена раба",
-        "zhCN": "贩奴者的出价"
+        "zhCN": "奴隶的代价"
     },
     {
         "id": 50070,
         "Key": "Judas Kiss",
         "enUS": "Judas Kiss",
-        "zhTW": "猶大之吻",
+        "zhTW": "犹大之吻",
         "deDE": "Judas Kiss",
         "esES": "El beso de Judas",
         "frFR": "Judas Kiss",
@@ -27322,7 +27322,7 @@
         "id": 50071,
         "Key": "Sorcerer's Cache",
         "enUS": "Sorcerer's Cache",
-        "zhTW": "巫師的藏寶庫",
+        "zhTW": "巫师的藏宝库",
         "deDE": "Cache des Hexenmeisters",
         "esES": "Alijo del brujo",
         "frFR": "Cache du sorcier",
@@ -27339,7 +27339,7 @@
         "id": 50072,
         "Key": "Charon's Token",
         "enUS": "Charon's Token",
-        "zhTW": "喀戎令牌",
+        "zhTW": "卡戎令牌",
         "deDE": "Charons Spielstein",
         "esES": "Ficha de Caronte",
         "frFR": "Jeton de Charon",
@@ -27350,13 +27350,13 @@
         "jaJP": "カロンのトークン",
         "ptBR": "Símbolo de Charon",
         "ruRU": "Жетон Чарона",
-        "zhCN": "喀戎令牌"
+        "zhCN": "卡戎令牌"
     },
     {
         "id": 50073,
         "Key": "Heartpiercer",
         "enUS": "Heartpiercer",
-        "zhTW": "刺心者",
+        "zhTW": "心跳",
         "deDE": "Heartpiercer",
         "esES": "Heartpiercer",
         "frFR": "Heartpiercer",
@@ -27367,13 +27367,13 @@
         "jaJP": "ハートピアサー",
         "ptBR": "Perfurador de corações",
         "ruRU": "Сердцеед",
-        "zhCN": "刺心者"
+        "zhCN": "心跳"
     },
     {
         "id": 50074,
         "Key": "Windrunner",
         "enUS": "Windrunner",
-        "zhTW": "風舞者",
+        "zhTW": "风之旅",
         "deDE": "Windrunner",
         "esES": "Cortavientos",
         "frFR": "Coureur de vent",
@@ -27384,13 +27384,13 @@
         "jaJP": "ウィンドランナー",
         "ptBR": "Corredor de vento",
         "ruRU": "Windrunner",
-        "zhCN": "风舞者"
+        "zhCN": "风之旅"
     },
     {
         "id": 50075,
         "Key": "Quicksilver",
         "enUS": "Quicksilver",
-        "zhTW": "水銀",
+        "zhTW": "流星",
         "deDE": "Quicksilver",
         "esES": "Quicksilver",
         "frFR": "Quicksilver",
@@ -27401,13 +27401,13 @@
         "jaJP": "クイックシルバー",
         "ptBR": "Mercúrio",
         "ruRU": "Quicksilver",
-        "zhCN": "水银"
+        "zhCN": "流星"
     },
     {
         "id": 50076,
         "Key": "Raptorshaft",
         "enUS": "Raptorshaft",
-        "zhTW": "掠奪者之軸",
+        "zhTW": "猛禽轴",
         "deDE": "Raptorshaft",
         "esES": "Raptorshaft",
         "frFR": "Arbre de transmission",
@@ -27418,13 +27418,13 @@
         "jaJP": "ラプターシャフト",
         "ptBR": "Eixo do Raptor",
         "ruRU": "Raptorshaft",
-        "zhCN": "掠夺者之轴"
+        "zhCN": "猛禽轴"
     },
     {
         "id": 50077,
         "Key": "Hawkfire",
         "enUS": "Hawkfire",
-        "zhTW": "鷹火",
+        "zhTW": "鹰火",
         "deDE": "Falkenfeuer",
         "esES": "Hawkfire",
         "frFR": "Feu de faucon",
@@ -27458,7 +27458,7 @@
         "id": 50079,
         "Key": "agr",
         "enUS": "ÿc;Grabber: Amethyst",
-        "zhTW": "ÿc;寶石提取器：紫水晶",
+        "zhTW": "ÿc;選擇器：紫水晶",
         "deDE": "ÿc;Greifer: Amethyst",
         "esES": "ÿc;Selector: Amatista",
         "frFR": "ÿc;Sélecteur: Améthyste",
@@ -27469,13 +27469,13 @@
         "jaJP": "ÿc;選択ツール：アメジスト",
         "ptBR": "ÿc;Seletor: Ametista",
         "ruRU": "ÿc;Захват: Аметист",
-        "zhCN": "ÿc;宝石提取器：紫水晶"
+        "zhCN": "ÿc;选择器：紫水晶"
     },
     {
         "id": 50080,
         "Key": "tgr",
         "enUS": "ÿc9Grabber: Topaz",
-        "zhTW": "ÿc9寶石提取器：黃寶石",
+        "zhTW": "ÿc9選擇器：黃玉",
         "deDE": "ÿc9Greifer: Topas",
         "esES": "ÿc9Selector: Topacio",
         "frFR": "ÿc9Sélecteur: Topaze",
@@ -27486,13 +27486,13 @@
         "jaJP": "ÿc9選択ツール：トパーズ",
         "ptBR": "ÿc9Seletor: Topázio",
         "ruRU": "ÿc9Захват: Топаз",
-        "zhCN": "ÿc9宝石提取器：黄宝石"
+        "zhCN": "ÿc9选择器：黄玉"
     },
     {
         "id": 50081,
         "Key": "sgr",
         "enUS": "ÿc3Grabber: Sapphire",
-        "zhTW": "ÿc3寶石提取器：藍寶石",
+        "zhTW": "ÿc3選擇器：藍寶石",
         "deDE": "ÿc3Greifer: Saphir",
         "esES": "ÿc3Selector: Zafiro",
         "frFR": "ÿc3Sélecteur: Saphir",
@@ -27503,13 +27503,13 @@
         "jaJP": "ÿc3選択ツール：サファイア",
         "ptBR": "ÿc3Seletor: Safira",
         "ruRU": "ÿc3Захват: Сапфир",
-        "zhCN": "ÿc3宝石提取器：蓝宝石"
+        "zhCN": "ÿc3选择器：蓝宝石"
     },
     {
         "id": 50082,
         "Key": "mgr",
         "enUS": "ÿc0Grabber: Diamond",
-        "zhTW": "ÿc0寶石提取器：鑽石",
+        "zhTW": "ÿc0選擇器：鑽石",
         "deDE": "ÿc0Greifer: Diamant",
         "esES": "ÿc0Selector: Diamante",
         "frFR": "ÿc0Sélecteur: Diamant",
@@ -27520,13 +27520,13 @@
         "jaJP": "ÿc0選択ツール：ダイヤモンド",
         "ptBR": "ÿc0Seletor: Diamante",
         "ruRU": "ÿc0Захват: Алмаз",
-        "zhCN": "ÿc0宝石提取器：钻石"
+        "zhCN": "ÿc0选择器：钻石"
     },
     {
         "id": 50083,
         "Key": "egr",
         "enUS": "ÿc2Grabber: Emerald",
-        "zhTW": "ÿc2寶石提取器：綠宝石",
+        "zhTW": "ÿc2選擇器：祖母綠",
         "deDE": "ÿc2Greifer: Smaragd",
         "esES": "ÿc2Selector: Esmeralda",
         "frFR": "ÿc2Sélecteur: Émeraude",
@@ -27537,13 +27537,13 @@
         "jaJP": "ÿc2選択ツール：エメラルド",
         "ptBR": "ÿc2Seletor: Esmeralda",
         "ruRU": "ÿc2Захват: Изумруд",
-        "zhCN": "ÿc2宝石提取器：绿宝石"
+        "zhCN": "ÿc2选择器：祖母绿"
     },
     {
         "id": 50084,
         "Key": "rgr",
         "enUS": "ÿc1Grabber: Ruby",
-        "zhTW": "ÿc1寶石提取器：紅寶石",
+        "zhTW": "ÿc1選擇器：紅寶石",
         "deDE": "ÿc1Greifer: Rubin",
         "esES": "ÿc1Selector: Rubí",
         "frFR": "ÿc1Sélecteur: Rubis",
@@ -27554,13 +27554,13 @@
         "jaJP": "ÿc1選択ツール：ルビー",
         "ptBR": "ÿc1Seletor: Rubi",
         "ruRU": "ÿc1Захват: Рубин",
-        "zhCN": "ÿc1宝石提取器：红宝石"
+        "zhCN": "ÿc1选择器：红宝石"
     },
     {
         "id": 50085,
         "Key": "kgr",
         "enUS": "ÿc5Grabber: Skull",
-        "zhTW": "ÿc5寶石提取器：骷髏",
+        "zhTW": "ÿc5選擇器：骷髏",
         "deDE": "ÿc5Greifer: Schädel",
         "esES": "ÿc5Selector: Calavera",
         "frFR": "ÿc5Sélecteur: Crâne",
@@ -27571,13 +27571,13 @@
         "jaJP": "ÿc5選択ツール：スカル",
         "ptBR": "ÿc5Seletor: Crânio",
         "ruRU": "ÿc5Захват: Череп",
-        "zhCN": "ÿc5宝石提取器：骷髅"
+        "zhCN": "ÿc5选择器：骷髅"
     },
     {
         "id": 50086,
         "Key": "s01",
         "enUS": "ÿc8Stack: El Runeÿc9 (ÿc0#1ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： El ÿc9 (ÿc0#1ÿc9)",
+        "zhTW": "ÿc8堆疊：艾爾符文ÿc9 (ÿc0#1ÿc9)",
         "deDE": "ÿc8Stapel: El-Runeÿc9 (ÿc0#1ÿc9)",
         "esES": "ÿc8Montón: Runa Elÿc9 (ÿc0#1ÿc9)",
         "frFR": "ÿc8Pile: Rune Elÿc9 (ÿc0#1ÿc9)",
@@ -27588,13 +27588,13 @@
         "jaJP": "ÿc8スタック：エルルーンÿc9 (ÿc0#1ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Elÿc9 (ÿc0#1ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Элÿc9 (ÿc0#1ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： El ÿc9 (ÿc0#1ÿc9)"
+        "zhCN": "ÿc8堆叠：艾尔符文ÿc9 (ÿc0#1ÿc9)"
     },
     {
         "id": 50087,
         "Key": "s02",
         "enUS": "ÿc8Stack: Eld Runeÿc9 (ÿc0#2ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Eldÿc9 (ÿc0#2ÿc9)",
+        "zhTW": "ÿc8堆疊：艾德符文ÿc9 (ÿc0#2ÿc9)",
         "deDE": "ÿc8Stapel: Eld-Runeÿc9 (ÿc0#2ÿc9)",
         "esES": "ÿc8Montón: Runa Eldÿc9 (ÿc0#2ÿc9)",
         "frFR": "ÿc8Pile: Rune Eldÿc9 (ÿc0#2ÿc9)",
@@ -27605,13 +27605,13 @@
         "jaJP": "ÿc8スタック：エルドルーンÿc9 (ÿc0#2ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Eldÿc9 (ÿc0#2ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Элдÿc9 (ÿc0#2ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Eldÿc9 (ÿc0#2ÿc9)"
+        "zhCN": "ÿc8堆叠：艾德符文ÿc9 (ÿc0#2ÿc9)"
     },
     {
         "id": 50088,
         "Key": "s03",
         "enUS": "ÿc8Stack: Tir Runeÿc9 (ÿc0#3ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Tirÿc9 (ÿc0#3ÿc9)",
+        "zhTW": "ÿc8堆疊：提爾符文ÿc9 (ÿc0#3ÿc9)",
         "deDE": "ÿc8Stapel: Tir-Runeÿc9 (ÿc0#3ÿc9)",
         "esES": "ÿc8Montón: Runa Tirÿc9 (ÿc0#3ÿc9)",
         "frFR": "ÿc8Pile: Rune Tirÿc9 (ÿc0#3ÿc9)",
@@ -27622,13 +27622,13 @@
         "jaJP": "ÿc8スタック：ティアルーンÿc9 (ÿc0#3ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Tirÿc9 (ÿc0#3ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Тирÿc9 (ÿc0#3ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Tirÿc9 (ÿc0#3ÿc9)"
+        "zhCN": "ÿc8堆叠：提尔符文ÿc9 (ÿc0#3ÿc9)"
     },
     {
         "id": 50089,
         "Key": "s04",
         "enUS": "ÿc8Stack: Nef Runeÿc9 (ÿc0#4ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Nefÿc9 (ÿc0#4ÿc9)",
+        "zhTW": "ÿc8堆疊：奈夫符文ÿc9 (ÿc0#4ÿc9)",
         "deDE": "ÿc8Stapel: Nef-Runeÿc9 (ÿc0#4ÿc9)",
         "esES": "ÿc8Montón: Runa Nefÿc9 (ÿc0#4ÿc9)",
         "frFR": "ÿc8Pile: Rune Nefÿc9 (ÿc0#4ÿc9)",
@@ -27639,13 +27639,13 @@
         "jaJP": "ÿc8スタック：ネフルーンÿc9 (ÿc0#4ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Nefÿc9 (ÿc0#4ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Нефÿc9 (ÿc0#4ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Nefÿc9 (ÿc0#4ÿc9)"
+        "zhCN": "ÿc8堆叠：奈夫符文ÿc9 (ÿc0#4ÿc9)"
     },
     {
         "id": 50090,
         "Key": "s05",
         "enUS": "ÿc8Stack: Eth Runeÿc9 (ÿc0#5ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Ethÿc9 (ÿc0#5ÿc9)",
+        "zhTW": "ÿc8堆疊：艾司符文ÿc9 (ÿc0#5ÿc9)",
         "deDE": "ÿc8Stapel: Eth-Runeÿc9 (ÿc0#5ÿc9)",
         "esES": "ÿc8Montón: Runa Ethÿc9 (ÿc0#5ÿc9)",
         "frFR": "ÿc8Pile: Rune Ethÿc9 (ÿc0#5ÿc9)",
@@ -27656,13 +27656,13 @@
         "jaJP": "ÿc8スタック：エスルーンÿc9 (ÿc0#5ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Ethÿc9 (ÿc0#5ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Этÿc9 (ÿc0#5ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Ethÿc9 (ÿc0#5ÿc9)"
+        "zhCN": "ÿc8堆叠：艾斯符文ÿc9 (ÿc0#5ÿc9)"
     },
     {
         "id": 50091,
         "Key": "s06",
         "enUS": "ÿc8Stack: Ith Runeÿc9 (ÿc0#6ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Ithÿc9 (ÿc0#6ÿc9)",
+        "zhTW": "ÿc8堆疊：伊司符文ÿc9 (ÿc0#6ÿc9)",
         "deDE": "ÿc8Stapel: Ith-Runeÿc9 (ÿc0#6ÿc9)",
         "esES": "ÿc8Montón: Runa Ithÿc9 (ÿc0#6ÿc9)",
         "frFR": "ÿc8Pile: Rune Ithÿc9 (ÿc0#6ÿc9)",
@@ -27673,13 +27673,13 @@
         "jaJP": "ÿc8スタック：イスルーンÿc9 (ÿc0#6ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Ithÿc9 (ÿc0#6ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Итÿc9 (ÿc0#6ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Ithÿc9 (ÿc0#6ÿc9)"
+        "zhCN": "ÿc8堆叠：伊斯符文ÿc9 (ÿc0#6ÿc9)"
     },
     {
         "id": 50092,
         "Key": "s07",
         "enUS": "ÿc8Stack: Tal Runeÿc9 (ÿc0#7ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Talÿc9 (ÿc0#7ÿc9)",
+        "zhTW": "ÿc8堆疊：塔爾符文ÿc9 (ÿc0#7ÿc9)",
         "deDE": "ÿc8Stapel: Tal-Runeÿc9 (ÿc0#7ÿc9)",
         "esES": "ÿc8Montón: Runa Talÿc9 (ÿc0#7ÿc9)",
         "frFR": "ÿc8Pile: Rune Talÿc9 (ÿc0#7ÿc9)",
@@ -27690,13 +27690,13 @@
         "jaJP": "ÿc8スタック：タルルーンÿc9 (ÿc0#7ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Talÿc9 (ÿc0#7ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Талÿc9 (ÿc0#7ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Talÿc9 (ÿc0#7ÿc9)"
+        "zhCN": "ÿc8堆叠：塔尔符文ÿc9 (ÿc0#7ÿc9)"
     },
     {
         "id": 50093,
         "Key": "s08",
         "enUS": "ÿc8Stack: Ral Runeÿc9 (ÿc0#8ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Ralÿc9 (ÿc0#8ÿc9)",
+        "zhTW": "ÿc8堆疊：拉爾符文ÿc9 (ÿc0#8ÿc9)",
         "deDE": "ÿc8Stapel: Ral-Runeÿc9 (ÿc0#8ÿc9)",
         "esES": "ÿc8Montón: Runa Ralÿc9 (ÿc0#8ÿc9)",
         "frFR": "ÿc8Pile: Rune Ralÿc9 (ÿc0#8ÿc9)",
@@ -27707,13 +27707,13 @@
         "jaJP": "ÿc8スタック：ラルルーンÿc9 (ÿc0#8ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Ralÿc9 (ÿc0#8ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Ралÿc9 (ÿc0#8ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Ralÿc9 (ÿc0#8ÿc9)"
+        "zhCN": "ÿc8堆叠：拉尔符文ÿc9 (ÿc0#8ÿc9)"
     },
     {
         "id": 50094,
         "Key": "s09",
         "enUS": "ÿc8Stack: Ort Runeÿc9 (ÿc0#9ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Ortÿc9 (ÿc0#9ÿc9)",
+        "zhTW": "ÿc8堆疊：奧特符文ÿc9（ÿc0#9ÿc9）",
         "deDE": "ÿc8Stapel: Ort-Runeÿc9 (ÿc0#9ÿc9)",
         "esES": "ÿc8Montón: Runa Ortÿc9 (ÿc0#9ÿc9)",
         "frFR": "ÿc8Pile : Rune Ortÿc9 (ÿc0#9ÿc9)",
@@ -27724,13 +27724,13 @@
         "jaJP": "ÿc8スタック：オルト・ルーンÿc9 (ÿc0#9ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Ortÿc9 (ÿc0#9ÿc9)",
         "ruRU": "ÿc8Стопка: руна Ортÿc9 (ÿc0#9ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Ortÿc9 (ÿc0#9ÿc9)"
+        "zhCN": "ÿc8堆叠：奥特符文ÿc9（ÿc0#9ÿc9）"
     },
     {
         "id": 50095,
         "Key": "s10",
         "enUS": "ÿc8Stack: Thul Runeÿc9 (ÿc0#10ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Thulÿc9 (ÿc0#10ÿc9)",
+        "zhTW": "ÿc8堆疊：圖爾符文ÿc9 (ÿc0#10ÿc9)",
         "deDE": "ÿc8Stapel: Thul-Runeÿc9 (ÿc0#10ÿc9)",
         "esES": "ÿc8Montón: Runa Thulÿc9 (ÿc0#10ÿc9)",
         "frFR": "ÿc8Pile: Rune Thulÿc9 (ÿc0#10ÿc9)",
@@ -27741,13 +27741,13 @@
         "jaJP": "ÿc8スタック：トゥルルーンÿc9 (ÿc0#10ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Thulÿc9 (ÿc0#10ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Тулÿc9 (ÿc0#10ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Thulÿc9 (ÿc0#10ÿc9)"
+        "zhCN": "ÿc8堆叠：图尔符文ÿc9 (ÿc0#10ÿc9)"
     },
     {
         "id": 50096,
         "Key": "s11",
         "enUS": "ÿc8Stack: Amn Runeÿc9 (ÿc0#11ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Amnÿc9 (ÿc0#11ÿc9)",
+        "zhTW": "ÿc8堆疊：艾姆符文ÿc9 (ÿc0#11ÿc9)",
         "deDE": "ÿc8Stapel: Amn-Runeÿc9 (ÿc0#11ÿc9)",
         "esES": "ÿc8Montón: Runa Amnÿc9 (ÿc0#11ÿc9)",
         "frFR": "ÿc8Pile: Rune Amnÿc9 (ÿc0#11ÿc9)",
@@ -27758,13 +27758,13 @@
         "jaJP": "ÿc8スタック：アムンルーンÿc9 (ÿc0#11ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Amnÿc9 (ÿc0#11ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Амнÿc9 (ÿc0#11ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Amnÿc9 (ÿc0#11ÿc9)"
+        "zhCN": "ÿc8堆叠：艾姆符文ÿc9 (ÿc0#11ÿc9)"
     },
     {
         "id": 50097,
         "Key": "s12",
         "enUS": "ÿc8Stack: Sol Runeÿc9 (ÿc0#12ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Solÿc9 (ÿc0#12ÿc9)",
+        "zhTW": "ÿc8堆疊：索爾符文ÿc9 (ÿc0#12ÿc9)",
         "deDE": "ÿc8Stapel: Sol-Runeÿc9 (ÿc0#12ÿc9)",
         "esES": "ÿc8Montón: Runa Solÿc9 (ÿc0#12ÿc9)",
         "frFR": "ÿc8Pile: Rune Solÿc9 (ÿc0#12ÿc9)",
@@ -27775,13 +27775,13 @@
         "jaJP": "ÿc8スタック：ソルルーンÿc9 (ÿc0#12ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Solÿc9 (ÿc0#12ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Солÿc9 (ÿc0#12ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Solÿc9 (ÿc0#12ÿc9)"
+        "zhCN": "ÿc8堆叠：索尔符文ÿc9 (ÿc0#12ÿc9)"
     },
     {
         "id": 50098,
         "Key": "s13",
         "enUS": "ÿc8Stack: Shael Runeÿc9 (ÿc0#13ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Shaelÿc9 (ÿc0#13ÿc9)",
+        "zhTW": "ÿc8堆疊：沙爾符文ÿc9 (ÿc0#13ÿc9)",
         "deDE": "ÿc8Stapel: Shael-Runeÿc9 (ÿc0#13ÿc9)",
         "esES": "ÿc8Montón: Runa Shaelÿc9 (ÿc0#13ÿc9)",
         "frFR": "ÿc8Pile: Rune Shaelÿc9 (ÿc0#13ÿc9)",
@@ -27792,13 +27792,13 @@
         "jaJP": "ÿc8スタック：シャエルルーンÿc9 (ÿc0#13ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Shaelÿc9 (ÿc0#13ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Шаэльÿc9 (ÿc0#13ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Shaelÿc9 (ÿc0#13ÿc9)"
+        "zhCN": "ÿc8堆叠：沙尔符文ÿc9 (ÿc0#13ÿc9)"
     },
     {
         "id": 50099,
         "Key": "s14",
         "enUS": "ÿc8Stack: Dol Runeÿc9 (ÿc0#14ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Dolÿc9 (ÿc0#14ÿc9)",
+        "zhTW": "ÿc8堆疊：多爾符文ÿc9 (ÿc0#14ÿc9)",
         "deDE": "ÿc8Stapel: Dol-Runeÿc9 (ÿc0#14ÿc9)",
         "esES": "ÿc8Montón: Runa Dolÿc9 (ÿc0#14ÿc9)",
         "frFR": "ÿc8Pile: Rune Dolÿc9 (ÿc0#14ÿc9)",
@@ -27809,13 +27809,13 @@
         "jaJP": "ÿc8スタック：ドルルーンÿc9 (ÿc0#14ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Dolÿc9 (ÿc0#14ÿc9)",
         "ruRU": "ÿc8Стопка: Руна Долÿc9 (ÿc0#14ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Dolÿc9 (ÿc0#14ÿc9)"
+        "zhCN": "ÿc8堆叠：多尔符文ÿc9 (ÿc0#14ÿc9)"
     },
     {
         "id": 50100,
         "Key": "s15",
         "enUS": "ÿc8Stack: Hel Runeÿc9 (ÿc0#15ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Helÿc9 (ÿc0#15ÿc9)",
+        "zhTW": "ÿc8堆疊：赫爾符文ÿc9 (ÿc0#15ÿc9)",
         "deDE": "ÿc8Stapel: Hel-Runeÿc9 (ÿc0#15ÿc9)",
         "esES": "ÿc8Montón: Runa Helÿc9 (ÿc0#15ÿc9)",
         "frFR": "ÿc8Pile: Rune Helÿc9 (ÿc0#15ÿc9)",
@@ -27826,13 +27826,13 @@
         "jaJP": "ÿc8スタック：ヘル・ルーンÿc9 (ÿc0#15ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Helÿc9 (ÿc0#15ÿc9)",
         "ruRU": "ÿc8Стопка: руна Хелÿc9 (ÿc0#15ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Helÿc9 (ÿc0#15ÿc9)"
+        "zhCN": "ÿc8堆叠：海尔符文ÿc9 (ÿc0#15ÿc9)"
     },
     {
         "id": 50101,
         "Key": "s16",
         "enUS": "ÿc8Stack: Io Runeÿc9 (ÿc0#16ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Ioÿc9 (ÿc0#16ÿc9)",
+        "zhTW": "ÿc8堆疊：伊奧符文ÿc9 (ÿc0#16ÿc9)",
         "deDE": "ÿc8Stapel: Io-Runeÿc9 (ÿc0#16ÿc9)",
         "esES": "ÿc8Montón: Runa Ioÿc9 (ÿc0#16ÿc9)",
         "frFR": "ÿc8Pile: Rune Ioÿc9 (ÿc0#16ÿc9)",
@@ -27843,13 +27843,13 @@
         "jaJP": "ÿc8スタック：イオ・ルーンÿc9 (ÿc0#16ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Ioÿc9 (ÿc0#16ÿc9)",
         "ruRU": "ÿc8Стопка: руна Иоÿc9 (ÿc0#16ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Ioÿc9 (ÿc0#16ÿc9)"
+        "zhCN": "ÿc8堆叠：伊奧符文ÿc9 (ÿc0#16ÿc9)"
     },
     {
         "id": 50102,
         "Key": "s17",
         "enUS": "ÿc8Stack: Lum Runeÿc9 (ÿc0#17ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Lumÿc9 (ÿc0#17ÿc9)",
+        "zhTW": "ÿc8堆疊：盧姆符文ÿc9 (ÿc0#17ÿc9)",
         "deDE": "ÿc8Stapel: Lum-Runeÿc9 (ÿc0#17ÿc9)",
         "esES": "ÿc8Montón: Runa Lumÿc9 (ÿc0#17ÿc9)",
         "frFR": "ÿc8Pile: Rune Lumÿc9 (ÿc0#17ÿc9)",
@@ -27860,13 +27860,13 @@
         "jaJP": "ÿc8スタック：ルム・ルーンÿc9 (ÿc0#17ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Lumÿc9 (ÿc0#17ÿc9)",
         "ruRU": "ÿc8Стопка: руна Лумÿc9 (ÿc0#17ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Lumÿc9 (ÿc0#17ÿc9)"
+        "zhCN": "ÿc8堆叠：卢姆符文ÿc9 (ÿc0#17ÿc9)"
     },
     {
         "id": 50103,
         "Key": "s18",
         "enUS": "ÿc8Stack: Ko Runeÿc9 (ÿc0#18ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Koÿc9 (ÿc0#18ÿc9)",
+        "zhTW": "ÿc8堆疊：柯符文ÿc9 (ÿc0#18ÿc9)",
         "deDE": "ÿc8Stapel: Ko-Runeÿc9 (ÿc0#18ÿc9)",
         "esES": "ÿc8Montón: Runa Koÿc9 (ÿc0#18ÿc9)",
         "frFR": "ÿc8Pile: Rune Koÿc9 (ÿc0#18ÿc9)",
@@ -27877,13 +27877,13 @@
         "jaJP": "ÿc8スタック：コ・ルーンÿc9 (ÿc0#18ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Koÿc9 (ÿc0#18ÿc9)",
         "ruRU": "ÿc8Стопка: руна Коÿc9 (ÿc0#18ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Koÿc9 (ÿc0#18ÿc9)"
+        "zhCN": "ÿc8堆叠：柯符文ÿc9 (ÿc0#18ÿc9)"
     },
     {
         "id": 50104,
         "Key": "s19",
         "enUS": "ÿc8Stack: Fal Runeÿc9 (ÿc0#19ÿc9)",
-        "zhTW": "ÿc8已堆疊符文： Falÿc9 (ÿc0#19ÿc9)",
+        "zhTW": "ÿc8堆疊：法爾符文ÿc9 (ÿc0#19ÿc9)",
         "deDE": "ÿc8Stapel: Fal-Runeÿc9 (ÿc0#19ÿc9)",
         "esES": "ÿc8Montón: Runa Falÿc9 (ÿc0#19ÿc9)",
         "frFR": "ÿc8Pile: Rune Falÿc9 (ÿc0#19ÿc9)",
@@ -27894,13 +27894,13 @@
         "jaJP": "ÿc8スタック：ファル・ルーンÿc9 (ÿc0#19ÿc9)",
         "ptBR": "ÿc8Pilha: Runa Falÿc9 (ÿc0#19ÿc9)",
         "ruRU": "ÿc8Стопка: руна Фалÿc9 (ÿc0#19ÿc9)",
-        "zhCN": "ÿc8已堆叠符文： Falÿc9 (ÿc0#19ÿc9)"
+        "zhCN": "ÿc8堆叠：法尔符文ÿc9 (ÿc0#19ÿc9)"
     },
     {
         "id": 50105,
         "Key": "s20",
         "enUS": "ÿc8Stack: Lem Runeÿc9 (ÿc0#20ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Lemÿc9 (ÿc0#20ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：萊姆符文ÿc9 (ÿc0#20ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Lem-Runeÿc9 (ÿc0#20ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Lemÿc9 (ÿc0#20ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Lemÿc9 (ÿc0#20ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -27911,13 +27911,13 @@
         "jaJP": "ÿc8スタック：レム・ルーンÿc9 (ÿc0#20ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Lemÿc9 (ÿc0#20ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Лемÿc9 (ÿc0#20ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Lemÿc9 (ÿc0#20ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：莱姆符文ÿc9 (ÿc0#20ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50106,
         "Key": "s21",
         "enUS": "ÿc8Stack: Pul Runeÿc9 (ÿc0#21ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Pulÿc9 (ÿc0#21ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：普爾符文ÿc9 (ÿc0#21ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Pul-Runeÿc9 (ÿc0#21ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Pulÿc9 (ÿc0#21ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Pulÿc9 (ÿc0#21ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -27928,13 +27928,13 @@
         "jaJP": "ÿc8スタック：プル・ルーンÿc9 (ÿc0#21ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Pulÿc9 (ÿc0#21ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Пулÿc9 (ÿc0#21ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Pulÿc9 (ÿc0#21ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：普尔符文ÿc9 (ÿc0#21ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50107,
         "Key": "s22",
         "enUS": "ÿc8Stack: Um Runeÿc9 (ÿc0#22ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Umÿc9 (ÿc0#22ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：烏姆符文ÿc9 (ÿc0#22ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Um-Runeÿc9 (ÿc0#22ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Umÿc9 (ÿc0#22ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Umÿc9 (ÿc0#22ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -27945,13 +27945,13 @@
         "jaJP": "ÿc8スタック：ウム・ルーンÿc9 (ÿc0#22ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Umÿc9 (ÿc0#22ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Умÿc9 (ÿc0#22ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Umÿc9 (ÿc0#22ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：乌姆符文ÿc9 (ÿc0#22ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50108,
         "Key": "s23",
         "enUS": "ÿc8Stack: Mal Runeÿc9 (ÿc0#23ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Malÿc9 (ÿc0#23ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：瑪爾符文ÿc9 (ÿc0#23ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Mal-Runeÿc9 (ÿc0#23ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Malÿc9 (ÿc0#23ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Malÿc9 (ÿc0#23ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -27962,13 +27962,13 @@
         "jaJP": "ÿc8スタック：マル・ルーンÿc9 (ÿc0#23ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Malÿc9 (ÿc0#23ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Малÿc9 (ÿc0#23ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Malÿc9 (ÿc0#23ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：玛尔符文ÿc9 (ÿc0#23ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50109,
         "Key": "s24",
         "enUS": "ÿc8Stack: Ist Runeÿc9 (ÿc0#24ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Istÿc9 (ÿc0#24ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：伊司特符文ÿc9（ÿc0#24ÿc9）\nÿc;~撿起~ÿc0",
         "deDE": "ÿc8Stapel: Ist-Runeÿc9 (ÿc0#24ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Istÿc9 (ÿc0#24ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile : Rune Istÿc9 (ÿc0#24ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -27979,13 +27979,13 @@
         "jaJP": "ÿc8スタック：イスト・ルーンÿc9 (ÿc0#24ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Istÿc9 (ÿc0#24ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Истÿc9 (ÿc0#24ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Istÿc9 (ÿc0#24ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：伊司特符文ÿc9（ÿc0#24ÿc9）\nÿc;~拾取~ÿc0"
     },
     {
         "id": 50110,
         "Key": "s25",
         "enUS": "ÿc8Stack: Gul Runeÿc9 (ÿc0#25ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Gulÿc9 (ÿc0#25ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：古爾符文ÿc9 (ÿc0#25ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Gul-Runeÿc9 (ÿc0#25ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Gulÿc9 (ÿc0#25ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Gulÿc9 (ÿc0#25ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -27996,13 +27996,13 @@
         "jaJP": "ÿc8スタック：ガル・ルーンÿc9 (ÿc0#25ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Gulÿc9 (ÿc0#25ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Гулÿc9 (ÿc0#25ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Gulÿc9 (ÿc0#25ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：古尔符文ÿc9 (ÿc0#25ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50111,
         "Key": "s26",
         "enUS": "ÿc8Stack: Vex Runeÿc9 (ÿc0#26ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Vexÿc9 (ÿc0#26ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：維克斯符文ÿc9 (ÿc0#26ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Vex-Runeÿc9 (ÿc0#26ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Vexÿc9 (ÿc0#26ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Vexÿc9 (ÿc0#26ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -28013,13 +28013,13 @@
         "jaJP": "ÿc8スタック：ベックス・ルーンÿc9 (ÿc0#26ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Vexÿc9 (ÿc0#26ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Вексÿc9 (ÿc0#26ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Vexÿc9 (ÿc0#26ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：维克斯符文ÿc9 (ÿc0#26ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50112,
         "Key": "s27",
         "enUS": "ÿc8Stack: Ohm Runeÿc9 (ÿc0#27ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Ohmÿc9 (ÿc0#27ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：歐姆符文ÿc9 (ÿc0#27ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Ohm-Runeÿc9 (ÿc0#27ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Ohmÿc9 (ÿc0#27ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Ohmÿc9 (ÿc0#27ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -28030,13 +28030,13 @@
         "jaJP": "ÿc8スタック：オーム・ルーンÿc9 (ÿc0#27ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Ohmÿc9 (ÿc0#27ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Омÿc9 (ÿc0#27ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Ohmÿc9 (ÿc0#27ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：欧姆符文ÿc9 (ÿc0#27ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50113,
         "Key": "s28",
         "enUS": "ÿc8Stack: Lo Runeÿc9 (ÿc0#28ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Loÿc9 (ÿc0#28ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：Lo符文ÿc9 (ÿc0#28ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Lo-Runeÿc9 (ÿc0#28ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Loÿc9 (ÿc0#28ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Loÿc9 (ÿc0#28ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -28047,13 +28047,13 @@
         "jaJP": "ÿc8スタック：ロー・ルーンÿc9 (ÿc0#28ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Loÿc9 (ÿc0#28ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Лоÿc9 (ÿc0#28ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Loÿc9 (ÿc0#28ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：Lo符文ÿc9 (ÿc0#28ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50114,
         "Key": "s29",
         "enUS": "ÿc8Stack: Sur Runeÿc9 (ÿc0#29ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Surÿc9 (ÿc0#29ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：Sur符文ÿc9 (ÿc0#29ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Sur-Runeÿc9 (ÿc0#29ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Surÿc9 (ÿc0#29ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Surÿc9 (ÿc0#29ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -28064,13 +28064,13 @@
         "jaJP": "ÿc8スタック：スール・ルーンÿc9 (ÿc0#29ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Surÿc9 (ÿc0#29ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Сурÿc9 (ÿc0#29ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Surÿc9 (ÿc0#29ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：Sur符文ÿc9 (ÿc0#29ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50115,
         "Key": "s30",
         "enUS": "ÿc8Stack: Ber Runeÿc9 (ÿc0#30ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Berÿc9 (ÿc0#30ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：Ber符文ÿc9 (ÿc0#30ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Ber-Runeÿc9 (ÿc0#30ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Berÿc9 (ÿc0#30ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Berÿc9 (ÿc0#30ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -28081,13 +28081,13 @@
         "jaJP": "ÿc8スタック：ベル・ルーンÿc9 (ÿc0#30ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Berÿc9 (ÿc0#30ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Берÿc9 (ÿc0#30ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Berÿc9 (ÿc0#30ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：Ber符文ÿc9 (ÿc0#30ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50116,
         "Key": "s31",
         "enUS": "ÿc8Stack: Jah Runeÿc9 (ÿc0#31ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Jahÿc9 (ÿc0#31ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：Jah符文ÿc9 (ÿc0#31ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Jah-Runeÿc9 (ÿc0#31ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Jahÿc9 (ÿc0#31ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Jahÿc9 (ÿc0#31ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -28098,13 +28098,13 @@
         "jaJP": "ÿc8スタック：ジャー・ルーンÿc9 (ÿc0#31ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Jahÿc9 (ÿc0#31ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Яхÿc9 (ÿc0#31ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Jahÿc9 (ÿc0#31ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：Jah符文ÿc9 (ÿc0#31ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50117,
         "Key": "s32",
         "enUS": "ÿc8Stack: Cham Runeÿc9 (ÿc0#32ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Chamÿc9 (ÿc0#32ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：Cham符文ÿc9 (ÿc0#32ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Cham-Runeÿc9 (ÿc0#32ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Chamÿc9 (ÿc0#32ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Chamÿc9 (ÿc0#32ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -28115,13 +28115,13 @@
         "jaJP": "ÿc8スタック：チャム・ルーンÿc9 (ÿc0#32ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Chamÿc9 (ÿc0#32ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Чамÿc9 (ÿc0#32ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Chamÿc9 (ÿc0#32ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：Cham符文ÿc9 (ÿc0#32ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50118,
         "Key": "s33",
         "enUS": "ÿc8Stack: Zod Runeÿc9 (ÿc0#33ÿc9)\nÿc;~Pick Up~ÿc0",
-        "zhTW": "ÿc8已堆疊符文： Zodÿc9 (ÿc0#33ÿc9)\n~拾取~ÿc0",
+        "zhTW": "ÿc8堆疊：Zod符文ÿc9 (ÿc0#33ÿc9)\nÿc;~撿取~ÿc0",
         "deDE": "ÿc8Stapel: Zod-Runeÿc9 (ÿc0#33ÿc9)\nÿc;~Aufheben~ÿc0",
         "esES": "ÿc8Montón: Runa Zodÿc9 (ÿc0#33ÿc9)\nÿc;~Recoger~ÿc0",
         "frFR": "ÿc8Pile: Rune Zodÿc9 (ÿc0#33ÿc9)\nÿc;~Ramasser~ÿc0",
@@ -28132,13 +28132,13 @@
         "jaJP": "ÿc8スタック：ゾッド・ルーンÿc9 (ÿc0#33ÿc9)\nÿc;~拾う~ÿc0",
         "ptBR": "ÿc8Pilha: Runa Zodÿc9 (ÿc0#33ÿc9)\nÿc;~Pegar~ÿc0",
         "ruRU": "ÿc8Стопка: руна Зодÿc9 (ÿc0#33ÿc9)\nÿc;~Поднять~ÿc0",
-        "zhCN": "ÿc8已堆叠符文： Zodÿc9 (ÿc0#33ÿc9)\n~拾取~ÿc0"
+        "zhCN": "ÿc8堆叠：Zod符文ÿc9 (ÿc0#33ÿc9)\nÿc;~捡取~ÿc0"
     },
     {
         "id": 50119,
         "Key": "Road to Perdition1",
         "enUS": "Road to Perdition",
-        "zhTW": "通往毀滅之路",
+        "zhTW": "通往灭亡之路",
         "deDE": "Straße zur Verdammnis",
         "esES": "Camino a la perdición",
         "frFR": "La route de la perdition",
@@ -28149,13 +28149,13 @@
         "jaJP": "ロード・トゥ・パーディション",
         "ptBR": "Estrada Para o Pecado",
         "ruRU": "Дорога в погибель",
-        "zhCN": "通往毁灭之路"
+        "zhCN": "通往灭亡之路"
     },
     {
         "id": 50120,
         "Key": "tkg",
         "enUS": "ÿc1Grabber: Terror Key",
-        "zhTW": "ÿc1鑰匙提取器：恐怖之鑰",
+        "zhTW": "ÿc1收集者：恐懼之鑰",
         "deDE": "ÿc1Greifer: Schlüssel des Schreckens",
         "esES": "ÿc1Recolector: Llave del Terror",
         "frFR": "ÿc1Ramasseur : Clé de la Terreur",
@@ -28166,13 +28166,13 @@
         "jaJP": "ÿc1グラバー：テラーキー",
         "ptBR": "ÿc1Coletor: Chave do Terror",
         "ruRU": "ÿc1Граббер: Ключ Ужаса",
-        "zhCN": "ÿc1钥匙提取器：恐怖之钥"
+        "zhCN": "ÿc1收集者：恐惧之钥"
     },
     {
         "id": 50121,
         "Key": "hkg",
         "enUS": "ÿc9Grabber: Hate Key",
-        "zhTW": "ÿc9鑰匙提取器：憎恨之鑰",
+        "zhTW": "ÿc9收集者：憎恨之鑰",
         "deDE": "ÿc9Greifer: Schlüssel des Hasses",
         "esES": "ÿc9Recolector: Llave del Odio",
         "frFR": "ÿc9Ramasseur : Clé de la Haine",
@@ -28183,13 +28183,13 @@
         "jaJP": "ÿc9グラバー：ヘイトキー",
         "ptBR": "ÿc9Coletor: Chave do Ódio",
         "ruRU": "ÿc9Граббер: Ключ Ненависти",
-        "zhCN": "ÿc9钥匙提取器：憎恨之钥"
+        "zhCN": "ÿc9收集者：憎恨之钥"
     },
     {
         "id": 50122,
         "Key": "dkg",
         "enUS": "ÿcAGrabber: Destruction Key",
-        "zhTW": "ÿcA鑰匙提取器：毀滅之鑰",
+        "zhTW": "ÿcA收集者：毀滅之鑰",
         "deDE": "ÿcAGreifer: Schlüssel der Zerstörung",
         "esES": "ÿcARecolector: Llave de la Destrucción",
         "frFR": "ÿcARamasseur : Clé de la Destruction",
@@ -28200,13 +28200,13 @@
         "jaJP": "ÿcAグラバー：デストラクションキー",
         "ptBR": "ÿcAColetor: Chave da Destruição",
         "ruRU": "ÿcAГраббер: Ключ Разрушения",
-        "zhCN": "ÿcA钥匙提取器：毁灭之钥"
+        "zhCN": "ÿcA收集者：毁灭之钥"
     },
     {
         "id": 50123,
         "Key": "z01",
         "enUS": "Magic Arrows",
-        "zhTW": "魔法箭矢",
+        "zhTW": "魔法箭",
         "deDE": "Magische Pfeile",
         "esES": "Flechas mágicas",
         "frFR": "Flèches magiques",
@@ -28217,13 +28217,13 @@
         "jaJP": "魔法の矢",
         "ptBR": "Flechas mágicas",
         "ruRU": "Волшебные стрелы",
-        "zhCN": "魔法箭矢"
+        "zhCN": "魔法箭"
     },
     {
         "id": 50124,
         "Key": "z02",
         "enUS": "Magic Bolts",
-        "zhTW": "魔法弩矢",
+        "zhTW": "魔力螺栓",
         "deDE": "Magische Bolzen",
         "esES": "Pernos mágicos",
         "frFR": "Boulons magiques",
@@ -28234,13 +28234,13 @@
         "jaJP": "マジックボルト",
         "ptBR": "Parafusos mágicos",
         "ruRU": "Волшебные болты",
-        "zhCN": "魔法弩矢"
+        "zhCN": "魔力螺栓"
     },
     {
         "id": 50125,
         "Key": "Replenishing Quiver",
         "enUS": "Replenishing Quiver",
-        "zhTW": "自動回復箭袋",
+        "zhTW": "补充箭筒",
         "deDE": "Köcher wieder auffüllen",
         "esES": "Carcaj de reposición",
         "frFR": "Carquois de réapprovisionnement",
@@ -28251,13 +28251,13 @@
         "jaJP": "矢筒の補充",
         "ptBR": "Aljava de reabastecimento",
         "ruRU": "Пополнение колчана",
-        "zhCN": "自动回复箭袋"
+        "zhCN": "补充箭筒"
     },
     {
         "id": 50126,
         "Key": "Quiver of Piercing",
         "enUS": "Quiver of Piercing",
-        "zhTW": "穿刺箭袋",
+        "zhTW": "穿刺之戒",
         "deDE": "Köcher der Durchdringung",
         "esES": "Carcaj de perforación",
         "frFR": "Carquois de perforation",
@@ -28268,13 +28268,13 @@
         "jaJP": "ピアスの矢筒",
         "ptBR": "Aljava de perfuração",
         "ruRU": "Пронзительный колчан",
-        "zhCN": "穿刺箭袋"
+        "zhCN": "穿刺之戒"
     },
     {
         "id": 50127,
         "Key": "Quiver of Slaying",
         "enUS": "Quiver of Slaying",
-        "zhTW": "殺戮箭袋",
+        "zhTW": "杀戮之剑",
         "deDE": "Köcher des Tötens",
         "esES": "Carcaj de Matanza",
         "frFR": "Carquois de la mort",
@@ -28285,13 +28285,13 @@
         "jaJP": "殺しの矢筒",
         "ptBR": "Aljava de Caça",
         "ruRU": "Колчан истребления",
-        "zhCN": "杀戮箭袋"
+        "zhCN": "杀戮之剑"
     },
     {
         "id": 50128,
         "Key": "Replenishing Bolt Case",
         "enUS": "Replenishing Bolt Case",
-        "zhTW": "自動回復弩盒",
+        "zhTW": "补充螺栓箱",
         "deDE": "Nachfüllen des Bolzenkoffers",
         "esES": "Reposición de la caja de cerrojos",
         "frFR": "Réapprovisionnement de la boîte à goujons",
@@ -28302,13 +28302,13 @@
         "jaJP": "ボルトケースの補充",
         "ptBR": "Reabastecimento da caixa de parafusos",
         "ruRU": "Пополнение запаса болтов",
-        "zhCN": "自动回复弩盒"
+        "zhCN": "补充螺栓箱"
     },
     {
         "id": 50129,
         "Key": "Bolt Case of Piercing",
         "enUS": "Bolt Case of Piercing",
-        "zhTW": "穿刺弩盒",
+        "zhTW": "螺栓穿刺案例",
         "deDE": "Bolzen Fall von Piercing",
         "esES": "Perno Caso de perforación",
         "frFR": "Cas de boulon de piercing",
@@ -28319,13 +28319,13 @@
         "jaJP": "ピアスのボルトケース",
         "ptBR": "Caso de piercing no parafuso",
         "ruRU": "Болт для пирсинга",
-        "zhCN": "穿刺弩盒"
+        "zhCN": "螺栓穿刺案例"
     },
     {
         "id": 50130,
         "Key": "Bolt Case of Slaying",
         "enUS": "Bolt Case of Slaying",
-        "zhTW": "殺戮弩盒",
+        "zhTW": "杀戮的螺栓案例",
         "deDE": "Bolzenfall der Tötung",
         "esES": "Caso Bolt de Slaying",
         "frFR": "Cas d'assassinat de boulons",
@@ -28336,13 +28336,13 @@
         "jaJP": "ボルト事件",
         "ptBR": "Caso Bolt de assassinato",
         "ruRU": "Болт Дело об убийстве",
-        "zhCN": "杀戮弩盒"
+        "zhCN": "杀戮的螺栓案例"
     },
     {
         "id": 50131,
         "Key": "Sepia Shard",
         "enUS": "Sepia Shard",
-        "zhTW": "深褐碎片",
+        "zhTW": "深褐色碎片",
         "deDE": "Sepia-Scherbe",
         "esES": "Fragmento de sepia",
         "frFR": "Éclat sépia",
@@ -28353,13 +28353,13 @@
         "jaJP": "セピアの破片",
         "ptBR": "Fragmento de Sépia",
         "ruRU": "Осколок сепии",
-        "zhCN": "深褐碎片"
+        "zhCN": "深褐色碎片"
     },
     {
         "id": 50132,
         "Key": "Silverdawn",
         "enUS": "Silverdawn",
-        "zhTW": "銀色黎明",
+        "zhTW": "银色黎明",
         "deDE": "Silberdämmerung",
         "esES": "Silverdawn",
         "frFR": "L'aube argentée",
@@ -28376,7 +28376,7 @@
         "id": 50133,
         "Key": "Manticore's Retort",
         "enUS": "Manticore's Retort",
-        "zhTW": "刺尾獅的反擊",
+        "zhTW": "刺尾狮的反驳",
         "deDE": "Manticore's Erwiderung",
         "esES": "La réplica de Mantícora",
         "frFR": "La réplique de Manticore",
@@ -28387,13 +28387,13 @@
         "jaJP": "マンティコアのレトルト",
         "ptBR": "Réplica de Manticore",
         "ruRU": "Ответный удар Мантикоры",
-        "zhCN": "刺尾狮的反击"
+        "zhCN": "刺尾狮的反驳"
     },
     {
         "id": 50134,
         "Key": "Sparrow's Trill",
         "enUS": "Sparrow's Trill",
-        "zhTW": "雀鳴",
+        "zhTW": "麻雀的鸣叫",
         "deDE": "Sperbertriller",
         "esES": "Trino de gorrión",
         "frFR": "Trille du moineau",
@@ -28404,13 +28404,13 @@
         "jaJP": "スズメのトリル",
         "ptBR": "Trinado de Pardal",
         "ruRU": "Воробьиная трель",
-        "zhCN": "雀鸣"
+        "zhCN": "麻雀的鸣叫"
     },
     {
         "id": 50135,
         "Key": "Flicker Cinch",
         "enUS": "Flicker Cinch",
-        "zhTW": "閃爍繫帶",
+        "zhTW": "闪烁夹",
         "deDE": "Flimmern Cinch",
         "esES": "Cinta Flicker",
         "frFR": "Cinch de scintillement",
@@ -28421,13 +28421,13 @@
         "jaJP": "フリッカーシンチ",
         "ptBR": "Moleza Centilante",
         "ruRU": "Мерцающая застежка",
-        "zhCN": "闪烁系带"
+        "zhCN": "闪烁夹"
     },
     {
         "id": 50136,
         "Key": "Soul Stinger",
         "enUS": "Soul Stinger",
-        "zhTW": "靈魂毒刺",
+        "zhTW": "灵魂毒刺",
         "deDE": "Soul Stinger",
         "esES": "Aguijón del alma",
         "frFR": "Soul Stinger",
@@ -28461,7 +28461,7 @@
         "id": 50138,
         "Key": "Eternity Cable",
         "enUS": "Eternity Cable",
-        "zhTW": "永恆之纜",
+        "zhTW": "永恒电缆",
         "deDE": "Ewigkeitskabel",
         "esES": "Cable de eternidad",
         "frFR": "Câble d'éternité",
@@ -28472,13 +28472,13 @@
         "jaJP": "エタニティ・ケーブル",
         "ptBR": "Cabo Da Eternidade",
         "ruRU": "Кабель вечности",
-        "zhCN": "永恒之缆"
+        "zhCN": "永恒电缆"
     },
     {
         "id": 50139,
         "Key": "Dreamsplitter",
         "enUS": "Dreamsplitter",
-        "zhTW": "夢境碎片",
+        "zhTW": "分梦者",
         "deDE": "Traumsplitter",
         "esES": "Dreamsplitter",
         "frFR": "Le séparateur de rêves",
@@ -28489,13 +28489,13 @@
         "jaJP": "ドリームスプリッター",
         "ptBR": "Divisor de Sonho",
         "ruRU": "Dreamsplitter",
-        "zhCN": "梦境碎片"
+        "zhCN": "分梦者"
     },
     {
         "id": 50140,
         "Key": "Seafarer's Security",
         "enUS": "Seafarer's Security",
-        "zhTW": "海员的安護",
+        "zhTW": "海员安全",
         "deDE": "Sicherheit für Seeleute",
         "esES": "Seguridad de la gente de mar",
         "frFR": "Sécurité des marins",
@@ -28506,13 +28506,13 @@
         "jaJP": "船員の安全保障",
         "ptBR": "Segurança do Marítimo",
         "ruRU": "Безопасность моряков",
-        "zhCN": "海员的安护"
+        "zhCN": "海员安全"
     },
     {
         "id": 50141,
         "Key": "Murdering Shard",
         "enUS": "Murdering Shard",
-        "zhTW": "謀殺碎片",
+        "zhTW": "杀人碎片",
         "deDE": "Mörderischer Splitter",
         "esES": "Fragmento asesino",
         "frFR": "Tesson meurtrier",
@@ -28523,13 +28523,13 @@
         "jaJP": "殺人シャード",
         "ptBR": "Fragmento Assassino",
         "ruRU": "Убийство Осколка",
-        "zhCN": "谋杀碎片"
+        "zhCN": "杀人碎片"
     },
     {
         "id": 50142,
         "Key": "Dawn Shadow",
         "enUS": "Dawn Shadow",
-        "zhTW": "黎明陰影",
+        "zhTW": "黎明阴影",
         "deDE": "Morgendämmerung Schatten",
         "esES": "Sombra del amanecer",
         "frFR": "Ombre de l'aube",
@@ -28546,7 +28546,7 @@
         "id": 50143,
         "Key": "Desecration Sigil",
         "enUS": "Desecration Sigil",
-        "zhTW": "褻瀆徽章",
+        "zhTW": "亵渎徽章",
         "deDE": "Siegel der Entweihung",
         "esES": "Sello de profanación",
         "frFR": "Sigil de profanation",
@@ -28580,7 +28580,7 @@
         "id": 50145,
         "Key": "Soul Of The Tanar'Ri",
         "enUS": "Soul Of The Tanar'Ri",
-        "zhTW": "塔納里之魂",
+        "zhTW": "塔纳里之魂",
         "deDE": "Die Seele des Tanar'Ri",
         "esES": "Alma de los Tanar'Ri",
         "frFR": "L'âme du Tanar'Ri",
@@ -28614,7 +28614,7 @@
         "id": 50147,
         "Key": "Goblin Grin",
         "enUS": "Goblin Grin",
-        "zhTW": "哥布林的笑容",
+        "zhTW": "妖精的笑容",
         "deDE": "Kobold Grinsen",
         "esES": "Sonrisa de duende",
         "frFR": "Rictus de gobelin",
@@ -28625,13 +28625,13 @@
         "jaJP": "ゴブリン・グリン",
         "ptBR": "Grilhão De Goblin",
         "ruRU": "Гоблинский оскал",
-        "zhCN": "哥布林的笑容"
+        "zhCN": "妖精的笑容"
     },
     {
         "id": 50148,
         "Key": "Death's Witness",
         "enUS": "Death's Witness",
-        "zhTW": "死亡見證",
+        "zhTW": "死亡见证",
         "deDE": "Der Zeuge des Todes",
         "esES": "Testigo de la muerte",
         "frFR": "Le témoin de la mort",
@@ -28648,7 +28648,7 @@
         "id": 50149,
         "Key": "Scalp Hunter",
         "enUS": "Scalp Hunter",
-        "zhTW": "頭皮獵人",
+        "zhTW": "头皮猎人",
         "deDE": "Skalpjäger",
         "esES": "Cazador del cuero cabelludo",
         "frFR": "Chasseur de cuir chevelu",
@@ -28665,7 +28665,7 @@
         "id": 50150,
         "Key": "Sinister Smile",
         "enUS": "Sinister Smile",
-        "zhTW": "邪惡的微笑",
+        "zhTW": "阴险的微笑",
         "deDE": "Finsteres Lächeln",
         "esES": "Sonrisa siniestra",
         "frFR": "Sourire sinistre",
@@ -28676,13 +28676,13 @@
         "jaJP": "不吉な微笑み",
         "ptBR": "Sorriso Sinistro",
         "ruRU": "Зловещая улыбка",
-        "zhCN": "邪恶的微笑"
+        "zhCN": "阴险的微笑"
     },
     {
         "id": 50151,
         "Key": "Chiaroscuro Visage",
         "enUS": "Chiaroscuro Visage",
-        "zhTW": "明暗之面",
+        "zhTW": "明暗对比",
         "deDE": "Chiaroscuro Visage",
         "esES": "Claroscuro Visage",
         "frFR": "Visage en clair-obscur",
@@ -28693,13 +28693,13 @@
         "jaJP": "キアロスクーロ・ヴィサージュ",
         "ptBR": "Visagem Do Quiaroscuro",
         "ruRU": "Визаж в стиле кьяроскуро",
-        "zhCN": "明暗之面"
+        "zhCN": "明暗对比"
     },
     {
         "id": 50152,
         "Key": "Janus' Face",
         "enUS": "Janus' Face",
-        "zhTW": "傑納斯之面",
+        "zhTW": "杰纳斯的脸",
         "deDE": "Janusgesicht",
         "esES": "Cara de Jano",
         "frFR": "Le visage de Janus",
@@ -28710,13 +28710,13 @@
         "jaJP": "ヤヌスの顔",
         "ptBR": "Rosto de Janus",
         "ruRU": "Лицо Януса",
-        "zhCN": "杰纳斯之面"
+        "zhCN": "杰纳斯的脸"
     },
     {
         "id": 50153,
         "Key": "Carrion Comfort",
         "enUS": "Carrion Comfort",
-        "zhTW": "腐肉之舒",
+        "zhTW": "腐肉的舒适",
         "deDE": "Aas-Komfort",
         "esES": "Carrion Comfort",
         "frFR": "Confort du charognard",
@@ -28727,13 +28727,13 @@
         "jaJP": "カリオン・コンフォート",
         "ptBR": "Carniceiro Confortavel",
         "ruRU": "Комфорт карриона",
-        "zhCN": "腐肉之舒"
+        "zhCN": "腐肉的舒适"
     },
     {
         "id": 50154,
         "Key": "Reaper's Trophy",
         "enUS": "Reaper's Trophy",
-        "zhTW": "死神獎杯",
+        "zhTW": "死神奖杯",
         "deDE": "Trophäe des Sensenmannes",
         "esES": "Trofeo de la Parca",
         "frFR": "Trophée du faucheur",
@@ -28767,7 +28767,7 @@
         "id": 50156,
         "Key": "Dreamweaver",
         "enUS": "Dreamweaver",
-        "zhTW": "織梦者",
+        "zhTW": "织梦者",
         "deDE": "Dreamweaver",
         "esES": "Dreamweaver",
         "frFR": "Dreamweaver",
@@ -28784,7 +28784,7 @@
         "id": 50157,
         "Key": "Dreadmother",
         "enUS": "Dreadmother",
-        "zhTW": "恐懼之母",
+        "zhTW": "恐惧母亲",
         "deDE": "Dreadmother",
         "esES": "Dreadmother",
         "frFR": "La mère des épouvantails",
@@ -28795,7 +28795,7 @@
         "jaJP": "ドレッド・マザー",
         "ptBR": "Mãe Temida",
         "ruRU": "Дредемот",
-        "zhCN": "恐惧之母"
+        "zhCN": "恐惧母亲"
     },
     {
         "id": 50158,
@@ -28818,7 +28818,7 @@
         "id": 50159,
         "Key": "Grip of the Gorgon",
         "enUS": "Grip of the Gorgon",
-        "zhTW": "戈爾貢之握",
+        "zhTW": "高竿之握",
         "deDE": "Der Griff der Gorgone",
         "esES": "Agarre de la Gorgona",
         "frFR": "Poignée de la gorgone",
@@ -28829,13 +28829,13 @@
         "jaJP": "ゴルゴンの掌握",
         "ptBR": "Punho do Górgona",
         "ruRU": "Хватка Горгоны",
-        "zhCN": "戈尔贡之握"
+        "zhCN": "高竿之握"
     },
     {
         "id": 50160,
         "Key": "Secret of Steel",
         "enUS": "Secret of Steel",
-        "zhTW": "鋼鐵之秘",
+        "zhTW": "钢铁的秘密",
         "deDE": "Geheimnis aus Stahl",
         "esES": "El secreto del acero",
         "frFR": "Le secret de l'acier",
@@ -28846,13 +28846,13 @@
         "jaJP": "鋼鉄の秘密",
         "ptBR": "Aço Secreto",
         "ruRU": "Секрет стали",
-        "zhCN": "钢铁之秘"
+        "zhCN": "钢铁的秘密"
     },
     {
         "id": 50161,
         "Key": "Hellchatter",
         "enUS": "Hellchatter",
-        "zhTW": "地獄的嘮叨",
+        "zhTW": "地狱唠叨",
         "deDE": "Hellchatter",
         "esES": "Hellchatter",
         "frFR": "Hellchatter",
@@ -28863,7 +28863,7 @@
         "jaJP": "ヘルチャッター",
         "ptBR": "Conversa do Inferno",
         "ruRU": "Адская болтовня",
-        "zhCN": "地狱的唠叨"
+        "zhCN": "地狱唠叨"
     },
     {
         "id": 50162,
@@ -28886,7 +28886,7 @@
         "id": 50163,
         "Key": "Twilight Presence",
         "enUS": "Twilight Presence",
-        "zhTW": "暮光投射",
+        "zhTW": "暮光之城",
         "deDE": "Dämmerungspräsenz",
         "esES": "Presencia crepuscular",
         "frFR": "Présence crépusculaire",
@@ -28897,13 +28897,13 @@
         "jaJP": "トワイライト・プレゼンス",
         "ptBR": "Presença Crepuscular",
         "ruRU": "Сумеречное присутствие",
-        "zhCN": "暮光投射"
+        "zhCN": "暮光之城"
     },
     {
         "id": 50164,
         "Key": "Voice of the Prophet",
         "enUS": "Voice of the Prophet",
-        "zhTW": "先知之聲",
+        "zhTW": "先知之声",
         "deDE": "Die Stimme des Propheten",
         "esES": "Voz del Profeta",
         "frFR": "La voix du prophète",
@@ -28920,7 +28920,7 @@
         "id": 50165,
         "Key": "Fortress of Morpheus",
         "enUS": "Fortress of Morpheus",
-        "zhTW": "墨菲斯要塞",
+        "zhTW": "莫斐斯要塞",
         "deDE": "Festung von Morpheus",
         "esES": "Fortaleza de Morfeo",
         "frFR": "Forteresse de Morphée",
@@ -28931,13 +28931,13 @@
         "jaJP": "モーフィアスの要塞",
         "ptBR": "Fortaleza de Morpheus",
         "ruRU": "Крепость Морфея",
-        "zhCN": "墨菲斯要塞"
+        "zhCN": "莫斐斯要塞"
     },
     {
         "id": 50166,
         "Key": "Dawnfall",
         "enUS": "Dawnfall",
-        "zhTW": "黎明降臨",
+        "zhTW": "黎明降临",
         "deDE": "Dawnfall",
         "esES": "Amanecer",
         "frFR": "Dawnfall",
@@ -28971,7 +28971,7 @@
         "id": 50168,
         "Key": "Cleric's Rebuke",
         "enUS": "Cleric's Rebuke",
-        "zhTW": "教士的斥責",
+        "zhTW": "教士的斥责",
         "deDE": "Kleriker-Schelte",
         "esES": "Reprensión del clérigo",
         "frFR": "La réplique de l'ecclésiastique",
@@ -28988,7 +28988,7 @@
         "id": 50169,
         "Key": "Grand Inquisitor",
         "enUS": "Grand Inquisitor",
-        "zhTW": "大審判官",
+        "zhTW": "大审判官",
         "deDE": "Großinquisitor",
         "esES": "Gran Inquisidor",
         "frFR": "Grand Inquisiteur",
@@ -29005,7 +29005,7 @@
         "id": 50170,
         "Key": "Chaos Kin",
         "enUS": "Chaos Kin",
-        "zhTW": "渾沌之屬",
+        "zhTW": "Chaos Kin",
         "deDE": "Chaos-Kin",
         "esES": "Caos Kin",
         "frFR": "Chaos Kin",
@@ -29016,13 +29016,13 @@
         "jaJP": "カオス・キン",
         "ptBR": "Parente do Caos",
         "ruRU": "Хаос Кин",
-        "zhCN": "混沌之属"
+        "zhCN": "Chaos Kin"
     },
     {
         "id": 50171,
         "Key": "Darkhunger",
         "enUS": "Darkhunger",
-        "zhTW": "黑暗飢餓",
+        "zhTW": "黑暗饥饿",
         "deDE": "Dunkelheitshunger",
         "esES": "Darkhunger",
         "frFR": "Darkhunger",
@@ -29039,7 +29039,7 @@
         "id": 50172,
         "Key": "Dragon Mask",
         "enUS": "Dragon Mask",
-        "zhTW": "龍之面具",
+        "zhTW": "龙面具",
         "deDE": "Dragon Mask",
         "esES": "Máscara de dragón",
         "frFR": "Dragon Mask",
@@ -29050,7 +29050,7 @@
         "jaJP": "ドラゴンマスク",
         "ptBR": "Máscara Do Dragão",
         "ruRU": "Маска дракона",
-        "zhCN": "龙之面具"
+        "zhCN": "龙面具"
     },
     {
         "id": 50173,
@@ -29073,7 +29073,7 @@
         "id": 50174,
         "Key": "Chimera's Chaos",
         "enUS": "Chimera's Chaos",
-        "zhTW": "奇美拉的混亂",
+        "zhTW": "奇美拉的混乱",
         "deDE": "Das Chaos der Chimäre",
         "esES": "El caos de Quimera",
         "frFR": "Le chaos des chimères",
@@ -29090,7 +29090,7 @@
         "id": 50175,
         "Key": "Deadgaze",
         "enUS": "Deadgaze",
-        "zhTW": "死亡凝視",
+        "zhTW": "死光",
         "deDE": "Deadgaze",
         "esES": "Deadgaze",
         "frFR": "Le feu de paille",
@@ -29101,13 +29101,13 @@
         "jaJP": "デッドゲイズ",
         "ptBR": "Olhar Mortal",
         "ruRU": "Deadgaze",
-        "zhCN": "死亡凝视"
+        "zhCN": "死光"
     },
     {
         "id": 50176,
         "Key": "Gambler's Glory",
         "enUS": "Gambler's Glory",
-        "zhTW": "賭徒的榮耀",
+        "zhTW": "赌徒的荣耀",
         "deDE": "Der Ruhm des Spielers",
         "esES": "La gloria del jugador",
         "frFR": "La gloire du joueur",
@@ -29124,7 +29124,7 @@
         "id": 50177,
         "Key": "Slayer's Glee",
         "enUS": "Slayer's Glee",
-        "zhTW": "屠夫的歡樂",
+        "zhTW": "杀手的欢乐",
         "deDE": "Glee der Jägerin",
         "esES": "Glee de la Cazadora",
         "frFR": "La joie de la tueuse",
@@ -29135,13 +29135,13 @@
         "jaJP": "スレイヤーズ・グリー",
         "ptBR": "Alegria do Retalhador",
         "ruRU": "Хор Истребительницы",
-        "zhCN": "屠夫的欢乐"
+        "zhCN": "杀手的欢乐"
     },
     {
         "id": 50178,
         "Key": "Hellraiser's Casque",
         "enUS": "Hellraiser's Casque",
-        "zhTW": "魔魂之盔",
+        "zhTW": "地狱魔王的卡斯克",
         "deDE": "Hellraiser's Casque",
         "esES": "Casco de Hellraiser",
         "frFR": "Casque de Hellraiser",
@@ -29152,13 +29152,13 @@
         "jaJP": "ヘルレイザーのカスク",
         "ptBR": "Casquet do Inferno",
         "ruRU": "Каска адского убийцы",
-        "zhCN": "魔魂之盔"
+        "zhCN": "地狱魔王的卡斯克"
     },
     {
         "id": 50179,
         "Key": "Conscience of the King",
         "enUS": "Conscience of the King",
-        "zhTW": "國王的良知",
+        "zhTW": "国王的良知",
         "deDE": "Das Gewissen des Königs",
         "esES": "La conciencia del Rey",
         "frFR": "La conscience du roi",
@@ -29175,7 +29175,7 @@
         "id": 50180,
         "Key": "Foul Embrace",
         "enUS": "Foul Embrace",
-        "zhTW": "邪惡的擁抱",
+        "zhTW": "邪恶的拥抱",
         "deDE": "Verdorbene Umarmung",
         "esES": "Foul Embrace",
         "frFR": "Foul Embrace",
@@ -29192,7 +29192,7 @@
         "id": 50181,
         "Key": "The King's Heart",
         "enUS": "The King's Heart",
-        "zhTW": "國王之心",
+        "zhTW": "国王的心",
         "deDE": "Das Herz des Königs",
         "esES": "El corazón del Rey",
         "frFR": "Le cœur du roi",
@@ -29209,7 +29209,7 @@
         "id": 50182,
         "Key": "Blood Brother",
         "enUS": "Blood Brother",
-        "zhTW": "血緣兄弟",
+        "zhTW": "血缘兄弟",
         "deDE": "Blutsbruder",
         "esES": "Hermano de sangre",
         "frFR": "Frère de sang",
@@ -29226,7 +29226,7 @@
         "id": 50183,
         "Key": "Wraith Whisper",
         "enUS": "Wraith Whisper",
-        "zhTW": "幽靈低語",
+        "zhTW": "幽灵低语",
         "deDE": "Wraith-Flüstern",
         "esES": "Susurro del Espectro",
         "frFR": "Chuchotement de Wraith",
@@ -29243,7 +29243,7 @@
         "id": 50184,
         "Key": "Silverskin",
         "enUS": "Silverskin",
-        "zhTW": "銀皮",
+        "zhTW": "银皮",
         "deDE": "Silberhaut",
         "esES": "Piel de plata",
         "frFR": "Peau d'argent",
@@ -29260,7 +29260,7 @@
         "id": 50185,
         "Key": "Eye of Heaven",
         "enUS": "Eye of Heaven",
-        "zhTW": "天堂之眼",
+        "zhTW": "天眼",
         "deDE": "Auge des Himmels",
         "esES": "Ojo del cielo",
         "frFR": "L'œil du ciel",
@@ -29271,13 +29271,13 @@
         "jaJP": "天の目",
         "ptBR": "Olho do Paraiso",
         "ruRU": "Око небесное",
-        "zhCN": "天堂之眼"
+        "zhCN": "天眼"
     },
     {
         "id": 50186,
         "Key": "Copperbite",
         "enUS": "Copperbite",
-        "zhTW": "黃銅之咬",
+        "zhTW": "Copperbite",
         "deDE": "Copperbite",
         "esES": "Copperbite",
         "frFR": "Copperbite",
@@ -29288,13 +29288,13 @@
         "jaJP": "カッパーバイト",
         "ptBR": "Cobre Mordido",
         "ruRU": "Коппербит",
-        "zhCN": "黄铜之咬"
+        "zhCN": "Copperbite"
     },
     {
         "id": 50187,
         "Key": "Sanctuary's Scion",
         "enUS": "Sanctuary's Scion",
-        "zhTW": "聖堂子弟",
+        "zhTW": "圣域的后裔",
         "deDE": "Heiligtumsspross",
         "esES": "Vástago del Santuario",
         "frFR": "Le scion du sanctuaire",
@@ -29305,13 +29305,13 @@
         "jaJP": "サンクチュアリのサイオーン",
         "ptBR": "Santuário de Scion",
         "ruRU": "Шпион Санктуария",
-        "zhCN": "圣堂子弟"
+        "zhCN": "圣域的后裔"
     },
     {
         "id": 50188,
         "Key": "Falcon Sharp",
         "enUS": "Falcon Sharp",
-        "zhTW": "獵鷹之銳",
+        "zhTW": "猎鹰夏普",
         "deDE": "Falkenscharf",
         "esES": "Halcón afilado",
         "frFR": "Falcon Sharp",
@@ -29322,13 +29322,13 @@
         "jaJP": "ファルコンシャープ",
         "ptBR": "Falcão Afiado",
         "ruRU": "Сокол Шарп",
-        "zhCN": "猎鹰之锐"
+        "zhCN": "猎鹰夏普"
     },
     {
         "id": 50189,
         "Key": "Night Prowler",
         "enUS": "Night Prowler",
-        "zhTW": "暗夜潛行者",
+        "zhTW": "夜间巡逻者",
         "deDE": "Night Prowler",
         "esES": "Merodeador nocturno",
         "frFR": "Rôdeur de nuit",
@@ -29339,13 +29339,13 @@
         "jaJP": "ナイト・プローラー",
         "ptBR": "Vagabundo da Noite",
         "ruRU": "Ночной сторож",
-        "zhCN": "暗夜潜行者"
+        "zhCN": "夜间巡逻者"
     },
     {
         "id": 50190,
         "Key": "Creeper's Canopy",
         "enUS": "Creeper's Canopy",
-        "zhTW": "爬山虎的樹冠",
+        "zhTW": "爬山虎的树冠",
         "deDE": "Das Blätterdach des Kriechers",
         "esES": "Tejadillo de enredadera",
         "frFR": "La canopée des lianes",
@@ -29379,7 +29379,7 @@
         "id": 50192,
         "Key": "Crimson Cry",
         "enUS": "Crimson Cry",
-        "zhTW": "緋紅哭泣",
+        "zhTW": "深红色的哭泣",
         "deDE": "Karminroter Schrei",
         "esES": "Grito carmesí",
         "frFR": "Crimson Cry",
@@ -29390,13 +29390,13 @@
         "jaJP": "クリムゾン・クライ",
         "ptBR": "Choro Rubro",
         "ruRU": "Багровый плач",
-        "zhCN": "绯红哭泣"
+        "zhCN": "深红色的哭泣"
     },
     {
         "id": 50193,
         "Key": "Simpleton's Shadow",
         "enUS": "Simpleton's Shadow",
-        "zhTW": "傻瓜之影",
+        "zhTW": "傻瓜的影子",
         "deDE": "Der Schatten des Einfaltspinsels",
         "esES": "La sombra del simplón",
         "frFR": "L'ombre du simplet",
@@ -29407,13 +29407,13 @@
         "jaJP": "単純バカの影",
         "ptBR": "Sombra Ordinaria",
         "ruRU": "Тень простака",
-        "zhCN": "傻瓜之影"
+        "zhCN": "傻瓜的影子"
     },
     {
         "id": 50194,
         "Key": "Murdering Bloom",
         "enUS": "Murdering Bloom",
-        "zhTW": "謀殺綻放",
+        "zhTW": "谋杀布鲁姆",
         "deDE": "Mörderische Blüte",
         "esES": "Asesinato de Bloom",
         "frFR": "L'assassinat de Bloom",
@@ -29424,13 +29424,13 @@
         "jaJP": "ブルームを殺す",
         "ptBR": "Florescer Assassino",
         "ruRU": "Убийство Блума",
-        "zhCN": "谋杀绽放"
+        "zhCN": "谋杀布鲁姆"
     },
     {
         "id": 50195,
         "Key": "Liege Reaver",
         "enUS": "Liege Reaver",
-        "zhTW": "君主掠奪者",
+        "zhTW": "Reaver 躺椅",
         "deDE": "Liege Reaver",
         "esES": "Tumbona Reaver",
         "frFR": "Chaise longue Reaver",
@@ -29441,13 +29441,13 @@
         "jaJP": "レイバー・ラウンジャー",
         "ptBR": "Destruidor Soberano",
         "ruRU": "Шезлонг Reaver",
-        "zhCN": "君主掠夺者"
+        "zhCN": "Reaver 躺椅"
     },
     {
         "id": 50196,
         "Key": "Winterquick",
         "enUS": "Winterquick",
-        "zhTW": "迅冬",
+        "zhTW": "冬季快速",
         "deDE": "Winterquick",
         "esES": "Winterquick",
         "frFR": "Vite fait l'hiver",
@@ -29458,13 +29458,13 @@
         "jaJP": "ウインタークイック",
         "ptBR": "Inverno Veloz",
         "ruRU": "Winterquick",
-        "zhCN": "迅冬"
+        "zhCN": "冬季快速"
     },
     {
         "id": 50197,
         "Key": "Bladespan",
         "enUS": "Bladespan",
-        "zhTW": "刀鋒環繞",
+        "zhTW": "刀片扳手",
         "deDE": "Klingenschlüssel",
         "esES": "Llave de cuchillas",
         "frFR": "Clé à lame",
@@ -29475,13 +29475,13 @@
         "jaJP": "ブレードスパナ",
         "ptBR": "Lamina Repetitiva",
         "ruRU": "Ключ для лезвий",
-        "zhCN": "刀锋环绕"
+        "zhCN": "刀片扳手"
     },
     {
         "id": 50198,
         "Key": "Troll's Touch",
         "enUS": "Troll's Touch",
-        "zhTW": "食人妖之觸",
+        "zhTW": "巨怪之触",
         "deDE": "Die Berührung des Trolls",
         "esES": "El toque del trol",
         "frFR": "Le toucher du troll",
@@ -29492,13 +29492,13 @@
         "jaJP": "トロールの手触り",
         "ptBR": "Toque do Troll",
         "ruRU": "Прикосновение тролля",
-        "zhCN": "巨魔之触"
+        "zhCN": "巨怪之触"
     },
     {
         "id": 50199,
         "Key": "Corpseflayer",
         "enUS": "Corpseflayer",
-        "zhTW": "剝尸者",
+        "zhTW": "噬尸者",
         "deDE": "Leichenfledderer",
         "esES": "Matacadáveres",
         "frFR": "Tueur de cadavres",
@@ -29509,7 +29509,7 @@
         "jaJP": "コープスフレイヤー",
         "ptBR": "Esfolador de Cadaveres",
         "ruRU": "Трупоед",
-        "zhCN": "剥尸者"
+        "zhCN": "噬尸者"
     },
     {
         "id": 50200,
@@ -29532,7 +29532,7 @@
         "id": 50201,
         "Key": "Scarab Cleaver",
         "enUS": "Scarab Cleaver",
-        "zhTW": "甲虫砍刀",
+        "zhTW": "刀疤刀",
         "deDE": "Skarabäusbeil",
         "esES": "Cuchilla escarabajo",
         "frFR": "Couteau Scarabée",
@@ -29543,13 +29543,13 @@
         "jaJP": "スカラベ・クリーバー",
         "ptBR": "Cutelo do Escaravelho",
         "ruRU": "Скарабей-кливер",
-        "zhCN": "甲虫砍刀"
+        "zhCN": "刀疤刀"
     },
     {
         "id": 50202,
         "Key": "Slithertongue",
         "enUS": "Slithertongue",
-        "zhTW": "辯才",
+        "zhTW": "Slithertongue",
         "deDE": "Schlangenzunge",
         "esES": "Lengua eslizón",
         "frFR": "Langue des lèvres",
@@ -29560,7 +29560,7 @@
         "jaJP": "スリザー・トング",
         "ptBR": "Lingua Escorregadia",
         "ruRU": "Slithertongue",
-        "zhCN": "辩才"
+        "zhCN": "Slithertongue"
     },
     {
         "id": 50203,
@@ -29583,7 +29583,7 @@
         "id": 50204,
         "Key": "Glitterkill",
         "enUS": "Glitterkill",
-        "zhTW": "魅力之殺",
+        "zhTW": "Glitterkill",
         "deDE": "Glitterkill",
         "esES": "Glitterkill",
         "frFR": "Glitterkill",
@@ -29594,13 +29594,13 @@
         "jaJP": "グリッターキル",
         "ptBR": "Brilho Assassino",
         "ruRU": "Глиттеркилл",
-        "zhCN": "魅力之杀"
+        "zhCN": "Glitterkill"
     },
     {
         "id": 50205,
         "Key": "Iniquity Razor",
         "enUS": "Iniquity Razor",
-        "zhTW": "不公剃刀",
+        "zhTW": "不公正剃刀",
         "deDE": "Ungerechtigkeit Rasiermesser",
         "esES": "Navaja de Iniquidad",
         "frFR": "Rasoir d'iniquité",
@@ -29611,13 +29611,13 @@
         "jaJP": "イクイティ・カミソリ",
         "ptBR": "Lâmina Da Iniquidade",
         "ruRU": "Бритва беззакония",
-        "zhCN": "不公剃刀"
+        "zhCN": "不公正剃刀"
     },
     {
         "id": 50206,
         "Key": "Talisman of Hades",
         "enUS": "Talisman of Hades",
-        "zhTW": "黑帝斯護身符",
+        "zhTW": "哈迪斯护身符",
         "deDE": "Talisman des Hades",
         "esES": "Talismán de Hades",
         "frFR": "Talisman d'Hadès",
@@ -29628,13 +29628,13 @@
         "jaJP": "黄泉の国の護符",
         "ptBR": "Talismã de Hades",
         "ruRU": "Талисман Аида",
-        "zhCN": "冥王护身符"
+        "zhCN": "哈迪斯护身符"
     },
     {
         "id": 50207,
         "Key": "Silent Shank",
         "enUS": "Silent Shank",
-        "zhTW": "無聲之柄",
+        "zhTW": "无声柄",
         "deDE": "Stummer Schaft",
         "esES": "Vástago silencioso",
         "frFR": "Tige silencieuse",
@@ -29645,13 +29645,13 @@
         "jaJP": "サイレント・シャンク",
         "ptBR": "Haste Silenciosa",
         "ruRU": "Бесшумный хвостовик",
-        "zhCN": "无声之柄"
+        "zhCN": "无声柄"
     },
     {
         "id": 50208,
         "Key": "Torturer's Trust",
         "enUS": "Torturer's Trust",
-        "zhTW": "折磨者的信任",
+        "zhTW": "酷刑折磨者信托基金",
         "deDE": "Torturer's Trust",
         "esES": "Torturer's Trust",
         "frFR": "Torturer's Trust",
@@ -29662,13 +29662,13 @@
         "jaJP": "拷問者の信託",
         "ptBR": "Confiança do Torturador",
         "ruRU": "Трест мучителей",
-        "zhCN": "折磨者的信任"
+        "zhCN": "酷刑折磨者信托基金"
     },
     {
         "id": 50209,
         "Key": "Peacemaker",
         "enUS": "ÿc4Peacemaker",
-        "zhTW": "ÿc4和平締造者",
+        "zhTW": "ÿc4和平缔造者",
         "deDE": "ÿc4Friedensstifter",
         "esES": "ÿc4Peacemaker",
         "frFR": "ÿc4Peacemaker",
@@ -29685,7 +29685,7 @@
         "id": 50210,
         "Key": "Simpering Sword",
         "enUS": "Simpering Sword",
-        "zhTW": "造作之剑",
+        "zhTW": "仿真剑",
         "deDE": "Simpelschwert",
         "esES": "Espada mimosa",
         "frFR": "L'épée simulatrice",
@@ -29696,13 +29696,13 @@
         "jaJP": "シンピング・ソード",
         "ptBR": "Espada Cintilante",
         "ruRU": "Меч, который не дает покоя",
-        "zhCN": "造作之剑"
+        "zhCN": "仿真剑"
     },
     {
         "id": 50211,
         "Key": "Legacy of the Eternals",
         "enUS": "Legacy of the Eternals",
-        "zhTW": "永恒之遗产",
+        "zhTW": "永恒的遗产",
         "deDE": "Das Vermächtnis der Ewigen",
         "esES": "El legado de los Eternos",
         "frFR": "L'héritage des éternels",
@@ -29713,13 +29713,13 @@
         "jaJP": "永遠の遺産",
         "ptBR": "Legado dos Eternos",
         "ruRU": "Наследие вечных",
-        "zhCN": "永恒之遗产"
+        "zhCN": "永恒的遗产"
     },
     {
         "id": 50212,
         "Key": "Sin Sister",
         "enUS": "Sin Sister",
-        "zhTW": "罪恶姐妹",
+        "zhTW": "没有姐妹",
         "deDE": "Keine Schwester",
         "esES": "Sin Sister",
         "frFR": "Pas de sœur",
@@ -29730,13 +29730,13 @@
         "jaJP": "シスターなし",
         "ptBR": "Pecado da Irmã",
         "ruRU": "Нет сестры",
-        "zhCN": "罪恶姐妹"
+        "zhCN": "没有姐妹"
     },
     {
         "id": 50213,
         "Key": "Autumn's Avatar",
         "enUS": "ÿc4Autumn's Avatar",
-        "zhTW": "ÿc4秋日头像",
+        "zhTW": "ÿc4Autumn 的头像",
         "deDE": "ÿc4Avatar von Autumn",
         "esES": "ÿc4Autumn's Avatar",
         "frFR": "ÿc4Autumn's Avatar",
@@ -29747,13 +29747,13 @@
         "jaJP": "ÿc4秋のアバター",
         "ptBR": "ÿc4Avatar de Outono",
         "ruRU": "ÿc4Autumn's Avatar",
-        "zhCN": "ÿc4秋日头像"
+        "zhCN": "ÿc4Autumn 的头像"
     },
     {
         "id": 50214,
         "Key": "Remembrance of Glory",
         "enUS": "ÿc4Remembrance of Glory",
-        "zhTW": "ÿc4榮耀之紀念",
+        "zhTW": "ÿc4光荣的纪念",
         "deDE": "ÿc4Erinnerung an den Ruhm",
         "esES": "ÿc4Recuerdo de Gloria",
         "frFR": "ÿc4Le souvenir de la gloire",
@@ -29764,13 +29764,13 @@
         "jaJP": "ÿc4栄光の追憶",
         "ptBR": "ÿc4Memória da Glóriosa",
         "ruRU": "ÿc4Память славы",
-        "zhCN": "ÿc4荣耀之纪念"
+        "zhCN": "ÿc4光荣的纪念"
     },
     {
         "id": 50215,
         "Key": "Argo's Anchor",
         "enUS": "ÿc4Argo's Anchor",
-        "zhTW": "ÿc4阿爾戈之錨",
+        "zhTW": "ÿc4Argo的主播",
         "deDE": "ÿc4Argo's Anker",
         "esES": "ÿc4Ancla de Argo",
         "frFR": "ÿc4Argo's Anchor",
@@ -29781,7 +29781,7 @@
         "jaJP": "ÿc4アルゴのアンカー",
         "ptBR": "ÿc4Ancora de Argo",
         "ruRU": "ÿc4Якорь Арго",
-        "zhCN": "ÿc4阿尔戈之锚"
+        "zhCN": "ÿc4Argo的主播"
     },
     {
         "id": 50216,
@@ -29802,9 +29802,9 @@
     },
     {
         "id": 50217,
-        "Key": "Life & Death",
+        "Key": "Life and Death",
         "enUS": "ÿc4Life & Death",
-        "zhTW": "ÿc4生命與死亡",
+        "zhTW": "ÿc4 生命与死亡",
         "deDE": "ÿc4Leben & Tod",
         "esES": "ÿc4Vida y muerte",
         "frFR": "ÿc4La vie et la mort",
@@ -29815,13 +29815,13 @@
         "jaJP": "ÿc4生と死",
         "ptBR": "ÿc4Salvador de Vidas",
         "ruRU": "ÿc4Жизнь и смерть",
-        "zhCN": "ÿc4生命与死亡"
+        "zhCN": "ÿc4 生命与死亡"
     },
     {
         "id": 50218,
         "Key": "Throne of Power",
         "enUS": "ÿc4Throne of Power",
-        "zhTW": "ÿc4權力王座",
+        "zhTW": "ÿc4权力宝座",
         "deDE": "ÿc4Thron der Macht",
         "esES": "ÿc4Trono de Poder",
         "frFR": "ÿc4Throne of Power",
@@ -29832,7 +29832,7 @@
         "jaJP": "ÿc4権力の座",
         "ptBR": "ÿc4Throne of Power",
         "ruRU": "ÿc4Трон власти",
-        "zhCN": "ÿc4权力王座"
+        "zhCN": "ÿc4权力宝座"
     },
     {
         "id": 50219,
@@ -29855,7 +29855,7 @@
         "id": 50220,
         "Key": "Queen's Call",
         "enUS": "ÿc4Queen's Call",
-        "zhTW": "ÿc4女王諭令",
+        "zhTW": "ÿc4女王的召唤",
         "deDE": "ÿc4Der Ruf der Königin",
         "esES": "ÿc4Queen's Call",
         "frFR": "ÿc4L'appel de la reine",
@@ -29866,13 +29866,13 @@
         "jaJP": "ÿc4クイーンズ・コール",
         "ptBR": "ÿc4Rainha Chamando",
         "ruRU": "ÿc4Призыв королевы",
-        "zhCN": "ÿc4女王谕令"
+        "zhCN": "ÿc4女王的召唤"
     },
     {
         "id": 50221,
         "Key": "Faerie Ring",
         "enUS": "Faerie Ring",
-        "zhTW": "精靈指環",
+        "zhTW": "精灵戒指",
         "deDE": "Faerie Ring",
         "esES": "Anillo de hada",
         "frFR": "Anneau de Faerie",
@@ -29883,13 +29883,13 @@
         "jaJP": "フェアリーリング",
         "ptBR": "Anel de Fada",
         "ruRU": "Кольцо феи",
-        "zhCN": "精灵之戒"
+        "zhCN": "精灵戒指"
     },
     {
         "id": 50222,
         "Key": "Jackal's Laughter",
         "enUS": "Jackal's Laughter",
-        "zhTW": "豺狼的笑聲",
+        "zhTW": "豺狼的笑声",
         "deDE": "Das Lachen des Schakals",
         "esES": "La risa del chacal",
         "frFR": "Le rire du chacal",
@@ -29906,7 +29906,7 @@
         "id": 50223,
         "Key": "Thief of Dreams",
         "enUS": "Thief of Dreams",
-        "zhTW": "盜夢者",
+        "zhTW": "盗梦者",
         "deDE": "Dieb der Träume",
         "esES": "Ladrón de sueños",
         "frFR": "Voleur de rêves",
@@ -29940,7 +29940,7 @@
         "id": 50225,
         "Key": "Knell of Discord",
         "enUS": "Knell of Discord",
-        "zhTW": "紛亂之喪鐘",
+        "zhTW": "不和谐的警钟",
         "deDE": "Die Glocke der Zwietracht",
         "esES": "El toque de la discordia",
         "frFR": "Le glas de la discorde",
@@ -29951,13 +29951,13 @@
         "jaJP": "不和の鐘",
         "ptBR": "Ajoelhar da Discordia",
         "ruRU": "Знак раздора",
-        "zhCN": "纷乱之丧钟"
+        "zhCN": "不和谐的警钟"
     },
     {
         "id": 50226,
         "Key": "Nameless Fear",
         "enUS": "Nameless Fear",
-        "zhTW": "無可名狀的驚懼",
+        "zhTW": "无名的恐惧",
         "deDE": "Namenlose Furcht",
         "esES": "Miedo sin nombre",
         "frFR": "Peur sans nom",
@@ -29968,13 +29968,13 @@
         "jaJP": "名もなき恐怖",
         "ptBR": "Medo Apavorante",
         "ruRU": "Безымянный страх",
-        "zhCN": "无可名状的惊惧"
+        "zhCN": "无名的恐惧"
     },
     {
         "id": 50227,
         "Key": "Jordan's Sigil",
         "enUS": "Jordan's Sigil",
-        "zhTW": "喬丹徽章",
+        "zhTW": "乔丹的徽章",
         "deDE": "Jordans Siegel",
         "esES": "Sello de Jordania",
         "frFR": "Le sigil de Jordan",
@@ -29985,13 +29985,13 @@
         "jaJP": "ジョーダンの紋章",
         "ptBR": "Sigilo de Jordan",
         "ruRU": "Знак Джордана",
-        "zhCN": "乔丹徽章"
+        "zhCN": "乔丹的徽章"
     },
     {
         "id": 50228,
         "Key": "Psyche Shroud",
         "enUS": "Psyche Shroud",
-        "zhTW": "精神帷幕",
+        "zhTW": "迷幻裹尸布",
         "deDE": "Psyche Leichentuch",
         "esES": "Sudario de Psique",
         "frFR": "Linceul de Psyché",
@@ -30002,13 +30002,13 @@
         "jaJP": "サイケ・シュラウド",
         "ptBR": "Mortalha Psique",
         "ruRU": "Саван Психеи",
-        "zhCN": "精神帷幕"
+        "zhCN": "迷幻裹尸布"
     },
     {
         "id": 50229,
         "Key": "Cryptking",
         "enUS": "Cryptking",
-        "zhTW": "地下之王",
+        "zhTW": "加密",
         "deDE": "Cryptking",
         "esES": "Criptomonedas",
         "frFR": "Cryptage",
@@ -30019,13 +30019,13 @@
         "jaJP": "クリプトキング",
         "ptBR": "Rei da Cripta",
         "ruRU": "Криптокинг",
-        "zhCN": "地下之王"
+        "zhCN": "加密"
     },
     {
         "id": 50230,
         "Key": "Rat Lord's Curse",
         "enUS": "Rat Lord's Curse",
-        "zhTW": "鼠王詛咒",
+        "zhTW": "鼠王的诅咒",
         "deDE": "Der Fluch des Rattenherrschers",
         "esES": "Maldición del Señor de las Ratas",
         "frFR": "La malédiction du seigneur des rats",
@@ -30036,7 +30036,7 @@
         "jaJP": "ネズミの呪い",
         "ptBR": "Portal do Rei Rato",
         "ruRU": "Проклятие крысиного лорда",
-        "zhCN": "鼠王诅咒"
+        "zhCN": "鼠王的诅咒"
     },
     {
         "id": 50231,
@@ -30059,7 +30059,7 @@
         "id": 50232,
         "Key": "Sigil of Hope",
         "enUS": "Sigil of Hope",
-        "zhTW": "希望之徽章",
+        "zhTW": "希望之符",
         "deDE": "Siegel der Hoffnung",
         "esES": "Sello de esperanza",
         "frFR": "Sigil de l'espoir",
@@ -30070,13 +30070,13 @@
         "jaJP": "希望の紋章",
         "ptBR": "Véu do Desespero",
         "ruRU": "Знак надежды",
-        "zhCN": "希望之徽章"
+        "zhCN": "希望之符"
     },
     {
         "id": 50233,
         "Key": "Steelflesh",
         "enUS": "Steelflesh",
-        "zhTW": "鋼鐵之軀",
+        "zhTW": "钢铁之躯",
         "deDE": "Steelflesh",
         "esES": "Carne de acero",
         "frFR": "Chair de poule",
@@ -30093,7 +30093,7 @@
         "id": 50234,
         "Key": "Ashenwrath",
         "enUS": "Ashenwrath",
-        "zhTW": "蒼白之忿",
+        "zhTW": "Ashenwrath",
         "deDE": "Aschenbranntwein",
         "esES": "Ashenwrath",
         "frFR": "Ashenwrath",
@@ -30104,13 +30104,13 @@
         "jaJP": "アシェンラス",
         "ptBR": "Fúria de Ashen",
         "ruRU": "Ashenwrath",
-        "zhCN": "苍白之忿"
+        "zhCN": "Ashenwrath"
     },
     {
         "id": 50235,
         "Key": "Gemini Coat",
         "enUS": "Gemini Coat",
-        "zhTW": "雙子座外袍",
+        "zhTW": "双子座大衣",
         "deDE": "Zwillinge Mantel",
         "esES": "Abrigo Géminis",
         "frFR": "Manteau Gemini",
@@ -30121,13 +30121,13 @@
         "jaJP": "ジェミニコート",
         "ptBR": "Casaco Gemeo",
         "ruRU": "Пальто Gemini",
-        "zhCN": "双子座外衣"
+        "zhCN": "双子座大衣"
     },
     {
         "id": 50236,
         "Key": "JuJu Flame",
         "enUS": "JuJu Flame",
-        "zhTW": "JuJu的火焰",
+        "zhTW": "JuJu Flame",
         "deDE": "JuJu Flamme",
         "esES": "JuJu Flame",
         "frFR": "JuJu Flame",
@@ -30138,13 +30138,13 @@
         "jaJP": "ジュジュの炎",
         "ptBR": "Chama de Juju",
         "ruRU": "JuJu Flame",
-        "zhCN": "JuJu的火焰"
+        "zhCN": "JuJu Flame"
     },
     {
         "id": 50237,
         "Key": "Mandrake's Bloom",
         "enUS": "Mandrake's Bloom",
-        "zhTW": "曼德拉克的綻放",
+        "zhTW": "曼德拉克的绽放",
         "deDE": "Die Blüte der Alraune",
         "esES": "Flor de Mandrágora",
         "frFR": "La floraison de la mandragore",
@@ -30161,7 +30161,7 @@
         "id": 50238,
         "Key": "Russetfire",
         "enUS": "Russetfire",
-        "zhTW": "赤褐之火",
+        "zhTW": "鲁塞特火",
         "deDE": "Russetfire",
         "esES": "Russetfire",
         "frFR": "Feu de roussette",
@@ -30172,13 +30172,13 @@
         "jaJP": "ラセットファイヤー",
         "ptBR": "Fogo Russet",
         "ruRU": "Russetfire",
-        "zhCN": "赤褐之火"
+        "zhCN": "鲁塞特火"
     },
     {
         "id": 50239,
         "Key": "Stinkshroud",
         "enUS": "Stinkshroud",
-        "zhTW": "惡臭裹尸布",
+        "zhTW": "臭气熏天",
         "deDE": "Stinkshroud",
         "esES": "Stinkshroud",
         "frFR": "La paille de fer",
@@ -30189,13 +30189,13 @@
         "jaJP": "臭気",
         "ptBR": "Mortalha Fedida",
         "ruRU": "Stinkshroud",
-        "zhCN": "恶臭裹尸布"
+        "zhCN": "臭气熏天"
     },
     {
         "id": 50240,
         "Key": "Xanadu Dreams",
         "enUS": "Xanadu Dreams",
-        "zhTW": "桃園之梦",
+        "zhTW": "仙度梦",
         "deDE": "Xanadu-Träume",
         "esES": "Sueños de Xanadú",
         "frFR": "Rêves de Xanadu",
@@ -30206,13 +30206,13 @@
         "jaJP": "ザナドゥ・ドリームス",
         "ptBR": "Sonhos de Xanadu",
         "ruRU": "Мечты Ксанаду",
-        "zhCN": "桃源之梦"
+        "zhCN": "仙度梦"
     },
     {
         "id": 50241,
         "Key": "Shattering Blow",
         "enUS": "Shattering Blow",
-        "zhTW": "粉碎打擊",
+        "zhTW": "粉碎打击",
         "deDE": "Zerschmetternder Hieb",
         "esES": "Golpe demoledor",
         "frFR": "Coup d'éclat",
@@ -30229,7 +30229,7 @@
         "id": 50242,
         "Key": "Madness of Chthulu",
         "enUS": "Madness of Chthulu",
-        "zhTW": "克蘇魯之瘋狂",
+        "zhTW": "疯狂的 Chthulu",
         "deDE": "Der Wahnsinn des Chthulu",
         "esES": "La locura de Chthulu",
         "frFR": "La folie de Chthulu",
@@ -30240,13 +30240,13 @@
         "jaJP": "チュトゥルの狂気",
         "ptBR": "Chthulu Louco",
         "ruRU": "Безумие Чтулу",
-        "zhCN": "克苏鲁的疯狂"
+        "zhCN": "疯狂的 Chthulu"
     },
     {
         "id": 50243,
         "Key": "Killing Blow",
         "enUS": "Killing Blow",
-        "zhTW": "致命一擊",
+        "zhTW": "致命一击",
         "deDE": "Tödlicher Hieb",
         "esES": "Golpe mortal",
         "frFR": "Coup mortel",
@@ -30263,7 +30263,7 @@
         "id": 50244,
         "Key": "Obsidian Husk",
         "enUS": "Obsidian Husk",
-        "zhTW": "黑曜石殼甲",
+        "zhTW": "黑曜石壳",
         "deDE": "Obsidian Schale",
         "esES": "Cáscara de obsidiana",
         "frFR": "Écorce d'obsidienne",
@@ -30274,13 +30274,13 @@
         "jaJP": "オブシディアン・ハスク",
         "ptBR": "Casca de Obsidiana",
         "ruRU": "Обсидиановая шелуха",
-        "zhCN": "黑曜石壳甲"
+        "zhCN": "黑曜石壳"
     },
     {
         "id": 50245,
         "Key": "Golem's Gain",
         "enUS": "Golem's Gain",
-        "zhTW": "魔像的收益",
+        "zhTW": "巨魔的收益",
         "deDE": "Golems Zugewinn",
         "esES": "Ganancia de Golem",
         "frFR": "Gain du golem",
@@ -30291,13 +30291,13 @@
         "jaJP": "ゴーレムのゲイン",
         "ptBR": "Ganho do Golem",
         "ruRU": "Усиление голема",
-        "zhCN": "魔像的收益"
+        "zhCN": "巨魔的收益"
     },
     {
         "id": 50246,
         "Key": "Halcyon Shroud",
         "enUS": "Halcyon Shroud",
-        "zhTW": "平安帷幕",
+        "zhTW": "哈尔西恩护罩",
         "deDE": "Halcyon Leichentuch",
         "esES": "Mortaja Halcyon",
         "frFR": "Linceul d'Halcyon",
@@ -30308,13 +30308,13 @@
         "jaJP": "ハルシオン・シュラウド",
         "ptBR": "Halcyon Matador",
         "ruRU": "Саван Хальциона",
-        "zhCN": "平安帷幕"
+        "zhCN": "哈尔西恩护罩"
     },
     {
         "id": 50247,
         "Key": "Tiger Eye",
         "enUS": "ÿc4Tiger Eye",
-        "zhTW": "ÿc4虎視",
+        "zhTW": "ÿc4虎视眈眈",
         "deDE": "ÿc4Tigerauge",
         "esES": "ÿc4Ojo de tigre",
         "frFR": "ÿc4Tiger Eye",
@@ -30325,13 +30325,13 @@
         "jaJP": "ÿc4タイガーアイ",
         "ptBR": "ÿc4Olho do Tigre",
         "ruRU": "ÿc4Тигровый глаз",
-        "zhCN": "ÿc4虎视"
+        "zhCN": "ÿc4虎视眈眈"
     },
     {
         "id": 50248,
         "Key": "Jade Facet",
         "enUS": "ÿc4Jade Facet",
-        "zhTW": "ÿc4翠玉刻面",
+        "zhTW": "ÿc4玉面",
         "deDE": "ÿc4Jade-Fassade",
         "esES": "ÿc4Fachada de jade",
         "frFR": "ÿc4Jade Facet",
@@ -30342,13 +30342,13 @@
         "jaJP": "ÿc4翡翠ファセット",
         "ptBR": "ÿc4Face Jade",
         "ruRU": "ÿc4 Нефритовый фасад",
-        "zhCN": "ÿc4翠玉刻面"
+        "zhCN": "ÿc4玉面"
     },
     {
         "id": 50249,
         "Key": "Diamond Facet",
         "enUS": "ÿc4Diamond Facet",
-        "zhTW": "ÿc4鑽石刻面",
+        "zhTW": "ÿc4钻石刻面",
         "deDE": "ÿc4Diamantenfacette",
         "esES": "ÿc4Faceta del diamante",
         "frFR": "ÿc4Diamant à facettes",
@@ -30365,7 +30365,7 @@
         "id": 50250,
         "Key": "Sapphire Facet",
         "enUS": "ÿc4Sapphire Facet",
-        "zhTW": "ÿc4寶藍刻面",
+        "zhTW": "ÿc4蓝宝石刻面",
         "deDE": "ÿc4Sapphire Facette",
         "esES": "ÿc4Faceta de zafiro",
         "frFR": "ÿc4Facette saphir",
@@ -30376,13 +30376,13 @@
         "jaJP": "ÿc4サファイアファセット",
         "ptBR": "ÿc4Face Safira",
         "ruRU": "ÿc4Сапфировая грань",
-        "zhCN": "ÿc4宝蓝刻面"
+        "zhCN": "ÿc4蓝宝石刻面"
     },
     {
         "id": 50251,
         "Key": "Emerald Facet",
         "enUS": "ÿc4Emerald Facet",
-        "zhTW": "ÿc4翡玉刻面",
+        "zhTW": "ÿc4翡翠面",
         "deDE": "ÿc4Smaragdfacette",
         "esES": "ÿc4Faceta Esmeralda",
         "frFR": "ÿc4Facette d'émeraude",
@@ -30393,13 +30393,13 @@
         "jaJP": "ÿc4エメラルドファセット",
         "ptBR": "ÿc4Face Esmeralda",
         "ruRU": "ÿc4Emerald Facet",
-        "zhCN": "ÿc4翡玉刻面"
+        "zhCN": "ÿc4翡翠面"
     },
     {
         "id": 50252,
         "Key": "Topaz Facet",
         "enUS": "ÿc4Topaz Facet",
-        "zhTW": "ÿc4黃玉刻面",
+        "zhTW": "ÿc4托帕石刻面",
         "deDE": "ÿc4Topas-Facette",
         "esES": "ÿc4Faceta Topacio",
         "frFR": "ÿc4Topaz Facet",
@@ -30410,13 +30410,13 @@
         "jaJP": "ÿc4トパーズファセット",
         "ptBR": "ÿc4Face Topaz",
         "ruRU": "ÿc4Топаз граненый",
-        "zhCN": "ÿc4黄玉刻面"
+        "zhCN": "ÿc4托帕石刻面"
     },
     {
         "id": 50253,
         "Key": "Star Facet",
         "enUS": "ÿc4Star Facet",
-        "zhTW": "ÿc4星辰刻面",
+        "zhTW": "ÿc4Star Facet",
         "deDE": "ÿc4Star Facet",
         "esES": "ÿc4Star Facet",
         "frFR": "ÿc4Star Facet",
@@ -30427,13 +30427,13 @@
         "jaJP": "ÿc4スターファセット",
         "ptBR": "ÿc4Face Estelar",
         "ruRU": "ÿc4Star Facet",
-        "zhCN": "ÿc4星辰刻面"
+        "zhCN": "ÿc4Star Facet"
     },
     {
         "id": 50254,
         "Key": "Heaven Facet",
         "enUS": "ÿc4Heaven Facet",
-        "zhTW": "ÿc4天堂刻面",
+        "zhTW": "ÿc4天堂面",
         "deDE": "ÿc4Heaven Facet",
         "esES": "ÿc4Heaven Facet",
         "frFR": "ÿc4Heaven Facet",
@@ -30444,13 +30444,13 @@
         "jaJP": "ÿc4ヘブンファセット",
         "ptBR": "ÿc4Face Celestial",
         "ruRU": "ÿc4Небесная грань",
-        "zhCN": "ÿc4天堂刻面"
+        "zhCN": "ÿc4天堂面"
     },
     {
         "id": 50255,
         "Key": "Deviljack",
         "enUS": "Deviljack",
-        "zhTW": "魔鬼傑克",
+        "zhTW": "魔鬼杰克",
         "deDE": "Deviljack",
         "esES": "Deviljack",
         "frFR": "Deviljack",
@@ -30467,7 +30467,7 @@
         "id": 50256,
         "Key": "Briarblade",
         "enUS": "Briarblade",
-        "zhTW": "歐石楠之刃",
+        "zhTW": "石楠刀",
         "deDE": "Briarblade",
         "esES": "Briarblade",
         "frFR": "Briarblade",
@@ -30478,13 +30478,13 @@
         "jaJP": "ブライヤーブレード",
         "ptBR": "Lamina Briar",
         "ruRU": "Бриарблейд",
-        "zhCN": "欧石楠之刃"
+        "zhCN": "石楠刀"
     },
     {
         "id": 50257,
         "Key": "Chromablade",
         "enUS": "Chromablade",
-        "zhTW": "炫彩之刃",
+        "zhTW": "Chromablade",
         "deDE": "Chromablade",
         "esES": "Chromablade",
         "frFR": "Chromablade",
@@ -30495,13 +30495,13 @@
         "jaJP": "クロマブレード",
         "ptBR": "Lamina Cromada",
         "ruRU": "Хромаблейд",
-        "zhCN": "炫彩之刃"
+        "zhCN": "Chromablade"
     },
     {
         "id": 50258,
         "Key": "Fiendslayer",
         "enUS": "Fiendslayer",
-        "zhTW": "屠魔者",
+        "zhTW": "Fiendslayer",
         "deDE": "Teufelsschicht",
         "esES": "Fiendslayer",
         "frFR": "Joueur de flammes",
@@ -30512,13 +30512,13 @@
         "jaJP": "魔物使い",
         "ptBR": "Matador de Demonios",
         "ruRU": "Fiendslayer",
-        "zhCN": "屠魔者"
+        "zhCN": "Fiendslayer"
     },
     {
         "id": 50259,
         "Key": "Irksome Edge",
         "enUS": "Irksome Edge",
-        "zhTW": "煩惱边缘",
+        "zhTW": "恼人的边缘",
         "deDE": "Ärgerliche Kante",
         "esES": "Borde irritable",
         "frFR": "Bordure gênante",
@@ -30529,13 +30529,13 @@
         "jaJP": "イラサム・エッジ",
         "ptBR": "Borda Enfadonha",
         "ruRU": "Неприятный край",
-        "zhCN": "烦恼边缘"
+        "zhCN": "恼人的边缘"
     },
     {
         "id": 50260,
         "Key": "Winterswipe",
         "enUS": "Winterswipe",
-        "zhTW": "凜冬揮擊",
+        "zhTW": "冬季擦拭",
         "deDE": "Winterswipe",
         "esES": "Winterswipe",
         "frFR": "Swipe d'hiver",
@@ -30546,13 +30546,13 @@
         "jaJP": "ウィンタースワイプ",
         "ptBR": "Inverno Roubado",
         "ruRU": "Winterswipe",
-        "zhCN": "凛冬挥击"
+        "zhCN": "冬季擦拭"
     },
     {
         "id": 50261,
         "Key": "Warrior Untamed",
         "enUS": "Warrior Untamed",
-        "zhTW": "桀驁的勇士",
+        "zhTW": "桀骜不驯的勇士",
         "deDE": "Ungezähmter Krieger",
         "esES": "Guerrero indomable",
         "frFR": "Guerrier indompté",
@@ -30563,7 +30563,7 @@
         "jaJP": "ウォリアー・アンテイムド",
         "ptBR": "Guerreiro Incontrolavel",
         "ruRU": "Воин, не знающий покоя",
-        "zhCN": "桀骜的勇士"
+        "zhCN": "桀骜不驯的勇士"
     },
     {
         "id": 50262,
@@ -30586,7 +30586,7 @@
         "id": 50263,
         "Key": "Deathflake",
         "enUS": "Deathflake",
-        "zhTW": "死亡剝片",
+        "zhTW": "死亡之花",
         "deDE": "Todesflocke",
         "esES": "Copo de la muerte",
         "frFR": "Flocon de la mort",
@@ -30597,13 +30597,13 @@
         "jaJP": "デスフレーク",
         "ptBR": "Floco da Morte",
         "ruRU": "Хлопья смерти",
-        "zhCN": "死亡剥片"
+        "zhCN": "死亡之花"
     },
     {
         "id": 50264,
         "Key": "Goreflood",
         "enUS": "Goreflood",
-        "zhTW": "血腥洪災",
+        "zhTW": "戈尔洪",
         "deDE": "Goreflood",
         "esES": "Goreflood",
         "frFR": "Goreflood",
@@ -30614,13 +30614,13 @@
         "jaJP": "ゴアフラッド",
         "ptBR": "Avalanche de Sangue",
         "ruRU": "Goreflood",
-        "zhCN": "血腥洪灾"
+        "zhCN": "戈尔洪"
     },
     {
         "id": 50265,
         "Key": "Lungreaver",
         "enUS": "Lungreaver",
-        "zhTW": "破肺斧",
+        "zhTW": "Lungreaver",
         "deDE": "Lungenzerstörer",
         "esES": "Lungreaver",
         "frFR": "Le creuseur de poumon",
@@ -30631,7 +30631,7 @@
         "jaJP": "ラングリーバー",
         "ptBR": "Reaver Pulmão",
         "ruRU": "Lungreaver",
-        "zhCN": "破肺斧"
+        "zhCN": "Lungreaver"
     },
     {
         "id": 50266,
@@ -30654,7 +30654,7 @@
         "id": 50267,
         "Key": "Gracehunter",
         "enUS": "Gracehunter",
-        "zhTW": "優雅猎手",
+        "zhTW": "恩典猎手",
         "deDE": "Gracehunter",
         "esES": "Gracehunter",
         "frFR": "Chasseur de primes",
@@ -30665,13 +30665,13 @@
         "jaJP": "グレースハンター",
         "ptBR": "Caçador Engraçado",
         "ruRU": "Gracehunter",
-        "zhCN": "优雅猎手"
+        "zhCN": "恩典猎手"
     },
     {
         "id": 50268,
         "Key": "Mirth Bringer",
         "enUS": "Mirth Bringer",
-        "zhTW": "歡樂使者",
+        "zhTW": "欢乐使者",
         "deDE": "Fröhlichkeitsbringer",
         "esES": "Portador de la alegría",
         "frFR": "Porteur de joie",
@@ -30688,7 +30688,7 @@
         "id": 50269,
         "Key": "Sandking",
         "enUS": "Sandking",
-        "zhTW": "沙之王",
+        "zhTW": "打磨",
         "deDE": "Schleifen",
         "esES": "Lijado",
         "frFR": "Sablage",
@@ -30699,13 +30699,13 @@
         "jaJP": "サンディング",
         "ptBR": "Areia Rei",
         "ruRU": "Шлифовка",
-        "zhCN": "沙之王"
+        "zhCN": "打磨"
     },
     {
         "id": 50270,
         "Key": "Nova Spine",
         "enUS": "Nova Spine",
-        "zhTW": "新星之脊",
+        "zhTW": "Nova Spine",
         "deDE": "Nova Wirbelsäule",
         "esES": "Nova Spine",
         "frFR": "Nova Spine",
@@ -30716,13 +30716,13 @@
         "jaJP": "ノヴァ・スパイン",
         "ptBR": "Espinha Nova",
         "ruRU": "Nova Spine",
-        "zhCN": "新星之脊"
+        "zhCN": "Nova Spine"
     },
     {
         "id": 50271,
         "Key": "Arctic Edge",
         "enUS": "Arctic Edge",
-        "zhTW": "北極邊緣",
+        "zhTW": "北极边缘",
         "deDE": "Arktische Kante",
         "esES": "Borde Ártico",
         "frFR": "Bordure arctique",
@@ -30739,7 +30739,7 @@
         "id": 50272,
         "Key": "Curseweaver",
         "enUS": "Curseweaver",
-        "zhTW": "織咒者",
+        "zhTW": "诅咒者",
         "deDE": "Fluchweber",
         "esES": "Curseweaver",
         "frFR": "Tisseur de malédiction",
@@ -30750,7 +30750,7 @@
         "jaJP": "カースウィーバー",
         "ptBR": "Tecelão Amaldiçoado",
         "ruRU": "Curseweaver",
-        "zhCN": "织咒者"
+        "zhCN": "诅咒者"
     },
     {
         "id": 50273,
@@ -30773,7 +30773,7 @@
         "id": 50274,
         "Key": "Coaldark",
         "enUS": "Coaldark",
-        "zhTW": "煤黑",
+        "zhTW": "科尔达克",
         "deDE": "Coaldark",
         "esES": "Coaldark",
         "frFR": "Coaldark",
@@ -30784,13 +30784,13 @@
         "jaJP": "コールダーク",
         "ptBR": "Carvão Escuro",
         "ruRU": "Коалдарк",
-        "zhCN": "煤黑"
+        "zhCN": "科尔达克"
     },
     {
         "id": 50275,
         "Key": "Hell's Messenger",
         "enUS": "Hell's Messenger",
-        "zhTW": "地獄信使",
+        "zhTW": "地狱使者",
         "deDE": "Der Bote der Hölle",
         "esES": "Mensajero del Infierno",
         "frFR": "Le messager de l'enfer",
@@ -30801,13 +30801,13 @@
         "jaJP": "地獄の使者",
         "ptBR": "Mensageiro do Inferno ",
         "ruRU": "Посланник ада",
-        "zhCN": "地狱信使"
+        "zhCN": "地狱使者"
     },
     {
         "id": 50276,
         "Key": "Elder Curse",
         "enUS": "Elder Curse",
-        "zhTW": "長老詛咒",
+        "zhTW": "长老诅咒",
         "deDE": "Holunderfluch",
         "esES": "Maldición de los ancianos",
         "frFR": "Malédiction des aînés",
@@ -30824,7 +30824,7 @@
         "id": 50277,
         "Key": "Warrior's Challenge",
         "enUS": "Warrior's Challenge",
-        "zhTW": "勇士的挑戰",
+        "zhTW": "勇士的挑战",
         "deDE": "Die Herausforderung des Kriegers",
         "esES": "Desafío del Guerrero",
         "frFR": "Le défi du guerrier",
@@ -30841,7 +30841,7 @@
         "id": 50278,
         "Key": "Oakheart",
         "enUS": "Oakheart",
-        "zhTW": "橡樹心室",
+        "zhTW": "橡树之心",
         "deDE": "Eichenherz",
         "esES": "Corazón de roble",
         "frFR": "Cœur de chêne",
@@ -30852,13 +30852,13 @@
         "jaJP": "オークハート",
         "ptBR": "Coração Carvalho",
         "ruRU": "Дубовое сердце",
-        "zhCN": "橡树心室"
+        "zhCN": "橡树之心"
     },
     {
         "id": 50279,
         "Key": "Quickfeint",
         "enUS": "Quickfeint",
-        "zhTW": "快速虛影",
+        "zhTW": "Quickfeint",
         "deDE": "Quickfeint",
         "esES": "Quickfeint",
         "frFR": "Quickfeint",
@@ -30869,13 +30869,13 @@
         "jaJP": "クイックフェイント",
         "ptBR": "Simulação Rapida",
         "ruRU": "Quickfeint",
-        "zhCN": "快速虚影"
+        "zhCN": "Quickfeint"
     },
     {
         "id": 50280,
         "Key": "Stunhummer",
         "enUS": "Stunhummer",
-        "zhTW": "震地蜂鳴",
+        "zhTW": "惊蛰龙虾",
         "deDE": "Betäubungshummer",
         "esES": "Langosta aturdidora",
         "frFR": "Homard étourdissant",
@@ -30886,13 +30886,13 @@
         "jaJP": "スタン・ロブスター",
         "ptBR": "Marte Atordoante",
         "ruRU": "Ошеломительный омар",
-        "zhCN": "震地蜂鸣"
+        "zhCN": "惊蛰龙虾"
     },
     {
         "id": 50281,
         "Key": "Spirit Crusher",
         "enUS": "Spirit Crusher",
-        "zhTW": "碎魂者",
+        "zhTW": "精神粉碎机",
         "deDE": "Geist Brecher",
         "esES": "Trituradora de espíritus",
         "frFR": "L'écraseur d'esprit",
@@ -30903,13 +30903,13 @@
         "jaJP": "スピリット・クラッシャー",
         "ptBR": "Espírito Triturado",
         "ruRU": "Крушитель духов",
-        "zhCN": "碎魂者"
+        "zhCN": "精神粉碎机"
     },
     {
         "id": 50282,
         "Key": "Vilifier",
         "enUS": "Vilifier",
-        "zhTW": "詆毀者",
+        "zhTW": "诋毁",
         "deDE": "Vilifizieren",
         "esES": "Vilify",
         "frFR": "Vilifier",
@@ -30920,13 +30920,13 @@
         "jaJP": "罵倒する",
         "ptBR": "Difamar",
         "ruRU": "Очернить",
-        "zhCN": "诋毁者"
+        "zhCN": "诋毁"
     },
     {
         "id": 50283,
         "Key": "Lesson in Pain",
         "enUS": "Lesson in Pain",
-        "zhTW": "痛苦的教訓",
+        "zhTW": "痛苦的教训",
         "deDE": "Lektion in Schmerz",
         "esES": "Lección de dolor",
         "frFR": "Leçon de douleur",
@@ -30943,7 +30943,7 @@
         "id": 50284,
         "Key": "Endless Sleep",
         "enUS": "Endless Sleep",
-        "zhTW": "無盡之眠",
+        "zhTW": "无尽的睡眠",
         "deDE": "Unendlicher Schlaf",
         "esES": "Sueño sin fin",
         "frFR": "Sommeil sans fin",
@@ -30954,13 +30954,13 @@
         "jaJP": "エンドレス・スリープ",
         "ptBR": "Sono Sem Fim",
         "ruRU": "Бесконечный сон",
-        "zhCN": "无尽之眠"
+        "zhCN": "无尽的睡眠"
     },
     {
         "id": 50285,
         "Key": "The Quickening",
         "enUS": "The Quickening",
-        "zhTW": "加速",
+        "zhTW": "唤醒",
         "deDE": "Die Wiederbelebung",
         "esES": "El Pronto",
         "frFR": "L'accélération",
@@ -30971,13 +30971,13 @@
         "jaJP": "クイックニング",
         "ptBR": "Aceleração",
         "ruRU": "Ускорение",
-        "zhCN": "加速"
+        "zhCN": "唤醒"
     },
     {
         "id": 50286,
         "Key": "Ambercall",
         "enUS": "Ambercall",
-        "zhTW": "安珀之呼",
+        "zhTW": "Ambercall",
         "deDE": "Ambercall",
         "esES": "Ambercall",
         "frFR": "Appel d'ambre",
@@ -30988,7 +30988,7 @@
         "jaJP": "アンバーコール",
         "ptBR": "Chamada Âmbar",
         "ruRU": "Ambercall",
-        "zhCN": "安珀之呼"
+        "zhCN": "Ambercall"
     },
     {
         "id": 50287,
@@ -31011,7 +31011,7 @@
         "id": 50288,
         "Key": "Dawnskein",
         "enUS": "Dawnskein",
-        "zhTW": "一綫黎明",
+        "zhTW": "道斯金",
         "deDE": "Dawnskein",
         "esES": "Dawnskein",
         "frFR": "Dawnskein",
@@ -31022,13 +31022,13 @@
         "jaJP": "ドーンスケイン",
         "ptBR": "Seu Magruga",
         "ruRU": "Dawnskein",
-        "zhCN": "一线黎明"
+        "zhCN": "道斯金"
     },
     {
         "id": 50289,
         "Key": "Darkflayer",
         "enUS": "Darkflayer",
-        "zhTW": "黑暗剝皮者",
+        "zhTW": "暗黑破坏者",
         "deDE": "Darkflayer",
         "esES": "Capa Oscura",
         "frFR": "Ténébreuse",
@@ -31039,7 +31039,7 @@
         "jaJP": "ダークレイヤー",
         "ptBR": "Esfolar No Escuro",
         "ruRU": "Darkflayer",
-        "zhCN": "黑暗剥皮者"
+        "zhCN": "暗黑破坏者"
     },
     {
         "id": 50290,
@@ -31062,7 +31062,7 @@
         "id": 50291,
         "Key": "Zenkiller",
         "enUS": "Zenkiller",
-        "zhTW": "灭禪者",
+        "zhTW": "Zenkiller",
         "deDE": "Zenkiller",
         "esES": "Zenkiller",
         "frFR": "Zenkiller",
@@ -31073,7 +31073,7 @@
         "jaJP": "ゼンキラー",
         "ptBR": "Assassino Zen",
         "ruRU": "Зенкиллер",
-        "zhCN": "灭禅者"
+        "zhCN": "Zenkiller"
     },
     {
         "id": 50292,
@@ -31096,7 +31096,7 @@
         "id": 50293,
         "Key": "Zealot's Branch",
         "enUS": "Zealot's Branch",
-        "zhTW": "狂熱者之枝",
+        "zhTW": "狂热者分部",
         "deDE": "Zweig des Zeloten",
         "esES": "Rama del Zelote",
         "frFR": "Branche du zélote",
@@ -31107,13 +31107,13 @@
         "jaJP": "狂信者の枝",
         "ptBR": "Ramo de Zelote",
         "ruRU": "Ветвь зилота",
-        "zhCN": "狂热者之枝"
+        "zhCN": "狂热者分部"
     },
     {
         "id": 50294,
         "Key": "Deceiver's Device",
         "enUS": "Deceiver's Device",
-        "zhTW": "欺騙者的装置",
+        "zhTW": "骗子装置",
         "deDE": "Gerät des Betrügers",
         "esES": "Dispositivo del Engañador",
         "frFR": "Dispositif de tromperie",
@@ -31124,13 +31124,13 @@
         "jaJP": "詐欺師の装置",
         "ptBR": "Dispositivo Enganador",
         "ruRU": "Устройство обманщика",
-        "zhCN": "欺骗者的装置"
+        "zhCN": "骗子装置"
     },
     {
         "id": 50295,
         "Key": "Fangtree",
         "enUS": "Fangtree",
-        "zhTW": "尖牙之樹",
+        "zhTW": "方树",
         "deDE": "Fangtree",
         "esES": "Fangtree",
         "frFR": "Fangtree",
@@ -31141,13 +31141,13 @@
         "jaJP": "ファングツリー",
         "ptBR": "Arvore Presa",
         "ruRU": "Fangtree",
-        "zhCN": "尖牙之树"
+        "zhCN": "方树"
     },
     {
         "id": 50296,
         "Key": "Woodclaw",
         "enUS": "Woodclaw",
-        "zhTW": "木之爪",
+        "zhTW": "木爪",
         "deDE": "Holzklaue",
         "esES": "Woodclaw",
         "frFR": "Scie à bois",
@@ -31158,13 +31158,13 @@
         "jaJP": "ウッドクロー",
         "ptBR": "Garra de Madeira",
         "ruRU": "Woodclaw",
-        "zhCN": "木之爪"
+        "zhCN": "木爪"
     },
     {
         "id": 50297,
         "Key": "Ruemonger",
         "enUS": "Ruemonger",
-        "zhTW": "懊悔販賣者",
+        "zhTW": "Ruemonger",
         "deDE": "Ruemonger",
         "esES": "Ruemonger",
         "frFR": "Ruemonger",
@@ -31175,13 +31175,13 @@
         "jaJP": "ルーマンガー",
         "ptBR": "Traficante Rue",
         "ruRU": "Ruemonger",
-        "zhCN": "懊悔贩卖者"
+        "zhCN": "Ruemonger"
     },
     {
         "id": 50298,
         "Key": "Slayer's Debt",
         "enUS": "Slayer's Debt",
-        "zhTW": "屠夫的債務",
+        "zhTW": "杀手的债务",
         "deDE": "Die Schuld der Jägerin",
         "esES": "Deuda del cazador",
         "frFR": "Dette de la Tueuse",
@@ -31192,13 +31192,13 @@
         "jaJP": "スレイヤーの借金",
         "ptBR": "Homicida Individado",
         "ruRU": "Долг истребителя",
-        "zhCN": "屠夫的债务"
+        "zhCN": "杀手的债务"
     },
     {
         "id": 50299,
         "Key": "Landsplitter",
         "enUS": "Landsplitter",
-        "zhTW": "土地分離者",
+        "zhTW": "土地分割器",
         "deDE": "Landverteiler",
         "esES": "Divisor de tierras",
         "frFR": "Séparateur de terres",
@@ -31209,13 +31209,13 @@
         "jaJP": "ランドスプリッター",
         "ptBR": "Terra Dividida",
         "ruRU": "Разделитель земли",
-        "zhCN": "土地分离者"
+        "zhCN": "土地分割器"
     },
     {
         "id": 50300,
         "Key": "Knave's Ascendence",
         "enUS": "Knave's Ascendence",
-        "zhTW": "克納維的崛起",
+        "zhTW": "克纳维的崛起",
         "deDE": "Der Aufstieg des Knappen",
         "esES": "Ascenso de Knave",
         "frFR": "L'ascension du chevalier",
@@ -31232,7 +31232,7 @@
         "id": 50301,
         "Key": "Oreseeker",
         "enUS": "Oreseeker",
-        "zhTW": "探礦者",
+        "zhTW": "Oreseeker",
         "deDE": "Oreseeker",
         "esES": "Oreseeker",
         "frFR": "Chercheur d'or",
@@ -31243,13 +31243,13 @@
         "jaJP": "オレシーカー",
         "ptBR": "Minerador",
         "ruRU": "Oreseeker",
-        "zhCN": "探矿者"
+        "zhCN": "Oreseeker"
     },
     {
         "id": 50302,
         "Key": "Rebuker",
         "enUS": "Rebuker",
-        "zhTW": "責難者",
+        "zhTW": "雷布克",
         "deDE": "Rebuker",
         "esES": "Rebuker",
         "frFR": "Rebuker",
@@ -31260,13 +31260,13 @@
         "jaJP": "リビューカー",
         "ptBR": "Repreensão",
         "ruRU": "Ребукер",
-        "zhCN": "责难者"
+        "zhCN": "雷布克"
     },
     {
         "id": 50303,
         "Key": "Ripskin",
         "enUS": "Ripskin",
-        "zhTW": "裂肤",
+        "zhTW": "Ripskin",
         "deDE": "Ripskin",
         "esES": "Ripskin",
         "frFR": "Peau de bête",
@@ -31277,13 +31277,13 @@
         "jaJP": "リップスキン",
         "ptBR": "Pele Rasgada",
         "ruRU": "Ripskin",
-        "zhCN": "裂肤"
+        "zhCN": "Ripskin"
     },
     {
         "id": 50304,
         "Key": "Puzzler's Mystery",
         "enUS": "Puzzler's Mystery",
-        "zhTW": "謎之秘寶",
+        "zhTW": "谜人之谜",
         "deDE": "Rätselhaftes Mysterium",
         "esES": "El misterio de Puzzler",
         "frFR": "Mystère de l'énigme",
@@ -31294,13 +31294,13 @@
         "jaJP": "パズラーの謎",
         "ptBR": "Quebra-Cabeças Misterioso",
         "ruRU": "Загадка головоломки",
-        "zhCN": "谜之秘宝"
+        "zhCN": "谜人之谜"
     },
     {
         "id": 50305,
         "Key": "Riddlesolver",
         "enUS": "Riddlesolver",
-        "zhTW": "解謎者",
+        "zhTW": "Riddlesolver",
         "deDE": "Riddlesolver",
         "esES": "Riddlesolver",
         "frFR": "Énigmeur",
@@ -31311,13 +31311,13 @@
         "jaJP": "リドルソルバー",
         "ptBR": "Solucionador de Enigmas",
         "ruRU": "Riddlesolver",
-        "zhCN": "解谜者"
+        "zhCN": "Riddlesolver"
     },
     {
         "id": 50306,
         "Key": "Puppeteer's Staff",
         "enUS": "Puppeteer's Staff",
-        "zhTW": "操偶之杖",
+        "zhTW": "木偶杖",
         "deDE": "Stab des Puppenspielers",
         "esES": "Bastón de titiritero",
         "frFR": "Personnel du marionnettiste",
@@ -31328,13 +31328,13 @@
         "jaJP": "人形遣いの杖",
         "ptBR": "Cajado da Marionete",
         "ruRU": "Посох кукловода",
-        "zhCN": "操偶之杖"
+        "zhCN": "木偶杖"
     },
     {
         "id": 50307,
         "Key": "Sage's Retort",
         "enUS": "Sage's Retort",
-        "zhTW": "聖者之反駁",
+        "zhTW": "圣人的反驳",
         "deDE": "Die Erwiderung des Weisen",
         "esES": "La réplica de Sage",
         "frFR": "La réplique de Sage",
@@ -31345,13 +31345,13 @@
         "jaJP": "セイジの反論",
         "ptBR": "Sábio Réplica",
         "ruRU": "Реплика мудреца",
-        "zhCN": "圣者之反驳"
+        "zhCN": "圣人的反驳"
     },
     {
         "id": 50308,
         "Key": "Strange Alchemy",
         "enUS": "Strange Alchemy",
-        "zhTW": "奇異煉金術",
+        "zhTW": "奇怪的炼金术",
         "deDE": "Seltsame Alchemie",
         "esES": "Extraña alquimia",
         "frFR": "L'étrange alchimie",
@@ -31362,13 +31362,13 @@
         "jaJP": "奇妙な錬金術",
         "ptBR": "Alquimia Estranha",
         "ruRU": "Странная алхимия",
-        "zhCN": "奇异炼金术"
+        "zhCN": "奇怪的炼金术"
     },
     {
         "id": 50309,
         "Key": "Bitter Sorrow",
         "enUS": "Bitter Sorrow",
-        "zhTW": "苦悲",
+        "zhTW": "苦涩的悲伤",
         "deDE": "Bitter Sorrow",
         "esES": "Amargo dolor",
         "frFR": "Sortie amère",
@@ -31379,13 +31379,13 @@
         "jaJP": "苦い悲しみ",
         "ptBR": "Tristeza Amargurada",
         "ruRU": "Горькая печаль",
-        "zhCN": "苦悲"
+        "zhCN": "苦涩的悲伤"
     },
     {
         "id": 50310,
         "Key": "Ire of Astaroth",
         "enUS": "Ire of Astaroth",
-        "zhTW": "阿斯塔羅斯之怒",
+        "zhTW": "阿斯塔罗斯之怒",
         "deDE": "Astaroths Ire",
         "esES": "Ire de Astaroth",
         "frFR": "Ire d'Astaroth",
@@ -31402,7 +31402,7 @@
         "id": 50311,
         "Key": "Child's Laughter",
         "enUS": "Child's Laughter",
-        "zhTW": "孩童的笑聲",
+        "zhTW": "儿童的笑声",
         "deDE": "Kinderlachen",
         "esES": "La risa del niño",
         "frFR": "Rire d'enfant",
@@ -31413,7 +31413,7 @@
         "jaJP": "子供の笑い声",
         "ptBR": "Risada infantil",
         "ruRU": "Детский смех",
-        "zhCN": "孩童的笑声"
+        "zhCN": "儿童的笑声"
     },
     {
         "id": 50312,
@@ -31453,7 +31453,7 @@
         "id": 50314,
         "Key": "Beeswarm",
         "enUS": "Beeswarm",
-        "zhTW": "蜂群",
+        "zhTW": "Beeswarm",
         "deDE": "Bienenwarm",
         "esES": "Calor de abeja",
         "frFR": "Beeswarm",
@@ -31464,7 +31464,7 @@
         "jaJP": "ビーズウォーム",
         "ptBR": "Abelhas Quentes",
         "ruRU": "Beeswarm",
-        "zhCN": "蜂群"
+        "zhCN": "Beeswarm"
     },
     {
         "id": 50315,
@@ -31487,7 +31487,7 @@
         "id": 50316,
         "Key": "Final Flight",
         "enUS": "Final Flight",
-        "zhTW": "告別飛行",
+        "zhTW": "最后的飞行",
         "deDE": "Letzter Flug",
         "esES": "Vuelo final",
         "frFR": "Dernier vol",
@@ -31498,13 +31498,13 @@
         "jaJP": "最終フライト",
         "ptBR": "Voo Final",
         "ruRU": "Последний полет",
-        "zhCN": "告別飞行"
+        "zhCN": "最后的飞行"
     },
     {
         "id": 50317,
         "Key": "Gale Song",
         "enUS": "Gale Song",
-        "zhTW": "大風歌",
+        "zhTW": "大风歌",
         "deDE": "Gale Song",
         "esES": "Gale Song",
         "frFR": "Gale Song",
@@ -31521,7 +31521,7 @@
         "id": 50318,
         "Key": "Ranger's Sting",
         "enUS": "Ranger's Sting",
-        "zhTW": "游俠之刺",
+        "zhTW": "游侠之刺",
         "deDE": "Waldläuferstich",
         "esES": "El aguijón del guardabosques",
         "frFR": "L'aiguillon du garde forestier",
@@ -31538,7 +31538,7 @@
         "id": 50319,
         "Key": "Warpwind",
         "enUS": "Warpwind",
-        "zhTW": "曲行之风",
+        "zhTW": "翘曲风",
         "deDE": "Rückenwind",
         "esES": "Warpwind",
         "frFR": "Le vent de la guerre",
@@ -31549,13 +31549,13 @@
         "jaJP": "ワープウインド",
         "ptBR": "Vento Deformado",
         "ruRU": "Варпвинд",
-        "zhCN": "曲行之风"
+        "zhCN": "翘曲风"
     },
     {
         "id": 50320,
         "Key": "Willowsting",
         "enUS": "Willowsting",
-        "zhTW": "永訣之刺",
+        "zhTW": "Willowsting",
         "deDE": "Willowsting",
         "esES": "Willowsting",
         "frFR": "Willowsting",
@@ -31566,7 +31566,7 @@
         "jaJP": "ウィロースティング",
         "ptBR": "Picada de Salgueiro",
         "ruRU": "Уиллоустинг",
-        "zhCN": "永诀之刺"
+        "zhCN": "Willowsting"
     },
     {
         "id": 50321,
@@ -31589,7 +31589,7 @@
         "id": 50322,
         "Key": "Spikethrower",
         "enUS": "Spikethrower",
-        "zhTW": "擲刺者",
+        "zhTW": "喷射器",
         "deDE": "Stachelwerfer",
         "esES": "Lanzavirotes",
         "frFR": "Lance-pierre",
@@ -31600,13 +31600,13 @@
         "jaJP": "スパイクスロワー",
         "ptBR": "Pistola de Pregos",
         "ruRU": "Колючий метатель",
-        "zhCN": "掷刺者"
+        "zhCN": "喷射器"
     },
     {
         "id": 50323,
         "Key": "Nail Flinger",
         "enUS": "Nail Flinger",
-        "zhTW": "抛釘器",
+        "zhTW": "指甲钳",
         "deDE": "Nail Flinger",
         "esES": "Dedos de uñas",
         "frFR": "Clou à ailettes",
@@ -31617,13 +31617,13 @@
         "jaJP": "ネイルフリンガー",
         "ptBR": "Unha do Dedo",
         "ruRU": "Щипцы для ногтей",
-        "zhCN": "抛钉器"
+        "zhCN": "指甲钳"
     },
     {
         "id": 50324,
         "Key": "Janglebright",
         "enUS": "Janglebright",
-        "zhTW": "聒噪炫目",
+        "zhTW": "Janglebright",
         "deDE": "Janglebright",
         "esES": "Janglebright",
         "frFR": "Janglebright",
@@ -31634,13 +31634,13 @@
         "jaJP": "ジャングルブライト",
         "ptBR": "Brilhante Chocalhar",
         "ruRU": "Джанглбрайт",
-        "zhCN": "聒噪炫目"
+        "zhCN": "Janglebright"
     },
     {
         "id": 50325,
         "Key": "Leafrazor",
         "enUS": "Leafrazor",
-        "zhTW": "刮叶刀",
+        "zhTW": "Leafrazor",
         "deDE": "Leafrazor",
         "esES": "Leafrazor",
         "frFR": "Leafrazor",
@@ -31651,13 +31651,13 @@
         "jaJP": "リーフレイザー",
         "ptBR": "Folha Navalha",
         "ruRU": "Leafrazor",
-        "zhCN": "刮叶刀"
+        "zhCN": "Leafrazor"
     },
     {
         "id": 50326,
         "Key": "Skyglow",
         "enUS": "Skyglow",
-        "zhTW": "霞光",
+        "zhTW": "天光",
         "deDE": "Himmelsglühen",
         "esES": "Skyglow",
         "frFR": "Lueur de ciel",
@@ -31668,13 +31668,13 @@
         "jaJP": "スカイグロー",
         "ptBR": "Céu Brilhante",
         "ruRU": "Skyglow",
-        "zhCN": "霞光"
+        "zhCN": "天光"
     },
     {
         "id": 50327,
         "Key": "Splinterfreeze",
         "enUS": "Splinterfreeze",
-        "zhTW": "碎片凝結",
+        "zhTW": "分裂冻结",
         "deDE": "Splitterfrost",
         "esES": "Splinterfreeze",
         "frFR": "Gel de l'épine dorsale",
@@ -31685,13 +31685,13 @@
         "jaJP": "スプリンターフリーズ",
         "ptBR": "Lasca Congelada",
         "ruRU": "Splinterfreeze",
-        "zhCN": "碎片凝结"
+        "zhCN": "分裂冻结"
     },
     {
         "id": 50328,
         "Key": "Teeth of Infinity",
         "enUS": "Teeth of Infinity",
-        "zhTW": "無限之牙",
+        "zhTW": "无限之牙",
         "deDE": "Die Zähne der Unendlichkeit",
         "esES": "Dientes del Infinito",
         "frFR": "Les dents de l'infini",
@@ -31708,7 +31708,7 @@
         "id": 50329,
         "Key": "Sting of Humiliation",
         "enUS": "Sting of Humiliation",
-        "zhTW": "羞辱之刺痛",
+        "zhTW": "羞辱的刺痛",
         "deDE": "Stachel der Erniedrigung",
         "esES": "El aguijón de la humillación",
         "frFR": "La piqûre de l'humiliation",
@@ -31719,13 +31719,13 @@
         "jaJP": "屈辱の棘",
         "ptBR": "Picada Humilhante",
         "ruRU": "Укус унижения",
-        "zhCN": "羞辱之刺痛"
+        "zhCN": "羞辱的刺痛"
     },
     {
         "id": 50330,
         "Key": "Tonguecutter",
         "enUS": "Tonguecutter",
-        "zhTW": "割舌刀",
+        "zhTW": "通古塔",
         "deDE": "Tonguecutter",
         "esES": "Tonguecutter",
         "frFR": "Tonguecutter",
@@ -31736,7 +31736,7 @@
         "jaJP": "トンガリ",
         "ptBR": "Língua Cortada",
         "ruRU": "Тонкорез",
-        "zhCN": "割舌刀"
+        "zhCN": "通古塔"
     },
     {
         "id": 50331,
@@ -31759,7 +31759,7 @@
         "id": 50332,
         "Key": "Subtle Slice",
         "enUS": "Subtle Slice",
-        "zhTW": "細微切片",
+        "zhTW": "微妙的切片",
         "deDE": "Subtile Slice",
         "esES": "Rebanada sutil",
         "frFR": "Tranche subtile",
@@ -31770,13 +31770,13 @@
         "jaJP": "微妙なスライス",
         "ptBR": "Faria Sutil",
         "ruRU": "Тонкий ломтик",
-        "zhCN": "细微切片"
+        "zhCN": "微妙的切片"
     },
     {
         "id": 50333,
         "Key": "Tidrik's Initiator",
         "enUS": "Tidrik's Initiator",
-        "zhTW": "提德里克的啓動器",
+        "zhTW": "提德里克的启动器",
         "deDE": "Tidriks Initiator",
         "esES": "Iniciador de Tidrik",
         "frFR": "L'initiateur de Tidrik",
@@ -31793,7 +31793,7 @@
         "id": 50334,
         "Key": "Equinox Visor",
         "enUS": "Equinox Visor",
-        "zhTW": "晝夜护面",
+        "zhTW": "Equinox 遮阳板",
         "deDE": "Equinox Visier",
         "esES": "Equinox Visor",
         "frFR": "Visière Equinox",
@@ -31804,13 +31804,13 @@
         "jaJP": "エクイノックス・バイザー",
         "ptBR": "Visor Equinox",
         "ruRU": "Козырек Equinox",
-        "zhCN": "昼夜护面"
+        "zhCN": "Equinox 遮阳板"
     },
     {
         "id": 50335,
         "Key": "Crown of Thorns",
         "enUS": "Crown of Thorns",
-        "zhTW": "荊棘王冠",
+        "zhTW": "荆棘王冠",
         "deDE": "Dornenkrone",
         "esES": "Corona de espinas",
         "frFR": "Couronne d'épines",
@@ -31827,7 +31827,7 @@
         "id": 50336,
         "Key": "Trickster's Guise",
         "enUS": "Trickster's Guise",
-        "zhTW": "欺騙者的僞裝",
+        "zhTW": "捣蛋鬼的伪装",
         "deDE": "Trickbetrügerische Tarnung",
         "esES": "Guisa de embaucador",
         "frFR": "L'astuce du tricheur",
@@ -31838,7 +31838,7 @@
         "jaJP": "トリックスターの装い",
         "ptBR": "Aparência Trapaceira",
         "ruRU": "Личина трикстера",
-        "zhCN": "欺骗者的伪装"
+        "zhCN": "捣蛋鬼的伪装"
     },
     {
         "id": 50337,
@@ -31861,7 +31861,7 @@
         "id": 50338,
         "Key": "Freedom's Facade",
         "enUS": "Freedom's Facade",
-        "zhTW": "自由假面",
+        "zhTW": "自由的外表",
         "deDE": "Die Fassade der Freiheit",
         "esES": "Fachada de la libertad",
         "frFR": "La façade de la liberté",
@@ -31872,13 +31872,13 @@
         "jaJP": "自由のファサード",
         "ptBR": "Fachada Libertavel",
         "ruRU": "Фасад свободы",
-        "zhCN": "自由假面"
+        "zhCN": "自由的外表"
     },
     {
         "id": 50339,
         "Key": "Cursed Hindsight",
         "enUS": "Cursed Hindsight",
-        "zhTW": "被詛咒的馬後炮",
+        "zhTW": "被诅咒的后见之明",
         "deDE": "Verfluchte Einsicht",
         "esES": "Retrospectiva maldita",
         "frFR": "Rétrospective maudite",
@@ -31889,13 +31889,13 @@
         "jaJP": "呪われた後知恵",
         "ptBR": "Vista Traseira Amaldiçoada",
         "ruRU": "Проклятая непредусмотрительность",
-        "zhCN": "被诅咒的马后炮"
+        "zhCN": "被诅咒的后见之明"
     },
     {
         "id": 50340,
         "Key": "Morning's Tears",
         "enUS": "Morning's Tears",
-        "zhTW": "清晨之淚",
+        "zhTW": "清晨的眼泪",
         "deDE": "Die Tränen des Morgens",
         "esES": "Lágrimas de la mañana",
         "frFR": "Larmes du matin",
@@ -31906,13 +31906,13 @@
         "jaJP": "朝の涙",
         "ptBR": "Lágrimas de manhã",
         "ruRU": "Утренние слезы",
-        "zhCN": "清晨之泪"
+        "zhCN": "清晨的眼泪"
     },
     {
         "id": 50341,
         "Key": "Muddled Thoughts",
         "enUS": "Muddled Thoughts",
-        "zhTW": "混亂思緒",
+        "zhTW": "混乱的思绪",
         "deDE": "Verworrene Gedanken",
         "esES": "Pensamientos confusos",
         "frFR": "Pensées confuses",
@@ -31923,13 +31923,13 @@
         "jaJP": "モヤモヤした思い",
         "ptBR": "Opinião Atrapalhada",
         "ruRU": "Непонятные мысли",
-        "zhCN": "混乱思绪"
+        "zhCN": "混乱的思绪"
     },
     {
         "id": 50342,
         "Key": "Treachery's Allure",
         "enUS": "Treachery's Allure",
-        "zhTW": "背叛的誘惑",
+        "zhTW": "背叛的诱惑",
         "deDE": "Die Verlockung des Verrats",
         "esES": "El encanto de la traición",
         "frFR": "L'attrait de la trahison",
@@ -31946,7 +31946,7 @@
         "id": 50343,
         "Key": "Threatspeaker",
         "enUS": "Threatspeaker",
-        "zhTW": "威脅者",
+        "zhTW": "威胁发言者",
         "deDE": "Drohbriefe",
         "esES": "Altavoz de amenazas",
         "frFR": "L'auteur de la menace",
@@ -31957,13 +31957,13 @@
         "jaJP": "スレットスピーカー",
         "ptBR": "Fala Ameaçadora",
         "ruRU": "Угроза",
-        "zhCN": "威胁者"
+        "zhCN": "威胁发言者"
     },
     {
         "id": 50344,
         "Key": "Traitor's Mark",
         "enUS": "Traitor's Mark",
-        "zhTW": "叛徒的印記",
+        "zhTW": "叛徒的印记",
         "deDE": "Das Zeichen des Verräters",
         "esES": "Marca del traidor",
         "frFR": "La marque du traître",
@@ -31980,7 +31980,7 @@
         "id": 50345,
         "Key": "Skein of Deceit",
         "enUS": "Skein of Deceit",
-        "zhTW": "欺騙之綹",
+        "zhTW": "欺骗之绺",
         "deDE": "Strang der Täuschung",
         "esES": "La madeja del engaño",
         "frFR": "L'écheveau de la tromperie",
@@ -31997,7 +31997,7 @@
         "id": 50346,
         "Key": "Lepertouch",
         "enUS": "Lepertouch",
-        "zhTW": "麻風之觸",
+        "zhTW": "Lepertouch",
         "deDE": "Lepertouch",
         "esES": "Lepertouch",
         "frFR": "Lepertouch",
@@ -32008,13 +32008,13 @@
         "jaJP": "レパタッチ",
         "ptBR": "Toque Leproso",
         "ruRU": "Lepertouch",
-        "zhCN": "麻风之触"
+        "zhCN": "Lepertouch"
     },
     {
         "id": 50347,
         "Key": "Cacophony",
         "enUS": "Cacophony",
-        "zhTW": "雜音",
+        "zhTW": "Cacophony",
         "deDE": "Kakophonie",
         "esES": "Cacofonía",
         "frFR": "Cacophonie",
@@ -32025,13 +32025,13 @@
         "jaJP": "不協和音",
         "ptBR": "Cacofonia",
         "ruRU": "Какофония",
-        "zhCN": "杂音"
+        "zhCN": "Cacophony"
     },
     {
         "id": 50348,
         "Key": "Debt Finisher",
         "enUS": "Debt Finisher",
-        "zhTW": "還債者",
+        "zhTW": "债务终结者",
         "deDE": "Schulden-Finisher",
         "esES": "Finalizador de deudas",
         "frFR": "Finisseur de dette",
@@ -32042,7 +32042,7 @@
         "jaJP": "デット・フィニッシャー",
         "ptBR": "Débito Finalizado",
         "ruRU": "Отделка долгов",
-        "zhCN": "还债者"
+        "zhCN": "债务终结者"
     },
     {
         "id": 50349,
@@ -32065,7 +32065,7 @@
         "id": 50350,
         "Key": "Knight's Dawn",
         "enUS": "Knight's Dawn",
-        "zhTW": "騎士的黎明",
+        "zhTW": "骑士的黎明",
         "deDE": "Ritterdämmerung",
         "esES": "Amanecer del Caballero",
         "frFR": "L'aube du chevalier",
@@ -32082,7 +32082,7 @@
         "id": 50351,
         "Key": "Shield of Osiris",
         "enUS": "Shield of Osiris",
-        "zhTW": "奧西里斯之盾",
+        "zhTW": "奥西里斯之盾",
         "deDE": "Schild des Osiris",
         "esES": "Escudo de Osiris",
         "frFR": "Bouclier d'Osiris",
@@ -32099,7 +32099,7 @@
         "id": 50352,
         "Key": "Green God's Bracers",
         "enUS": "Green God's Bracers",
-        "zhTW": "綠神護腕",
+        "zhTW": "绿神手镯",
         "deDE": "Grüner Armschützer des Gottes",
         "esES": "Brazales del Dios Verde",
         "frFR": "Bracelets du dieu vert",
@@ -32110,13 +32110,13 @@
         "jaJP": "グリーン・ゴッズ・ブレイサー",
         "ptBR": "Braceletes Verdes de Deus",
         "ruRU": "Зеленые браслеты бога",
-        "zhCN": "绿神护腕"
+        "zhCN": "绿神手镯"
     },
     {
         "id": 50353,
         "Key": "Goblin Touch",
         "enUS": "Goblin Touch",
-        "zhTW": "哥布林之觸",
+        "zhTW": "妖精之触",
         "deDE": "Kobold-Berührung",
         "esES": "Toque de duende",
         "frFR": "Toucher de gobelin",
@@ -32127,13 +32127,13 @@
         "jaJP": "ゴブリン・タッチ",
         "ptBR": "Goblin Tocador",
         "ruRU": "Прикосновение гоблина",
-        "zhCN": "哥布林之触"
+        "zhCN": "妖精之触"
     },
     {
         "id": 50354,
         "Key": "Fiendfeast",
         "enUS": "Fiendfeast",
-        "zhTW": "恶魔盛宴",
+        "zhTW": "Fiendfeast",
         "deDE": "Teufelsschmaus",
         "esES": "Fiendfeast",
         "frFR": "Festin clandestin",
@@ -32144,13 +32144,13 @@
         "jaJP": "フィーンド・フィースト",
         "ptBR": "Demônio Festivo",
         "ruRU": "Fiendfeast",
-        "zhCN": "恶魔盛宴"
+        "zhCN": "Fiendfeast"
     },
     {
         "id": 50355,
         "Key": "Firesign",
         "enUS": "Firesign",
-        "zhTW": "火之印記",
+        "zhTW": "火炬",
         "deDE": "Feuerzeichen",
         "esES": "Firesign",
         "frFR": "Feu d'artifice",
@@ -32161,13 +32161,13 @@
         "jaJP": "ファイヤーサイン",
         "ptBR": "Signo de Fogo",
         "ruRU": "Firesign",
-        "zhCN": "火之印记"
+        "zhCN": "火炬"
     },
     {
         "id": 50356,
         "Key": "Skein of Pain",
         "enUS": "Skein of Pain",
-        "zhTW": "痛苦之綹",
+        "zhTW": "痛苦之绺",
         "deDE": "Strang des Schmerzes",
         "esES": "Madeja de dolor",
         "frFR": "La douleur en filigrane",
@@ -32184,7 +32184,7 @@
         "id": 50357,
         "Key": "Angel's Tread",
         "enUS": "Angel's Tread",
-        "zhTW": "天使踏面",
+        "zhTW": "天使的足迹",
         "deDE": "Engelstritt",
         "esES": "La huella del ángel",
         "frFR": "Le pas de l'ange",
@@ -32195,13 +32195,13 @@
         "jaJP": "天使の足跡",
         "ptBR": "Anjo Passo",
         "ruRU": "Протектор ангела",
-        "zhCN": "天使踏面"
+        "zhCN": "天使的足迹"
     },
     {
         "id": 50358,
         "Key": "Marathon Slipper",
         "enUS": "Marathon Slipper",
-        "zhTW": "馬拉松的拖鞋",
+        "zhTW": "马拉松拖鞋",
         "deDE": "Marathon-Schuh",
         "esES": "Zapatilla Maratón",
         "frFR": "Chausson Marathon",
@@ -32212,13 +32212,13 @@
         "jaJP": "マラソン・スリッパ",
         "ptBR": "Maratona de Chinelo",
         "ruRU": "Тапочки для марафона",
-        "zhCN": "马拉松的拖鞋"
+        "zhCN": "马拉松拖鞋"
     },
     {
         "id": 50359,
         "Key": "Lilith's Heels",
         "enUS": "Lilith's Heels",
-        "zhTW": "莉莉絲的高跟鞋",
+        "zhTW": "莉莉丝的高跟鞋",
         "deDE": "Liliths Absätze",
         "esES": "Tacones de Lilith",
         "frFR": "Les talons de Lilith",
@@ -32235,7 +32235,7 @@
         "id": 50360,
         "Key": "Bonemesh",
         "enUS": "Bonemesh",
-        "zhTW": "白骨之網",
+        "zhTW": "Bonemesh",
         "deDE": "Bonemesh",
         "esES": "Bonemesh",
         "frFR": "Bonemesh",
@@ -32246,13 +32246,13 @@
         "jaJP": "ボーンメッシュ",
         "ptBR": "Malha Óssea",
         "ruRU": "Bonemesh",
-        "zhCN": "白骨之网"
+        "zhCN": "Bonemesh"
     },
     {
         "id": 50361,
         "Key": "Grimleaper",
         "enUS": "Grimleaper",
-        "zhTW": "冷酷逃亡者",
+        "zhTW": "Grimleaper",
         "deDE": "Grimleaper",
         "esES": "Grimleaper",
         "frFR": "Faucheur",
@@ -32263,13 +32263,13 @@
         "jaJP": "グリムリーパー",
         "ptBR": "Exterminio Severo",
         "ruRU": "Гримлипер",
-        "zhCN": "冷酷逃亡者"
+        "zhCN": "Grimleaper"
     },
     {
         "id": 50362,
         "Key": "Ivywrap",
         "enUS": "Ivywrap",
-        "zhTW": "春藤纏繞",
+        "zhTW": "Ivywrap",
         "deDE": "Ivywrap",
         "esES": "Ivywrap",
         "frFR": "Ivywrap",
@@ -32280,13 +32280,13 @@
         "jaJP": "アイビーラップ",
         "ptBR": "Hera Envolvida",
         "ruRU": "Ivywrap",
-        "zhCN": "春藤缠绕"
+        "zhCN": "Ivywrap"
     },
     {
         "id": 50363,
         "Key": "Leash of Cerberus",
         "enUS": "Leash of Cerberus",
-        "zhTW": "地獄犬的皮帶",
+        "zhTW": "地狱犬的皮带",
         "deDE": "Leine von Cerberus",
         "esES": "Correa de Cerbero",
         "frFR": "Laisse de Cerbère",
@@ -32303,7 +32303,7 @@
         "id": 50364,
         "Key": "Spiritseeker",
         "enUS": "Spiritseeker",
-        "zhTW": "尋靈者",
+        "zhTW": "寻灵者",
         "deDE": "Spiritseeker",
         "esES": "Spiritseeker",
         "frFR": "Chercheur d'esprit",
@@ -32320,7 +32320,7 @@
         "id": 50365,
         "Key": "Wreath of Suffering",
         "enUS": "Wreath of Suffering",
-        "zhTW": "苦難花環",
+        "zhTW": "苦难花环",
         "deDE": "Kranz des Leidens",
         "esES": "Corona de sufrimiento",
         "frFR": "Couronne de souffrance",
@@ -32337,7 +32337,7 @@
         "id": 50366,
         "Key": "Pirate's Faith",
         "enUS": "Pirate's Faith",
-        "zhTW": "海盜的信仰",
+        "zhTW": "海盗的信仰",
         "deDE": "Der Glaube der Piraten",
         "esES": "La fe del pirata",
         "frFR": "La foi du pirate",
@@ -32354,7 +32354,7 @@
         "id": 50367,
         "Key": "Bleeding Branch",
         "enUS": "Bleeding Branch",
-        "zhTW": "流血之枝",
+        "zhTW": "出血处",
         "deDE": "Blutender Zweig",
         "esES": "Rama sangrante",
         "frFR": "Branche saignante",
@@ -32365,13 +32365,13 @@
         "jaJP": "ブリーディング・ブランチ",
         "ptBR": "Ramo Sangrando",
         "ruRU": "Кровоточащая ветвь",
-        "zhCN": "流血之枝"
+        "zhCN": "出血处"
     },
     {
         "id": 50368,
         "Key": "Celestial Revelation",
         "enUS": "Celestial Revelation",
-        "zhTW": "天體啓示",
+        "zhTW": "天体启示",
         "deDE": "Die himmlische Offenbarung",
         "esES": "Revelación celestial",
         "frFR": "Révélation céleste",
@@ -32388,7 +32388,7 @@
         "id": 50369,
         "Key": "Doubleshot Machine",
         "enUS": "Doubleshot Machine",
-        "zhTW": "雙射機",
+        "zhTW": "双击机",
         "deDE": "Doubleshot-Maschine",
         "esES": "Máquina de tiro doble",
         "frFR": "Machine à double cliché",
@@ -32399,13 +32399,13 @@
         "jaJP": "ダブルショットマシン",
         "ptBR": "Máquina de tiro duplo",
         "ruRU": "Дуплетная машина",
-        "zhCN": "双射机"
+        "zhCN": "双击机"
     },
     {
         "id": 50370,
         "Key": "Elvenbrand",
         "enUS": "Elvenbrand",
-        "zhTW": "精靈烙印",
+        "zhTW": "精灵之火",
         "deDE": "Elfenfeuer",
         "esES": "Fuego élfico",
         "frFR": "Feu elfique",
@@ -32416,13 +32416,13 @@
         "jaJP": "エルフの火",
         "ptBR": "Marca Élfica",
         "ruRU": "Эльфийский огонь",
-        "zhCN": "精灵烙印"
+        "zhCN": "精灵之火"
     },
     {
         "id": 50371,
         "Key": "Hastemaster",
         "enUS": "Hastemaster",
-        "zhTW": "迅捷王者",
+        "zhTW": "Hastemaster",
         "deDE": "Hastemaster",
         "esES": "Hastemaster",
         "frFR": "Hastemaster",
@@ -32433,7 +32433,7 @@
         "jaJP": "ヘイストマスター",
         "ptBR": "Dominar a Pressa",
         "ruRU": "Hastemaster",
-        "zhCN": "迅捷王者"
+        "zhCN": "Hastemaster"
     },
     {
         "id": 50372,
@@ -32456,7 +32456,7 @@
         "id": 50373,
         "Key": "Bloodyearn",
         "enUS": "Bloodyearn",
-        "zhTW": "渴血",
+        "zhTW": "血赚",
         "deDE": "Bloodyearn",
         "esES": "Bloodyearn",
         "frFR": "Sang-argent",
@@ -32467,13 +32467,13 @@
         "jaJP": "ブラッディアーン",
         "ptBR": "Desejo de Sangrar",
         "ruRU": "Bloodyearn",
-        "zhCN": "渴血"
+        "zhCN": "血赚"
     },
     {
         "id": 50374,
         "Key": "Murder's Mistress",
         "enUS": "Murder's Mistress",
-        "zhTW": "謀殺者的情婦",
+        "zhTW": "谋杀案的情妇",
         "deDE": "Die Geliebte des Mörders",
         "esES": "La amante del asesinato",
         "frFR": "La maîtresse du meurtre",
@@ -32484,13 +32484,13 @@
         "jaJP": "殺人の愛人",
         "ptBR": "Amante do Assassinato",
         "ruRU": "Любовница убийцы",
-        "zhCN": "谋杀者的情妇"
+        "zhCN": "谋杀案的情妇"
     },
     {
         "id": 50375,
         "Key": "Ancients' Epiphany",
         "enUS": "Ancients' Epiphany",
-        "zhTW": "元老之頓悟",
+        "zhTW": "古人的顿悟",
         "deDE": "Epiphanie der Antike",
         "esES": "Epifanía de los Antiguos",
         "frFR": "L'épiphanie des anciens",
@@ -32501,7 +32501,7 @@
         "jaJP": "古代人の啓示",
         "ptBR": "Epifania dos Antigos",
         "ruRU": "Прозрение древних",
-        "zhCN": "元老之顿悟"
+        "zhCN": "古人的顿悟"
     },
     {
         "id": 50376,
@@ -32524,7 +32524,7 @@
         "id": 50377,
         "Key": "Arch-Nemesis",
         "enUS": "Arch-Nemesis",
-        "zhTW": "頭號勁敵",
+        "zhTW": "大克星",
         "deDE": "Arch-Nemesis",
         "esES": "Archi-Némesis",
         "frFR": "Arch-Nemesis",
@@ -32535,13 +32535,13 @@
         "jaJP": "アーチ・ネメシス",
         "ptBR": "Arqui-Inimigo",
         "ruRU": "Arch-Nemesis",
-        "zhCN": "头号劲敌"
+        "zhCN": "大克星"
     },
     {
         "id": 50378,
         "Key": "Archon's Ache",
         "enUS": "Archon's Ache",
-        "zhTW": "統御者之痛",
+        "zhTW": "阿琼之痛",
         "deDE": "Der Schmerz des Archons",
         "esES": "Dolor de Arconte",
         "frFR": "Le mal de l'archonte",
@@ -32552,13 +32552,13 @@
         "jaJP": "アルコンの痛み",
         "ptBR": "Dor de Arconte",
         "ruRU": "Болезнь архонта",
-        "zhCN": "统治者之痛"
+        "zhCN": "阿琼之痛"
     },
     {
         "id": 50379,
         "Key": "Auburn Fire",
         "enUS": "Auburn Fire",
-        "zhTW": "奥本之火",
+        "zhTW": "奥本消防",
         "deDE": "Auburn Feuer",
         "esES": "Incendio de Auburn",
         "frFR": "Feu d'Auburn",
@@ -32569,13 +32569,13 @@
         "jaJP": "オーバーン火災",
         "ptBR": "Fogo Ruivo",
         "ruRU": "Пожар в Оберне",
-        "zhCN": "奥本之火"
+        "zhCN": "奥本消防"
     },
     {
         "id": 50380,
         "Key": "Avalanche Strike",
         "enUS": "Avalanche Strike",
-        "zhTW": "雪崩侵襲",
+        "zhTW": "雪崩袭击",
         "deDE": "Lawinenabgang",
         "esES": "Huelga de avalancha",
         "frFR": "Grève d'avalanche",
@@ -32592,7 +32592,7 @@
         "id": 50381,
         "Key": "Biteblade",
         "enUS": "Biteblade",
-        "zhTW": "噬咬之刃",
+        "zhTW": "位刃",
         "deDE": "Biteblade",
         "esES": "Biteblade",
         "frFR": "Biteblade",
@@ -32603,13 +32603,13 @@
         "jaJP": "バイトブレード",
         "ptBR": "Lâmina Mordida",
         "ruRU": "Biteblade",
-        "zhCN": "噬咬之刃"
+        "zhCN": "位刃"
     },
     {
         "id": 50382,
         "Key": "Blasthammer",
         "enUS": "Blasthammer",
-        "zhTW": "爆破錘",
+        "zhTW": "爆破锤",
         "deDE": "Sprenghammer",
         "esES": "Martillo perforador",
         "frFR": "Marteau piqueur",
@@ -32626,7 +32626,7 @@
         "id": 50383,
         "Key": "Rotbranch",
         "enUS": "Rotbranch",
-        "zhTW": "腐爛之枝",
+        "zhTW": "红鹤",
         "deDE": "Rotbranch",
         "esES": "Grulla roja",
         "frFR": "Brindille rouge",
@@ -32637,13 +32637,13 @@
         "jaJP": "紅鶴",
         "ptBR": "Guindaste vermelho",
         "ruRU": "Красный журавль",
-        "zhCN": "腐烂之枝"
+        "zhCN": "红鹤"
     },
     {
         "id": 50384,
         "Key": "Blindman's Bluff",
         "enUS": "Blindman's Bluff",
-        "zhTW": "盲人之崖",
+        "zhTW": "盲人悬崖",
         "deDE": "Blinde Kuh",
         "esES": "Blindman's Bluff",
         "frFR": "Blindman's Bluff",
@@ -32654,13 +32654,13 @@
         "jaJP": "ブラインドマンズ・ブラフ",
         "ptBR": "Homem Cegado e Blefado",
         "ruRU": "Блеф Слепца",
-        "zhCN": "盲人之崖"
+        "zhCN": "盲人悬崖"
     },
     {
         "id": 50385,
         "Key": "Blindsight",
         "enUS": "Blindsight",
-        "zhTW": "盲視",
+        "zhTW": "盲点",
         "deDE": "Blindsight",
         "esES": "Blindsight",
         "frFR": "La vision aveugle",
@@ -32671,13 +32671,13 @@
         "jaJP": "ブラインドサイト",
         "ptBR": "Visão Cegada",
         "ruRU": "Слепое зрение",
-        "zhCN": "盲视"
+        "zhCN": "盲点"
     },
     {
         "id": 50386,
         "Key": "Blisterpain",
         "enUS": "Blisterpain",
-        "zhTW": "爆裂之痛",
+        "zhTW": "水泡疼痛",
         "deDE": "Blasenschmerz",
         "esES": "Dolor de ampollas",
         "frFR": "Douleur vésiculeuse",
@@ -32688,13 +32688,13 @@
         "jaJP": "ブリスター痛",
         "ptBR": "Bolha Dolorida",
         "ruRU": "Мозоли",
-        "zhCN": "爆裂之痛"
+        "zhCN": "水泡疼痛"
     },
     {
         "id": 50387,
         "Key": "Bloodrune",
         "enUS": "Bloodrune",
-        "zhTW": "血色符文",
+        "zhTW": "Bloodrune",
         "deDE": "Blutrune",
         "esES": "Bloodrune",
         "frFR": "La rune sanglante",
@@ -32705,13 +32705,13 @@
         "jaJP": "ブラッドルーン",
         "ptBR": "Runa de Sangue",
         "ruRU": "Бладрун",
-        "zhCN": "血色符文"
+        "zhCN": "Bloodrune"
     },
     {
         "id": 50388,
         "Key": "Brightmangler",
         "enUS": "Brightmangler",
-        "zhTW": "光明滾軋",
+        "zhTW": "Brightmangler",
         "deDE": "Brightmangler",
         "esES": "Brightmangler",
         "frFR": "Brightmangler",
@@ -32722,13 +32722,13 @@
         "jaJP": "ブライトマングラー",
         "ptBR": "Mangler Brilhante",
         "ruRU": "Brightmangler",
-        "zhCN": "光明滚轧"
+        "zhCN": "Brightmangler"
     },
     {
         "id": 50389,
         "Key": "Call of the Kindred",
         "enUS": "Call of the Kindred",
-        "zhTW": "至親之喚",
+        "zhTW": "亲属的召唤",
         "deDE": "Der Ruf der Gleichgesinnten",
         "esES": "La llamada de los Kindred",
         "frFR": "L'appel des Kindred",
@@ -32739,13 +32739,13 @@
         "jaJP": "キンドレッドの呼び声",
         "ptBR": "Chamado da Família",
         "ruRU": "Зов рода",
-        "zhCN": "至亲之唤"
+        "zhCN": "亲属的召唤"
     },
     {
         "id": 50390,
         "Key": "Celestial Judgment",
         "enUS": "Celestial Judgment",
-        "zhTW": "天國審判",
+        "zhTW": "天国的审判",
         "deDE": "Das himmlische Gericht",
         "esES": "Juicio Celestial",
         "frFR": "Jugement céleste",
@@ -32756,13 +32756,13 @@
         "jaJP": "天の審判",
         "ptBR": "Julgamento Celestial",
         "ruRU": "Небесный суд",
-        "zhCN": "天国审判"
+        "zhCN": "天国的审判"
     },
     {
         "id": 50391,
         "Key": "Chaos Wail",
         "enUS": "Chaos Wail",
-        "zhTW": "渾沌哀嚎",
+        "zhTW": "混沌哀嚎",
         "deDE": "Chaos Wail",
         "esES": "Lamento del caos",
         "frFR": "Chaos Wail",
@@ -32779,7 +32779,7 @@
         "id": 50392,
         "Key": "Chaos Flight",
         "enUS": "Chaos Flight",
-        "zhTW": "渾沌飛翔",
+        "zhTW": "混沌飞行",
         "deDE": "Chaosflug",
         "esES": "Vuelo del caos",
         "frFR": "Vol du chaos",
@@ -32790,13 +32790,13 @@
         "jaJP": "カオス・フライト",
         "ptBR": "Assassino do Caos",
         "ruRU": "Полет Хаоса",
-        "zhCN": "混沌飞翔"
+        "zhCN": "混沌飞行"
     },
     {
         "id": 50393,
         "Key": "Chorus of the Cursed",
         "enUS": "Chorus of the Cursed",
-        "zhTW": "被詛咒者的合鳴",
+        "zhTW": "被诅咒者合唱团",
         "deDE": "Chor der Verfluchten",
         "esES": "Coro de los malditos",
         "frFR": "Chœur des maudits",
@@ -32807,13 +32807,13 @@
         "jaJP": "呪いのコーラス",
         "ptBR": "Coro Amaldiçoado",
         "ruRU": "Хор проклятых",
-        "zhCN": "被诅咒者的合鸣"
+        "zhCN": "被诅咒者合唱团"
     },
     {
         "id": 50394,
         "Key": "Cold Comfort",
         "enUS": "Cold Comfort",
-        "zhTW": "冰寒之舒",
+        "zhTW": "冷舒适",
         "deDE": "Kalter Trost",
         "esES": "Confort frío",
         "frFR": "Confort froid",
@@ -32824,13 +32824,13 @@
         "jaJP": "コールド・コンフォート",
         "ptBR": "Frio Confortante",
         "ruRU": "Холодный комфорт",
-        "zhCN": "冰霜之舒"
+        "zhCN": "冷舒适"
     },
     {
         "id": 50395,
         "Key": "Cry of the Wretched",
         "enUS": "Cry of the Wretched",
-        "zhTW": "可憐人的哭泣",
+        "zhTW": "可怜人的哭泣",
         "deDE": "Der Schrei der Unglücklichen",
         "esES": "Grito de los miserables",
         "frFR": "Le cri des misérables",
@@ -32847,7 +32847,7 @@
         "id": 50396,
         "Key": "Cyanstrike",
         "enUS": "Cyanstrike",
-        "zhTW": "靛青打擊",
+        "zhTW": "Cyanstrike",
         "deDE": "Cyanstrike",
         "esES": "Cyanstrike",
         "frFR": "Cyanstrike",
@@ -32858,13 +32858,13 @@
         "jaJP": "シアンストライク",
         "ptBR": "Ataque Ciano",
         "ruRU": "Цианстрайк",
-        "zhCN": "靛青打击"
+        "zhCN": "Cyanstrike"
     },
     {
         "id": 50397,
         "Key": "Dark Nemesis",
         "enUS": "Dark Nemesis",
-        "zhTW": "黑暗復仇女神",
+        "zhTW": "黑暗复仇女神",
         "deDE": "Dunkle Nemesis",
         "esES": "Némesis Oscura",
         "frFR": "Dark Nemesis",
@@ -32915,7 +32915,7 @@
         "id": 50400,
         "Key": "Devil's Invocation",
         "enUS": "Devil's Invocation",
-        "zhTW": "魔鬼的祈禱",
+        "zhTW": "魔鬼的召唤",
         "deDE": "Beschwörung des Teufels",
         "esES": "Invocación del Diablo",
         "frFR": "Invocation du diable",
@@ -32926,13 +32926,13 @@
         "jaJP": "悪魔の召喚",
         "ptBR": "Invocação do Diabo",
         "ruRU": "Призыв дьявола",
-        "zhCN": "魔鬼的祈祷"
+        "zhCN": "魔鬼的召唤"
     },
     {
         "id": 50401,
         "Key": "Doom Hedge",
         "enUS": "Doom Hedge",
-        "zhTW": "末日界限",
+        "zhTW": "末日对冲",
         "deDE": "Schicksalshecke",
         "esES": "Doom Hedge",
         "frFR": "Haie du malheur",
@@ -32943,13 +32943,13 @@
         "jaJP": "ドゥーム・ヘッジ",
         "ptBR": "Cerca Condenada",
         "ruRU": "Doom Hedge",
-        "zhCN": "末日界限"
+        "zhCN": "末日对冲"
     },
     {
         "id": 50402,
         "Key": "Doom's Mirror",
         "enUS": "Doom's Mirror",
-        "zhTW": "厄運之鏡",
+        "zhTW": "厄运之镜",
         "deDE": "Der Spiegel des Schicksals",
         "esES": "Espejo de Doom",
         "frFR": "Le miroir de Doom",
@@ -32966,7 +32966,7 @@
         "id": 50403,
         "Key": "Doubtraiser",
         "enUS": "Doubtraiser",
-        "zhTW": "質疑者",
+        "zhTW": "怀疑者",
         "deDE": "Doubtraiser",
         "esES": "Doubtraiser",
         "frFR": "Doubtraiser",
@@ -32977,13 +32977,13 @@
         "jaJP": "ダウトレイザー",
         "ptBR": "Levantar Duvidas",
         "ruRU": "Doubtraiser",
-        "zhCN": "质疑者"
+        "zhCN": "怀疑者"
     },
     {
         "id": 50404,
         "Key": "Dreadfury",
         "enUS": "Dreadfury",
-        "zhTW": "驚怒",
+        "zhTW": "恐惧之怒",
         "deDE": "Dreadfury",
         "esES": "Dreadfury",
         "frFR": "Fureur de vivre",
@@ -32994,13 +32994,13 @@
         "jaJP": "ドレッドフューリー",
         "ptBR": "Furia e Medo",
         "ruRU": "Дредфури",
-        "zhCN": "惊怒"
+        "zhCN": "恐惧之怒"
     },
     {
         "id": 50405,
         "Key": "Deepwander",
         "enUS": "Deepwander",
-        "zhTW": "幽深漫步者",
+        "zhTW": "深海漫步",
         "deDE": "Tiefenwanderung",
         "esES": "Deepwander",
         "frFR": "Le vagabondage en profondeur",
@@ -33011,13 +33011,13 @@
         "jaJP": "ディープワンダー",
         "ptBR": "Vagar Profundamente",
         "ruRU": "Deepwander",
-        "zhCN": "幽深漫步者"
+        "zhCN": "深海漫步"
     },
     {
         "id": 50406,
         "Key": "Drunken Fury",
         "enUS": "Drunken Fury",
-        "zhTW": "怒如酣醉",
+        "zhTW": "醉酒的愤怒",
         "deDE": "Drunken Fury",
         "esES": "Furia ebria",
         "frFR": "Fureur ivre",
@@ -33028,13 +33028,13 @@
         "jaJP": "酔っぱらいの怒り",
         "ptBR": "Fúria Bêbada",
         "ruRU": "Пьяная ярость",
-        "zhCN": "怒如酣醉"
+        "zhCN": "醉酒的愤怒"
     },
     {
         "id": 50407,
         "Key": "Duskwreath",
         "enUS": "Duskwreath",
-        "zhTW": "黃昏花環",
+        "zhTW": "黄昏花环",
         "deDE": "Dämmerschoppen",
         "esES": "Corona crepuscular",
         "frFR": "Couronne crépusculaire",
@@ -33051,7 +33051,7 @@
         "id": 50408,
         "Key": "Easebringer",
         "enUS": "Easebringer",
-        "zhTW": "安和引者",
+        "zhTW": "Easebringer",
         "deDE": "Easebringer",
         "esES": "Easebringer",
         "frFR": "Easebringer",
@@ -33062,13 +33062,13 @@
         "jaJP": "イーズブリンガー",
         "ptBR": "Trazer Facilidade",
         "ruRU": "Easebringer",
-        "zhCN": "安和引者"
+        "zhCN": "Easebringer"
     },
     {
         "id": 50409,
         "Key": "Elflord's Victory",
         "enUS": "Elflord's Victory",
-        "zhTW": "艾爾弗雷德的勝利",
+        "zhTW": "艾尔弗雷德的胜利",
         "deDE": "Elflord's Sieg",
         "esES": "Victoria de Elflord",
         "frFR": "La victoire d'Elflord",
@@ -33085,7 +33085,7 @@
         "id": 50410,
         "Key": "Epoch's End",
         "enUS": "Epoch's End",
-        "zhTW": "紀元的終結",
+        "zhTW": "纪元的终结",
         "deDE": "Das Ende einer Epoche",
         "esES": "Fin de época",
         "frFR": "Fin d'époque",
@@ -33102,7 +33102,7 @@
         "id": 50411,
         "Key": "Everkeeper",
         "enUS": "Everkeeper",
-        "zhTW": "守恆者",
+        "zhTW": "恒守者",
         "deDE": "Everkeeper",
         "esES": "Everkeeper",
         "frFR": "Gardien de l'éternité",
@@ -33113,13 +33113,13 @@
         "jaJP": "エバーキーパー",
         "ptBR": "Eterno Guardião",
         "ruRU": "Everkeeper",
-        "zhCN": "守恒者"
+        "zhCN": "恒守者"
     },
     {
         "id": 50412,
         "Key": "Fair Weather",
         "enUS": "Fair Weather",
-        "zhTW": "天氣晴好",
+        "zhTW": "天气晴好",
         "deDE": "Schönes Wetter",
         "esES": "Buen tiempo",
         "frFR": "Beau temps",
@@ -33136,7 +33136,7 @@
         "id": 50413,
         "Key": "Fellowship's Hope",
         "enUS": "Fellowship's Hope",
-        "zhTW": "團隊的希望",
+        "zhTW": "团契的希望",
         "deDE": "Die Hoffnung der Gemeinschaft",
         "esES": "La esperanza de la confraternidad",
         "frFR": "L'espoir de la fraternité",
@@ -33147,13 +33147,13 @@
         "jaJP": "フェローシップの希望",
         "ptBR": "Amizade Esperada",
         "ruRU": "Надежда братства",
-        "zhCN": "团队的希望"
+        "zhCN": "团契的希望"
     },
     {
         "id": 50414,
         "Key": "Foul Sigil",
         "enUS": "Foul Sigil",
-        "zhTW": "違規徽章",
+        "zhTW": "犯规徽章",
         "deDE": "Verdorbenes Siegel",
         "esES": "Foul Sigil",
         "frFR": "Sigle de la Faute",
@@ -33164,13 +33164,13 @@
         "jaJP": "反則の紋章",
         "ptBR": "Falta Sigilo",
         "ruRU": "Неистовый знак",
-        "zhCN": "违规徽章"
+        "zhCN": "犯规徽章"
     },
     {
         "id": 50415,
         "Key": "Frostshiver",
         "enUS": "Frostshiver",
-        "zhTW": "霜顫",
+        "zhTW": "霜寒",
         "deDE": "Frostschauer",
         "esES": "Frostshiver",
         "frFR": "Frostshiver",
@@ -33181,13 +33181,13 @@
         "jaJP": "フロストシバー",
         "ptBR": "Geada Arrepiante",
         "ruRU": "Frostshiver",
-        "zhCN": "霜颤"
+        "zhCN": "霜寒"
     },
     {
         "id": 50416,
         "Key": "Full Suffering",
         "enUS": "Full Suffering",
-        "zhTW": "深度苦痛",
+        "zhTW": "充分受苦",
         "deDE": "Voller Leidensdruck",
         "esES": "Sufrimiento pleno",
         "frFR": "Souffrance totale",
@@ -33198,13 +33198,13 @@
         "jaJP": "完全な苦しみ",
         "ptBR": "Sofrer Por Completo",
         "ruRU": "Полное страдание",
-        "zhCN": "深度苦痛"
+        "zhCN": "充分受苦"
     },
     {
         "id": 50417,
         "Key": "Gainsayer",
         "enUS": "Gainsayer",
-        "zhTW": "否認者",
+        "zhTW": "收益者",
         "deDE": "Gainsayer",
         "esES": "Gainsayer",
         "frFR": "Gainsayer",
@@ -33215,13 +33215,13 @@
         "jaJP": "ゲイナー",
         "ptBR": "Ditadura Ganhada",
         "ruRU": "Gainsayer",
-        "zhCN": "否认者"
+        "zhCN": "收益者"
     },
     {
         "id": 50418,
         "Key": "Gatecleaver",
         "enUS": "Gatecleaver",
-        "zhTW": "破門斧",
+        "zhTW": "Gatecleaver",
         "deDE": "Gatecleaver",
         "esES": "Gatecleaver",
         "frFR": "Tisseur de portes",
@@ -33232,13 +33232,13 @@
         "jaJP": "ゲートクリーバー",
         "ptBR": "Portão Cortado",
         "ruRU": "Gatecleaver",
-        "zhCN": "破门斧"
+        "zhCN": "Gatecleaver"
     },
     {
         "id": 50419,
         "Key": "Ghoulslayer",
         "enUS": "Ghoulslayer",
-        "zhTW": "屠鬼者",
+        "zhTW": "食尸鬼",
         "deDE": "Ghoulslayer",
         "esES": "Ghoulslayer",
         "frFR": "Coucheuse de goules",
@@ -33249,7 +33249,7 @@
         "jaJP": "グールスレイヤー",
         "ptBR": "Matador de Vampiro",
         "ruRU": "Вурдалак",
-        "zhCN": "屠鬼者"
+        "zhCN": "食尸鬼"
     },
     {
         "id": 50420,
@@ -33272,7 +33272,7 @@
         "id": 50421,
         "Key": "Grandmaster's Glory",
         "enUS": "Grandmaster's Glory",
-        "zhTW": "大師的榮耀",
+        "zhTW": "大师的荣耀",
         "deDE": "Großmeisterlicher Ruhm",
         "esES": "Gloria del Gran Maestro",
         "frFR": "La gloire du grand maître",
@@ -33289,7 +33289,7 @@
         "id": 50422,
         "Key": "Groundshatter",
         "enUS": "Groundshatter",
-        "zhTW": "地面碎裂者",
+        "zhTW": "地面碎裂",
         "deDE": "Groundshatter",
         "esES": "Rompetierra",
         "frFR": "Éclats de terre",
@@ -33300,13 +33300,13 @@
         "jaJP": "グラウンドシャッター",
         "ptBR": "Britadeira",
         "ruRU": "Осколки земли",
-        "zhCN": "地面碎裂者"
+        "zhCN": "地面碎裂"
     },
     {
         "id": 50423,
         "Key": "Harper's Call",
         "enUS": "Harper's Call",
-        "zhTW": "哈珀之呼",
+        "zhTW": "哈珀的呼声",
         "deDE": "Harper's Call",
         "esES": "Llamada de Harper",
         "frFR": "Appel de Harper",
@@ -33317,7 +33317,7 @@
         "jaJP": "ハーパーズコール",
         "ptBR": "Chamado de Harper",
         "ruRU": "Зов Харпера",
-        "zhCN": "哈珀之呼"
+        "zhCN": "哈珀的呼声"
     },
     {
         "id": 50424,
@@ -33340,7 +33340,7 @@
         "id": 50425,
         "Key": "Heaven's Treasure",
         "enUS": "Heaven's Treasure",
-        "zhTW": "天堂的寶藏",
+        "zhTW": "天堂的宝藏",
         "deDE": "Der Schatz des Himmels",
         "esES": "El tesoro del cielo",
         "frFR": "Le trésor du ciel",
@@ -33357,7 +33357,7 @@
         "id": 50426,
         "Key": "Hecuba's Tresses",
         "enUS": "Hecuba's Tresses",
-        "zhTW": "赫庫芭的長髮",
+        "zhTW": "赫库芭的发饰",
         "deDE": "Hekubas Locken",
         "esES": "Trenzas de Hécuba",
         "frFR": "Tresses d'Hécube",
@@ -33368,13 +33368,13 @@
         "jaJP": "ヘクバのトレス",
         "ptBR": "Tranças de Hécuba",
         "ruRU": "Локоны Гекубы",
-        "zhCN": "赫库芭的长发"
+        "zhCN": "赫库芭的发饰"
     },
     {
         "id": 50427,
         "Key": "Hellshifter",
         "enUS": "Hellshifter",
-        "zhTW": "地獄變色龍",
+        "zhTW": "地狱变色龙",
         "deDE": "Hellshifter",
         "esES": "Hellshifter",
         "frFR": "Le métamorphe de l'enfer",
@@ -33408,7 +33408,7 @@
         "id": 50429,
         "Key": "Iceweaver",
         "enUS": "Iceweaver",
-        "zhTW": "織冰者",
+        "zhTW": "织冰者",
         "deDE": "Eisweber",
         "esES": "Tejedor de hielo",
         "frFR": "Tisseur de glace",
@@ -33425,7 +33425,7 @@
         "id": 50430,
         "Key": "Insight of the Ancients",
         "enUS": "Insight of the Ancients",
-        "zhTW": "遠古之洞察",
+        "zhTW": "古人的洞察力",
         "deDE": "Einsicht der Antiker",
         "esES": "La visión de los antiguos",
         "frFR": "Le regard des anciens",
@@ -33436,7 +33436,7 @@
         "jaJP": "古代人の洞察",
         "ptBR": "Conhecimento Ancestral",
         "ruRU": "Озарение древних",
-        "zhCN": "远古之洞察"
+        "zhCN": "古人的洞察力"
     },
     {
         "id": 50431,
@@ -33459,7 +33459,7 @@
         "id": 50432,
         "Key": "Hungerpang",
         "enUS": "Hungerpang",
-        "zhTW": "飢餓之痛",
+        "zhTW": "Hungerpang",
         "deDE": "Hungerpang",
         "esES": "Hungerpang",
         "frFR": "Hungerpang",
@@ -33470,13 +33470,13 @@
         "jaJP": "ハンガーパング",
         "ptBR": "Gastrite Nervosa",
         "ruRU": "Хунгерпанг",
-        "zhCN": "饥饿之痛"
+        "zhCN": "Hungerpang"
     },
     {
         "id": 50433,
         "Key": "Hushmaker",
         "enUS": "Hushmaker",
-        "zhTW": "製帽匠",
+        "zhTW": "Hushmaker",
         "deDE": "Hushmaker",
         "esES": "Hushmaker",
         "frFR": "Hushmaker",
@@ -33487,7 +33487,7 @@
         "jaJP": "ハッシュメーカー",
         "ptBR": "Fabricante Silêncioso",
         "ruRU": "Hushmaker",
-        "zhCN": "制帽匠"
+        "zhCN": "Hushmaker"
     },
     {
         "id": 50434,
@@ -33510,7 +33510,7 @@
         "id": 50435,
         "Key": "Jouster's Boast",
         "enUS": "Jouster's Boast",
-        "zhTW": "角斗士的豪言",
+        "zhTW": "角斗士的豪言壮语",
         "deDE": "Prahlerei des Jockeys",
         "esES": "Alarde de jinete",
         "frFR": "La vantardise du jouteur",
@@ -33521,13 +33521,13 @@
         "jaJP": "ジョースター自慢",
         "ptBR": "Jouster Ostentador",
         "ruRU": "Хвастовство джустера",
-        "zhCN": "角斗士的豪言"
+        "zhCN": "角斗士的豪言壮语"
     },
     {
         "id": 50436,
         "Key": "Killer's Watch",
         "enUS": "Killer's Watch",
-        "zhTW": "殺手的守望",
+        "zhTW": "杀手的手表",
         "deDE": "Killer's Watch",
         "esES": "Reloj del asesino",
         "frFR": "La montre du tueur",
@@ -33538,13 +33538,13 @@
         "jaJP": "キラーズ・ウォッチ",
         "ptBR": "Ver o Assasino",
         "ruRU": "Часы убийцы",
-        "zhCN": "杀手的守望"
+        "zhCN": "杀手的手表"
     },
     {
         "id": 50437,
         "Key": "Lashfire",
         "enUS": "Lashfire",
-        "zhTW": "鞭笞如火",
+        "zhTW": "睫火",
         "deDE": "Lashfire",
         "esES": "Lashfire",
         "frFR": "Lashfire",
@@ -33555,13 +33555,13 @@
         "jaJP": "ラッシュファイア",
         "ptBR": "Fogo Chicote",
         "ruRU": "Лашфайр",
-        "zhCN": "鞭笞如火"
+        "zhCN": "睫火"
     },
     {
         "id": 50438,
         "Key": "Lichward",
         "enUS": "Lichward",
-        "zhTW": "巫妖魂盒",
+        "zhTW": "Lichward",
         "deDE": "Lichward",
         "esES": "Lichward",
         "frFR": "Lichward",
@@ -33572,13 +33572,13 @@
         "jaJP": "リヒワード",
         "ptBR": "Enfermeira Líquen",
         "ruRU": "Личвард",
-        "zhCN": "巫妖魂盒"
+        "zhCN": "Lichward"
     },
     {
         "id": 50439,
         "Key": "Lilt of the Dryad",
         "enUS": "Lilt of the Dryad",
-        "zhTW": "林中女仙的歡唱",
+        "zhTW": "干尸之歌",
         "deDE": "Die Melodie der Dryade",
         "esES": "Lilt de la dríada",
         "frFR": "Lilt de la dryade",
@@ -33589,13 +33589,13 @@
         "jaJP": "リルト・オブ・ザ・ドライアド",
         "ptBR": "Melodia da Dríade",
         "ruRU": "Lilt of the Dryad",
-        "zhCN": "林中女仙的欢唱"
+        "zhCN": "干尸之歌"
     },
     {
         "id": 50440,
         "Key": "Long Suffering",
         "enUS": "Long Suffering",
-        "zhTW": "持久苦痛",
+        "zhTW": "长期痛苦",
         "deDE": "Langes Leiden",
         "esES": "Largo sufrimiento",
         "frFR": "Longues souffrances",
@@ -33606,7 +33606,7 @@
         "jaJP": "長い苦しみ",
         "ptBR": "Sofrimento Longo",
         "ruRU": "Долгие страдания",
-        "zhCN": "持久苦痛"
+        "zhCN": "长期痛苦"
     },
     {
         "id": 50441,
@@ -33629,7 +33629,7 @@
         "id": 50442,
         "Key": "Madman's Bluster",
         "enUS": "Madman's Bluster",
-        "zhTW": "疯子的咆哮",
+        "zhTW": "疯子的虚张声势",
         "deDE": "Schimpfwort des Verrückten",
         "esES": "Las bravatas del loco",
         "frFR": "L'esbroufe du fou",
@@ -33640,13 +33640,13 @@
         "jaJP": "マッドマンの威勢",
         "ptBR": "Homen Louco Barulhento",
         "ruRU": "Блеск безумца",
-        "zhCN": "疯子的咆哮"
+        "zhCN": "疯子的虚张声势"
     },
     {
         "id": 50443,
         "Key": "Malefactor's Reward",
         "enUS": "Malefactor's Reward",
-        "zhTW": "惡徒的回報",
+        "zhTW": "歹徒的奖赏",
         "deDE": "Die Belohnung des Übeltäters",
         "esES": "Recompensa del malhechor",
         "frFR": "Récompense du malfaiteur",
@@ -33657,13 +33657,13 @@
         "jaJP": "マレファクターの報酬",
         "ptBR": "Malfeitor Recompensado",
         "ruRU": "Награда злоумышленника",
-        "zhCN": "恶徒的回报"
+        "zhCN": "歹徒的奖赏"
     },
     {
         "id": 50444,
         "Key": "Morning After",
         "enUS": "Morning After",
-        "zhTW": "晨午之間",
+        "zhTW": "早晨之后",
         "deDE": "Der Morgen danach",
         "esES": "El día después",
         "frFR": "Le lendemain matin",
@@ -33674,13 +33674,13 @@
         "jaJP": "モーニング・アフター",
         "ptBR": "Depois De Manha",
         "ruRU": "Утро после",
-        "zhCN": "晨午之间"
+        "zhCN": "早晨之后"
     },
     {
         "id": 50445,
         "Key": "Nightwrath",
         "enUS": "Nightwrath",
-        "zhTW": "夜之怒吼",
+        "zhTW": "Nightwrath",
         "deDE": "Nightwrath",
         "esES": "Nightwrath",
         "frFR": "Courroux nocturne",
@@ -33691,13 +33691,13 @@
         "jaJP": "ナイトラス",
         "ptBR": "Ira Ao Anoitecer",
         "ruRU": "Nightwrath",
-        "zhCN": "夜之怒吼"
+        "zhCN": "Nightwrath"
     },
     {
         "id": 50446,
         "Key": "Nullwand",
         "enUS": "Nullwand",
-        "zhTW": "虛空法杖",
+        "zhTW": "零墙",
         "deDE": "Nullwand",
         "esES": "Pared cero",
         "frFR": "Mur zéro",
@@ -33708,13 +33708,13 @@
         "jaJP": "ゼロの壁",
         "ptBR": "Varinha Nula",
         "ruRU": "Нулевая стена",
-        "zhCN": "虚空法杖"
+        "zhCN": "零墙"
     },
     {
         "id": 50447,
         "Key": "Ocean's Embrace",
         "enUS": "Ocean's Embrace",
-        "zhTW": "海洋之擁",
+        "zhTW": "海洋的拥抱",
         "deDE": "Die Umarmung des Ozeans",
         "esES": "El abrazo del océano",
         "frFR": "L'étreinte de l'océan",
@@ -33725,13 +33725,13 @@
         "jaJP": "オーシャンズ・エンブレイス",
         "ptBR": "Oceano Abraçado",
         "ruRU": "Объятия океана",
-        "zhCN": "海洋之拥"
+        "zhCN": "海洋的拥抱"
     },
     {
         "id": 50448,
         "Key": "Nameweaver",
         "enUS": "Nameweaver",
-        "zhTW": "織名者",
+        "zhTW": "Nameweaver",
         "deDE": "Nameweaver",
         "esES": "Nameweaver",
         "frFR": "Tisseur de noms",
@@ -33742,13 +33742,13 @@
         "jaJP": "ネームウィーバー",
         "ptBR": "Tecelão Nomeado",
         "ruRU": "Nameweaver",
-        "zhCN": "织名者"
+        "zhCN": "Nameweaver"
     },
     {
         "id": 50449,
         "Key": "Lie Spreader",
         "enUS": "Lie Spreader",
-        "zhTW": "擴謊者",
+        "zhTW": "扩谎器",
         "deDE": "Lie Spreader",
         "esES": "Esparcidor de mentiras",
         "frFR": "Lie Spreader",
@@ -33759,7 +33759,7 @@
         "jaJP": "ライ・スプレッダー",
         "ptBR": "Espalhador de Mentiras",
         "ruRU": "Распространитель лжи",
-        "zhCN": "扩谎者"
+        "zhCN": "扩谎器"
     },
     {
         "id": 50450,
@@ -33782,7 +33782,7 @@
         "id": 50451,
         "Key": "Oracle's Riddle",
         "enUS": "Oracle's Riddle",
-        "zhTW": "神諭之謎",
+        "zhTW": "神谕之谜",
         "deDE": "Das Rätsel des Orakels",
         "esES": "El enigma del oráculo",
         "frFR": "L'énigme de l'Oracle",
@@ -33799,7 +33799,7 @@
         "id": 50452,
         "Key": "Paingiver",
         "enUS": "Paingiver",
-        "zhTW": "造痛者",
+        "zhTW": "Paingiver",
         "deDE": "Paingiver",
         "esES": "Paingiver",
         "frFR": "Paingiver",
@@ -33810,13 +33810,13 @@
         "jaJP": "ペインギバー",
         "ptBR": "Sadomasoquismo",
         "ruRU": "Паингивер",
-        "zhCN": "造痛者"
+        "zhCN": "Paingiver"
     },
     {
         "id": 50453,
         "Key": "Pandemonium",
         "enUS": "Pandemonium",
-        "zhTW": "騷動",
+        "zhTW": "大闹天宫",
         "deDE": "Pandemonium",
         "esES": "Pandemonium",
         "frFR": "Pandemonium",
@@ -33827,13 +33827,13 @@
         "jaJP": "パンデモニウム",
         "ptBR": "Pandemônio",
         "ruRU": "Пандемониум",
-        "zhCN": "骚动"
+        "zhCN": "大闹天宫"
     },
     {
         "id": 50454,
         "Key": "Panic of Thousands",
         "enUS": "Panic of Thousands",
-        "zhTW": "極度恐慌",
+        "zhTW": "千人恐慌",
         "deDE": "Panik der Tausenden",
         "esES": "Pánico de miles",
         "frFR": "La panique des milliers",
@@ -33844,13 +33844,13 @@
         "jaJP": "数千人のパニック",
         "ptBR": "Pânico de Milhares",
         "ruRU": "Многотысячная паника",
-        "zhCN": "极度恐慌"
+        "zhCN": "千人恐慌"
     },
     {
         "id": 50455,
         "Key": "Phoenix Fall",
         "enUS": "Phoenix Fall",
-        "zhTW": "鳳凰之墜",
+        "zhTW": "凤凰坠落",
         "deDE": "Phoenix Fall",
         "esES": "Phoenix Fall",
         "frFR": "Phoenix Fall",
@@ -33861,13 +33861,13 @@
         "jaJP": "フェニックスの秋",
         "ptBR": "Fenix Caido",
         "ruRU": "Падение Феникса",
-        "zhCN": "凤凰之坠"
+        "zhCN": "凤凰坠落"
     },
     {
         "id": 50456,
         "Key": "Pitykiller",
         "enUS": "Pitykiller",
-        "zhTW": "恥辱殺手",
+        "zhTW": "耻辱杀手",
         "deDE": "Schandfleck-Killer",
         "esES": "Asesino de la vergüenza",
         "frFR": "Tueur de la honte",
@@ -33884,7 +33884,7 @@
         "id": 50457,
         "Key": "Pleasures of the Perverse",
         "enUS": "Pleasures of the Perverse",
-        "zhTW": "反常之樂",
+        "zhTW": "反常的乐趣",
         "deDE": "Das Vergnügen des Perversen",
         "esES": "Los placeres de lo perverso",
         "frFR": "Les plaisirs de la perversité",
@@ -33895,13 +33895,13 @@
         "jaJP": "倒錯の快楽",
         "ptBR": "Prazer Perverso",
         "ruRU": "Удовольствия извращенцев",
-        "zhCN": "反常之乐"
+        "zhCN": "反常的乐趣"
     },
     {
         "id": 50458,
         "Key": "Prancing Pike",
         "enUS": "Prancing Pike",
-        "zhTW": "騰躍長槍",
+        "zhTW": "奔跑的梭子鱼",
         "deDE": "Tölpelhecht",
         "esES": "Lucio Rampante",
         "frFR": "Le brochet cabré",
@@ -33912,13 +33912,13 @@
         "jaJP": "プランシング・パイク",
         "ptBR": "Pique Empinado",
         "ruRU": "Шаловливая щука",
-        "zhCN": "腾跃长枪"
+        "zhCN": "奔跑的梭子鱼"
     },
     {
         "id": 50459,
         "Key": "Pride's Paradox",
         "enUS": "Pride's Paradox",
-        "zhTW": "驕傲的悖論",
+        "zhTW": "骄傲的悖论",
         "deDE": "Das Paradox des Stolzes",
         "esES": "La paradoja del orgullo",
         "frFR": "Le paradoxe de l'orgueil",
@@ -33935,7 +33935,7 @@
         "id": 50460,
         "Key": "Pull of Darkness",
         "enUS": "Pull of Darkness",
-        "zhTW": "黑暗的牽引",
+        "zhTW": "黑暗的拉力",
         "deDE": "Sog der Dunkelheit",
         "esES": "La fuerza de la oscuridad",
         "frFR": "L'attraction des ténèbres",
@@ -33946,7 +33946,7 @@
         "jaJP": "闇の引力",
         "ptBR": "Trevas Me Chama",
         "ruRU": "Тяга к темноте",
-        "zhCN": "黑暗的牵引"
+        "zhCN": "黑暗的拉力"
     },
     {
         "id": 50461,
@@ -33969,7 +33969,7 @@
         "id": 50462,
         "Key": "Queasespreader",
         "enUS": "Queasespreader",
-        "zhTW": "壓榨散佈者",
+        "zhTW": "Queasespreader",
         "deDE": "Queasespreader",
         "esES": "Esparcidor de colas",
         "frFR": "Répandeur de files d'attente",
@@ -33980,13 +33980,13 @@
         "jaJP": "クイーンズスプレッダー",
         "ptBR": "Espalhador de Quease",
         "ruRU": "Queasespreader",
-        "zhCN": "压榨散布者"
+        "zhCN": "Queasespreader"
     },
     {
         "id": 50463,
         "Key": "Rapturous Blessings",
         "enUS": "Rapturous Blessings",
-        "zhTW": "狂喜之祝福",
+        "zhTW": "狂喜的祝福",
         "deDE": "Entrückte Segnungen",
         "esES": "Rapturous Blessings",
         "frFR": "Bénédictions rapides",
@@ -33997,13 +33997,13 @@
         "jaJP": "ラプチャーな祝福",
         "ptBR": "Bênças Arrebatadas",
         "ruRU": "Восторженные благословения",
-        "zhCN": "狂喜之祝福"
+        "zhCN": "狂喜的祝福"
     },
     {
         "id": 50464,
         "Key": "Ravings of the Mad",
         "enUS": "Ravings of the Mad",
-        "zhTW": "瘋人瘋語",
+        "zhTW": "疯狂的咆哮",
         "deDE": "Die Tiraden der Verrückten",
         "esES": "Los desvaríos de los locos",
         "frFR": "Ravages de la folie",
@@ -34014,13 +34014,13 @@
         "jaJP": "狂気の沙汰",
         "ptBR": "Louco Delírado",
         "ruRU": "Размышления безумца",
-        "zhCN": "疯人疯语"
+        "zhCN": "疯狂的咆哮"
     },
     {
         "id": 50465,
         "Key": "Revoker",
         "enUS": "Revoker",
-        "zhTW": "翻轉者",
+        "zhTW": "翻转者",
         "deDE": "Revoker",
         "esES": "Revoker",
         "frFR": "Révocateur",
@@ -34037,7 +34037,7 @@
         "id": 50466,
         "Key": "Road to Perdition",
         "enUS": "Road to Perdition",
-        "zhTW": "墮獄之路",
+        "zhTW": "通往灭亡之路",
         "deDE": "Straße zur Verdammnis",
         "esES": "Camino a la perdición",
         "frFR": "La route de la perdition",
@@ -34048,13 +34048,13 @@
         "jaJP": "ロード・トゥ・パーディション",
         "ptBR": "Estrada Para o Pecado",
         "ruRU": "Дорога в погибель",
-        "zhCN": "堕狱之路"
+        "zhCN": "通往灭亡之路"
     },
     {
         "id": 50467,
         "Key": "Ruby Dawn",
         "enUS": "Ruby Dawn",
-        "zhTW": "深紅黎明",
+        "zhTW": "红宝石黎明",
         "deDE": "Rubindämmerung",
         "esES": "Amanecer de Rubí",
         "frFR": "Aube rubis",
@@ -34065,7 +34065,7 @@
         "jaJP": "ルビー・ドーン",
         "ptBR": "Rubi Despontado",
         "ruRU": "Рубиновый рассвет",
-        "zhCN": "深红黎明"
+        "zhCN": "红宝石黎明"
     },
     {
         "id": 50468,
@@ -34088,7 +34088,7 @@
         "id": 50469,
         "Key": "Serendipity",
         "enUS": "Serendipity",
-        "zhTW": "機緣",
+        "zhTW": "偶然性",
         "deDE": "Serendipity",
         "esES": "Serendipity",
         "frFR": "Sérendipité",
@@ -34099,13 +34099,13 @@
         "jaJP": "セレンディピティ",
         "ptBR": "Caso de Pena",
         "ruRU": "Serendipity",
-        "zhCN": "机缘"
+        "zhCN": "偶然性"
     },
     {
         "id": 50470,
         "Key": "Serpent's Sharp",
         "enUS": "Serpent's Sharp",
-        "zhTW": "巨蛇之銳",
+        "zhTW": "蛇的锋利",
         "deDE": "Schlangenscharf",
         "esES": "Afilado de serpiente",
         "frFR": "Le tranchant du serpent",
@@ -34116,13 +34116,13 @@
         "jaJP": "サーペントズ・シャープ",
         "ptBR": "Serpente Afiada",
         "ruRU": "Острие змеи",
-        "zhCN": "巨蛇之锐"
+        "zhCN": "蛇的锋利"
     },
     {
         "id": 50471,
         "Key": "Song of the Damned",
         "enUS": "Song of the Damned",
-        "zhTW": "墮獄者之歌",
+        "zhTW": "被诅咒者之歌",
         "deDE": "Das Lied der Verdammten",
         "esES": "Canción de los condenados",
         "frFR": "Le chant des damnés",
@@ -34133,13 +34133,13 @@
         "jaJP": "呪われた歌",
         "ptBR": "Canção Maldita",
         "ruRU": "Песнь проклятых",
-        "zhCN": "堕狱者之歌"
+        "zhCN": "被诅咒者之歌"
     },
     {
         "id": 50472,
         "Key": "Soulgatherer",
         "enUS": "Soulgatherer",
-        "zhTW": "靈魂收集者",
+        "zhTW": "灵魂收集者",
         "deDE": "Soulgatherer",
         "esES": "Soulgatherer",
         "frFR": "Rassembleur d'âmes",
@@ -34156,7 +34156,7 @@
         "id": 50473,
         "Key": "Spellbreaker",
         "enUS": "Spellbreaker",
-        "zhTW": "法術破壞者",
+        "zhTW": "法术破坏者",
         "deDE": "Spellbreaker",
         "esES": "Rompehechizos",
         "frFR": "Briseur de sorts",
@@ -34173,7 +34173,7 @@
         "id": 50474,
         "Key": "Starbreaker",
         "enUS": "Starbreaker",
-        "zhTW": "星辰破壞者",
+        "zhTW": "星际破坏者",
         "deDE": "Sternenbrecher",
         "esES": "Starbreaker",
         "frFR": "Brise-étoiles",
@@ -34184,7 +34184,7 @@
         "jaJP": "スターブレイカー",
         "ptBR": "Estrela Quebrada",
         "ruRU": "Starbreaker",
-        "zhCN": "星辰破坏者"
+        "zhCN": "星际破坏者"
     },
     {
         "id": 50475,
@@ -34207,7 +34207,7 @@
         "id": 50476,
         "Key": "Succulent Sin",
         "enUS": "Succulent Sin",
-        "zhTW": "甜美的罪惡",
+        "zhTW": "多汁的罪恶",
         "deDE": "Succulent Sin",
         "esES": "Pecado suculento",
         "frFR": "Succulent Sin",
@@ -34218,13 +34218,13 @@
         "jaJP": "多肉植物の罪",
         "ptBR": "Pecado Suculento",
         "ruRU": "Сочный грех",
-        "zhCN": "甜美的罪恶"
+        "zhCN": "多汁的罪恶"
     },
     {
         "id": 50477,
         "Key": "Summoner's Risk",
         "enUS": "Summoner's Risk",
-        "zhTW": "召喚師的風險",
+        "zhTW": "召唤师的风险",
         "deDE": "Risiko des Beschwörers",
         "esES": "Riesgo del Invocador",
         "frFR": "Risque de l'invocateur",
@@ -34241,7 +34241,7 @@
         "id": 50478,
         "Key": "Sunderblight",
         "enUS": "Sunderblight",
-        "zhTW": "雷光枯萎",
+        "zhTW": "雷光",
         "deDE": "Sunderblight",
         "esES": "Sunderblight",
         "frFR": "La lumière du soleil",
@@ -34252,13 +34252,13 @@
         "jaJP": "サンダーブライト",
         "ptBR": "Separação Arruinada",
         "ruRU": "Сандерблайт",
-        "zhCN": "雷光枯萎"
+        "zhCN": "雷光"
     },
     {
         "id": 50479,
         "Key": "Sweet Whisper",
         "enUS": "Sweet Whisper",
-        "zhTW": "甜蜜低語",
+        "zhTW": "甜蜜低语",
         "deDE": "Süßes Flüstern",
         "esES": "Dulce susurro",
         "frFR": "Chuchotement doux",
@@ -34275,7 +34275,7 @@
         "id": 50480,
         "Key": "Terminus Rod",
         "enUS": "Terminus Rod",
-        "zhTW": "終極標杆",
+        "zhTW": "终点站杆",
         "deDE": "Endstation Stab",
         "esES": "Varilla Terminus",
         "frFR": "Tige terminale",
@@ -34286,13 +34286,13 @@
         "jaJP": "ターミナス・ロッド",
         "ptBR": "Haste Terminada",
         "ruRU": "Стержень Терминуса",
-        "zhCN": "终极标杆"
+        "zhCN": "终点站杆"
     },
     {
         "id": 50481,
         "Key": "Tonstrike",
         "enUS": "Tonstrike",
-        "zhTW": "成噸重擊",
+        "zhTW": "声音罢工",
         "deDE": "Sound Strike",
         "esES": "Golpe de sonido",
         "frFR": "Grève du son",
@@ -34303,13 +34303,13 @@
         "jaJP": "サウンドストライク",
         "ptBR": "Greve de Ton",
         "ruRU": "Звуковой удар",
-        "zhCN": "成吨重击"
+        "zhCN": "声音罢工"
     },
     {
         "id": 50482,
         "Key": "Unity of Mind",
         "enUS": "Unity of Mind",
-        "zhTW": "心靈一統",
+        "zhTW": "心灵的统一",
         "deDE": "Die Einheit des Geistes",
         "esES": "Unidad de la mente",
         "frFR": "L'unité de l'esprit",
@@ -34320,13 +34320,13 @@
         "jaJP": "心の統一",
         "ptBR": "União Mental",
         "ruRU": "Единство разума",
-        "zhCN": "心灵一统"
+        "zhCN": "心灵的统一"
     },
     {
         "id": 50483,
         "Key": "Unseeing Eye",
         "enUS": "Unseeing Eye",
-        "zhTW": "無視之眼",
+        "zhTW": "看不见的眼睛",
         "deDE": "Unseeing Eye",
         "esES": "Ojo que no ve",
         "frFR": "Unseeing Eye",
@@ -34337,13 +34337,13 @@
         "jaJP": "見えない目",
         "ptBR": "Cego dos Olhos",
         "ruRU": "Невидящий глаз",
-        "zhCN": "无视之眼"
+        "zhCN": "看不见的眼睛"
     },
     {
         "id": 50484,
         "Key": "Utterance of Power",
         "enUS": "Utterance of Power",
-        "zhTW": "權力宣言",
+        "zhTW": "权力的宣示",
         "deDE": "Machtdemonstration",
         "esES": "Expresión de poder",
         "frFR": "Déclaration de puissance",
@@ -34354,13 +34354,13 @@
         "jaJP": "力の発露",
         "ptBR": "Expressão de Poder",
         "ruRU": "Отречение от власти",
-        "zhCN": "权力宣言"
+        "zhCN": "权力的宣示"
     },
     {
         "id": 50485,
         "Key": "Validator",
         "enUS": "Validator",
-        "zhTW": "檢驗者",
+        "zhTW": "验证器",
         "deDE": "Prüfer",
         "esES": "Validador",
         "frFR": "Valideur",
@@ -34371,13 +34371,13 @@
         "jaJP": "バリデータ",
         "ptBR": "Validador",
         "ruRU": "Валидатор",
-        "zhCN": "检验者"
+        "zhCN": "验证器"
     },
     {
         "id": 50486,
         "Key": "Valorsong",
         "enUS": "Valorsong",
-        "zhTW": "英勇之歌",
+        "zhTW": "Valorsong",
         "deDE": "Valorsong",
         "esES": "Valorsong",
         "frFR": "Valorsong",
@@ -34388,13 +34388,13 @@
         "jaJP": "ヴァロルソング",
         "ptBR": "Valor da Canção",
         "ruRU": "Valorsong",
-        "zhCN": "英勇之歌"
+        "zhCN": "Valorsong"
     },
     {
         "id": 50487,
         "Key": "Vanguard",
         "enUS": "Vanguard",
-        "zhTW": "先鋒",
+        "zhTW": "先锋队",
         "deDE": "Vanguard",
         "esES": "Vanguard",
         "frFR": "Vanguard",
@@ -34405,13 +34405,13 @@
         "jaJP": "ヴァンガード",
         "ptBR": "Vanguarda",
         "ruRU": "Авангард",
-        "zhCN": "先锋"
+        "zhCN": "先锋队"
     },
     {
         "id": 50488,
         "Key": "Vengeance of the Wronged",
         "enUS": "Vengeance of the Wronged",
-        "zhTW": "蒙冤者的復仇",
+        "zhTW": "蒙冤者的复仇",
         "deDE": "Die Rache der Ungerechten",
         "esES": "La venganza de los agraviados",
         "frFR": "La vengeance de l'offensé",
@@ -34428,7 +34428,7 @@
         "id": 50489,
         "Key": "Voice of Reason",
         "enUS": "Voice of Reason",
-        "zhTW": "理性之聲",
+        "zhTW": "理性之声",
         "deDE": "Stimme der Vernunft",
         "esES": "La voz de la razón",
         "frFR": "La voix de la raison",
@@ -34445,7 +34445,7 @@
         "id": 50490,
         "Key": "Warsummoner",
         "enUS": "Warsummoner",
-        "zhTW": "戰爭召喚者",
+        "zhTW": "Warsummoner",
         "deDE": "Warsummoner",
         "esES": "Warsummoner",
         "frFR": "Warsummoner",
@@ -34456,13 +34456,13 @@
         "jaJP": "ウォーズモナー",
         "ptBR": "Invocador Guerreiro",
         "ruRU": "Варсуммонер",
-        "zhCN": "战争召唤者"
+        "zhCN": "Warsummoner"
     },
     {
         "id": 50491,
         "Key": "Wave Whipper",
         "enUS": "Wave Whipper",
-        "zhTW": "波形鞭",
+        "zhTW": "波浪鞭",
         "deDE": "Wave Whipper",
         "esES": "Wave Whipper",
         "frFR": "Fouet à vagues",
@@ -34473,13 +34473,13 @@
         "jaJP": "ウェーブ・ホイッパー",
         "ptBR": "Onda Chicotante",
         "ruRU": "Волноотбойник",
-        "zhCN": "波形鞭"
+        "zhCN": "波浪鞭"
     },
     {
         "id": 50492,
         "Key": "Weakling's Whimper",
         "enUS": "Weakling's Whimper",
-        "zhTW": "弱者的嗚咽",
+        "zhTW": "弱者的呜咽",
         "deDE": "Schwächlingswimmer",
         "esES": "El gemido del débil",
         "frFR": "Le gémissement du faible",
@@ -34496,7 +34496,7 @@
         "id": 50493,
         "Key": "Wintershock",
         "enUS": "Wintershock",
-        "zhTW": "凜冬之震",
+        "zhTW": "冬震",
         "deDE": "Winterschock",
         "esES": "Wintershock",
         "frFR": "Choc hivernal",
@@ -34507,13 +34507,13 @@
         "jaJP": "ウィンターショック",
         "ptBR": "Choque Invernal",
         "ruRU": "Зимний шок",
-        "zhCN": "凜冬之震"
+        "zhCN": "冬震"
     },
     {
         "id": 50494,
         "Key": "Wishgranter",
         "enUS": "Wishgranter",
-        "zhTW": "許願者",
+        "zhTW": "Wishgranter",
         "deDE": "Wunschgranter",
         "esES": "Wishgranter",
         "frFR": "Fantôme de vœux",
@@ -34524,7 +34524,7 @@
         "jaJP": "ウィッシュグランター",
         "ptBR": "Desejo Concedido",
         "ruRU": "Wishgranter",
-        "zhCN": "许愿者"
+        "zhCN": "Wishgranter"
     },
     {
         "id": 50495,
@@ -34547,7 +34547,7 @@
         "id": 50496,
         "Key": "Wraithwatch",
         "enUS": "Wraithwatch",
-        "zhTW": "幽靈守望",
+        "zhTW": "守望者",
         "deDE": "Wraithwatch",
         "esES": "Espectros",
         "frFR": "Veilleuse",
@@ -34558,13 +34558,13 @@
         "jaJP": "レイスウォッチ",
         "ptBR": "Fantasmas Ti Observa",
         "ruRU": "Wraithwatch",
-        "zhCN": "幽灵守望"
+        "zhCN": "守望者"
     },
     {
         "id": 50497,
         "Key": "Wraithshadow",
         "enUS": "Wraithshadow",
-        "zhTW": "幽靈陰影",
+        "zhTW": "Wraithshadow",
         "deDE": "Wraithshadow",
         "esES": "Wraithshadow",
         "frFR": "L'ombre de Wraith",
@@ -34575,13 +34575,13 @@
         "jaJP": "レイスシャドウ",
         "ptBR": "Sombra Do Espectro",
         "ruRU": "Тень Рейфа",
-        "zhCN": "幽灵阴影"
+        "zhCN": "Wraithshadow"
     },
     {
         "id": 50498,
         "Key": "Wrathshifter",
         "enUS": "Wrathshifter",
-        "zhTW": "幽靈轉移者",
+        "zhTW": "Wrathshifter",
         "deDE": "Wrathshifter",
         "esES": "Wrathshifter",
         "frFR": "Le métamorphoseur de courroux",
@@ -34592,7 +34592,7 @@
         "jaJP": "ラースシフター",
         "ptBR": "Ira Mudada",
         "ruRU": "Wrathshifter",
-        "zhCN": "幽灵转移者"
+        "zhCN": "Wrathshifter"
     },
     {
         "id": 50499,
@@ -34615,7 +34615,7 @@
         "id": 50500,
         "Key": "Zapcaster",
         "enUS": "Zapcaster",
-        "zhTW": "毀壞施法者",
+        "zhTW": "Zapcaster",
         "deDE": "Zapcaster",
         "esES": "Zapcaster",
         "frFR": "Zapcaster",
@@ -34626,13 +34626,13 @@
         "jaJP": "ザップキャスター",
         "ptBR": "Rodizío de Tiro",
         "ruRU": "Zapcaster",
-        "zhCN": "毁坏施法者"
+        "zhCN": "Zapcaster"
     },
     {
         "id": 50501,
         "Key": "Zebrastride",
         "enUS": "Zebrastride",
-        "zhTW": "斑馬步伐",
+        "zhTW": "斑马线",
         "deDE": "Zebrastride",
         "esES": "Zebrastride",
         "frFR": "Zébrides",
@@ -34643,13 +34643,13 @@
         "jaJP": "ゼブラストライド",
         "ptBR": "Passeio Zebrast",
         "ruRU": "Зебрастрид",
-        "zhCN": "斑马步伐"
+        "zhCN": "斑马线"
     },
     {
         "id": 50502,
         "Key": "Zero Effect",
         "enUS": "Zero Effect",
-        "zhTW": "零點效應",
+        "zhTW": "零效应",
         "deDE": "Null-Effekt",
         "esES": "Efecto Cero",
         "frFR": "Effet zéro",
@@ -34660,13 +34660,13 @@
         "jaJP": "ゼロ効果",
         "ptBR": "Zero Efeito",
         "ruRU": "Нулевой эффект",
-        "zhCN": "零点效应"
+        "zhCN": "零效应"
     },
     {
         "id": 50503,
         "Key": "Conspiracy of Thieves",
         "enUS": "Conspiracy of Thieves",
-        "zhTW": "盜賊的密謀",
+        "zhTW": "盗贼阴谋",
         "deDE": "Verschwörung der Diebe",
         "esES": "Conspiración de ladrones",
         "frFR": "Conspiration de voleurs",
@@ -34677,13 +34677,13 @@
         "jaJP": "泥棒たちの陰謀",
         "ptBR": "Ladrões Conspiradores",
         "ruRU": "Заговор воров",
-        "zhCN": "盗贼的密谋"
+        "zhCN": "盗贼阴谋"
     },
     {
         "id": 50504,
         "Key": "Shadowy Places",
         "enUS": "Shadowy Places",
-        "zhTW": "朦朧之地",
+        "zhTW": "朦胧的地方",
         "deDE": "Schattenhafte Orte",
         "esES": "Lugares sombríos",
         "frFR": "Lieux d'ombre",
@@ -34694,13 +34694,13 @@
         "jaJP": "影のある場所",
         "ptBR": "Lugares Sombrios",
         "ruRU": "Теневые места",
-        "zhCN": "朦胧之地"
+        "zhCN": "朦胧的地方"
     },
     {
         "id": 50505,
         "Key": "Fearsome Rumors",
         "enUS": "Fearsome Rumors",
-        "zhTW": "可怕的謠言",
+        "zhTW": "可怕的谣言",
         "deDE": "Furchterregende Gerüchte",
         "esES": "Temibles rumores",
         "frFR": "Rumeurs redoutables",
@@ -34734,7 +34734,7 @@
         "id": 50507,
         "Key": "Dark Descent",
         "enUS": "Dark Descent",
-        "zhTW": "黑暗血統",
+        "zhTW": "黑暗后裔",
         "deDE": "Dunkler Abstieg",
         "esES": "Descenso oscuro",
         "frFR": "Dark Descent",
@@ -34745,13 +34745,13 @@
         "jaJP": "ダーク・ディセント",
         "ptBR": "Descida Sombria",
         "ruRU": "Темный спуск",
-        "zhCN": "黑暗血统"
+        "zhCN": "黑暗后裔"
     },
     {
         "id": 50508,
         "Key": "Wrath of the Seraphim",
         "enUS": "Wrath of the Seraphim",
-        "zhTW": "六翼天使之怒",
+        "zhTW": "塞拉芬之怒",
         "deDE": "Zorn der Seraphim",
         "esES": "Ira de los Serafines",
         "frFR": "La colère des séraphins",
@@ -34762,7 +34762,7 @@
         "jaJP": "セラフィムの怒り",
         "ptBR": "Ira do Serafim",
         "ruRU": "Гнев серафимов",
-        "zhCN": "六翼天使之怒"
+        "zhCN": "塞拉芬之怒"
     },
     {
         "id": 50509,
@@ -34785,7 +34785,7 @@
         "id": 50510,
         "Key": "Fortress of Solitude",
         "enUS": "Fortress of Solitude",
-        "zhTW": "孤獨堡壘",
+        "zhTW": "孤独堡垒",
         "deDE": "Festung der Einsamkeit",
         "esES": "Fortaleza de la soledad",
         "frFR": "Forteresse de solitude",
@@ -34802,7 +34802,7 @@
         "id": 50511,
         "Key": "God's Word",
         "enUS": "God's Word",
-        "zhTW": "上帝之語",
+        "zhTW": "上帝的话语",
         "deDE": "Gottes Wort",
         "esES": "Palabra de Dios",
         "frFR": "La parole de Dieu",
@@ -34813,13 +34813,13 @@
         "jaJP": "神の言葉",
         "ptBR": "Palavra de Deus",
         "ruRU": "Слово Божье",
-        "zhCN": "上帝之语"
+        "zhCN": "上帝的话语"
     },
     {
         "id": 50512,
         "Key": "Faith's Promise",
         "enUS": "Faith's Promise",
-        "zhTW": "信念之諾",
+        "zhTW": "信念的承诺",
         "deDE": "Das Versprechen des Glaubens",
         "esES": "La promesa de la fe",
         "frFR": "La promesse de la foi",
@@ -34830,13 +34830,13 @@
         "jaJP": "信仰の約束",
         "ptBR": "Promessa de Fé",
         "ruRU": "Обещание Веры",
-        "zhCN": "信念之诺"
+        "zhCN": "信念的承诺"
     },
     {
         "id": 50513,
         "Key": "Mystery of Life",
         "enUS": "Mystery of Life",
-        "zhTW": "生命之秘",
+        "zhTW": "生命之谜",
         "deDE": "Das Geheimnis des Lebens",
         "esES": "El misterio de la vida",
         "frFR": "Mystère de la vie",
@@ -34847,7 +34847,7 @@
         "jaJP": "生命の神秘",
         "ptBR": "Mistérios da Vida",
         "ruRU": "Тайна жизни",
-        "zhCN": "生命之秘"
+        "zhCN": "生命之谜"
     },
     {
         "id": 50514,
@@ -34870,7 +34870,7 @@
         "id": 50515,
         "Key": "Sudden Epiphany",
         "enUS": "Sudden Epiphany",
-        "zhTW": "突然的頓悟",
+        "zhTW": "突然的顿悟",
         "deDE": "Sudden Epiphany",
         "esES": "Epifanía repentina",
         "frFR": "Épiphanie soudaine",
@@ -34887,7 +34887,7 @@
         "id": 50516,
         "Key": "Burning Desire",
         "enUS": "Burning Desire",
-        "zhTW": "燃燒的欲望",
+        "zhTW": "燃烧的欲望",
         "deDE": "Brennendes Verlangen",
         "esES": "Deseo ardiente",
         "frFR": "Désir ardent",
@@ -34921,7 +34921,7 @@
         "id": 50518,
         "Key": "Frantic Distress",
         "enUS": "Frantic Distress",
-        "zhTW": "瘋狂的痛苦",
+        "zhTW": "疯狂的苦恼",
         "deDE": "Frantic Distress",
         "esES": "Angustia frenética",
         "frFR": "Détresse frénétique",
@@ -34932,13 +34932,13 @@
         "jaJP": "必死の苦悩",
         "ptBR": "Angústia Frenética",
         "ruRU": "Бешеная тревога",
-        "zhCN": "疯狂的痛苦"
+        "zhCN": "疯狂的苦恼"
     },
     {
         "id": 50519,
         "Key": "Trial by Fire",
         "enUS": "Trial by Fire",
-        "zhTW": "烈火試煉",
+        "zhTW": "烈火考验",
         "deDE": "Feuerprobe",
         "esES": "Prueba de fuego",
         "frFR": "L'épreuve du feu",
@@ -34949,7 +34949,7 @@
         "jaJP": "トライアル・バイ・ファイヤー",
         "ptBR": "Julgar com Fogo",
         "ruRU": "Испытание огнем",
-        "zhCN": "烈火试炼"
+        "zhCN": "烈火考验"
     },
     {
         "id": 50520,
@@ -34972,7 +34972,7 @@
         "id": 50521,
         "Key": "Survivor's Sonata",
         "enUS": "Survivor's Sonata",
-        "zhTW": "幸存者奏鳴曲",
+        "zhTW": "幸存者奏鸣曲",
         "deDE": "Die Sonate des Überlebenden",
         "esES": "Sonata del superviviente",
         "frFR": "Sonate du survivant",
@@ -34989,7 +34989,7 @@
         "id": 50522,
         "Key": "Braced for Battle",
         "enUS": "Braced for Battle",
-        "zhTW": "戰備就位",
+        "zhTW": "做好战斗准备",
         "deDE": "Gewappnet für die Schlacht",
         "esES": "Preparados para la batalla",
         "frFR": "Prêt pour la bataille",
@@ -35000,13 +35000,13 @@
         "jaJP": "戦闘態勢",
         "ptBR": "Suportar a Batalha",
         "ruRU": "Приготовиться к битве",
-        "zhCN": "战备就位"
+        "zhCN": "做好战斗准备"
     },
     {
         "id": 50523,
         "Key": "Threat of Retribution",
         "enUS": "Threat of Retribution",
-        "zhTW": "懲罰之脅",
+        "zhTW": "报复的威胁",
         "deDE": "Androhung von Vergeltung",
         "esES": "Amenaza de represalia",
         "frFR": "Menace de représailles",
@@ -35017,13 +35017,13 @@
         "jaJP": "報復の脅威",
         "ptBR": "Ameaça de Retribuição",
         "ruRU": "Угроза возмездия",
-        "zhCN": "惩罚之胁"
+        "zhCN": "报复的威胁"
     },
     {
         "id": 50524,
         "Key": "Vow of Revenge",
         "enUS": "Vow of Revenge",
-        "zhTW": "復仇誓言",
+        "zhTW": "复仇誓言",
         "deDE": "Schwur der Rache",
         "esES": "Voto de venganza",
         "frFR": "Vœu de vengeance",
@@ -35040,7 +35040,7 @@
         "id": 50525,
         "Key": "Wisdom of Thoth",
         "enUS": "Wisdom of Thoth",
-        "zhTW": "托特的智慧",
+        "zhTW": "托特智慧",
         "deDE": "Die Weisheit des Thoth",
         "esES": "Sabiduría de Toth",
         "frFR": "Sagesse de Thot",
@@ -35051,13 +35051,13 @@
         "jaJP": "トトの知恵",
         "ptBR": "Sabedoria de Thoth",
         "ruRU": "Мудрость Тота",
-        "zhCN": "托特的智慧"
+        "zhCN": "托特智慧"
     },
     {
         "id": 50526,
         "Key": "Light of Ra",
         "enUS": "Light of Ra",
-        "zhTW": "太陽神之光",
+        "zhTW": "魔王之光",
         "deDE": "Licht von Ra",
         "esES": "Luz de Ra",
         "frFR": "Lumière de Ra",
@@ -35068,7 +35068,7 @@
         "jaJP": "ラーの光",
         "ptBR": "Luz de Ra",
         "ruRU": "Свет Ра",
-        "zhCN": "太阳神之光"
+        "zhCN": "魔王之光"
     },
     {
         "id": 50527,
@@ -35091,7 +35091,7 @@
         "id": 50528,
         "Key": "Blessings of Osiris",
         "enUS": "Blessings of Osiris",
-        "zhTW": "奧西里斯的祝福",
+        "zhTW": "奥西里斯的祝福",
         "deDE": "Segnungen des Osiris",
         "esES": "Bendiciones de Osiris",
         "frFR": "Bénédictions d'Osiris",
@@ -35108,7 +35108,7 @@
         "id": 50529,
         "Key": "Blessed One",
         "enUS": "Blessed One",
-        "zhTW": "被祝福者",
+        "zhTW": "有福之人",
         "deDE": "Der Gesegnete",
         "esES": "Bendito",
         "frFR": "Bienheureux",
@@ -35119,13 +35119,13 @@
         "jaJP": "祝福されし者",
         "ptBR": "Abençoado",
         "ruRU": "Благословенный",
-        "zhCN": "被祝福者"
+        "zhCN": "有福之人"
     },
     {
         "id": 50530,
         "Key": "Cursed One",
         "enUS": "Cursed One",
-        "zhTW": "被詛咒者",
+        "zhTW": "被诅咒者",
         "deDE": "Der Verfluchte",
         "esES": "Maldito",
         "frFR": "Le maudit",
@@ -35142,7 +35142,7 @@
         "id": 50531,
         "Key": "Weeping at the Gate",
         "enUS": "Weeping at the Gate",
-        "zhTW": "門前哭泣",
+        "zhTW": "门前哭泣",
         "deDE": "Weinen vor dem Tor",
         "esES": "Llanto en la puerta",
         "frFR": "Pleurer à la porte",
@@ -35159,7 +35159,7 @@
         "id": 50532,
         "Key": "Death of a Thousand Cuts",
         "enUS": "Death of a Thousand Cuts",
-        "zhTW": "千刀萬剮",
+        "zhTW": "千刀万剐",
         "deDE": "Der Tod der tausend Schnitte",
         "esES": "La muerte de los mil cortes",
         "frFR": "La mort de mille coupures",
@@ -35176,7 +35176,7 @@
         "id": 50533,
         "Key": "Imperial Passion",
         "enUS": "Imperial Passion",
-        "zhTW": "帝國激情",
+        "zhTW": "帝国激情",
         "deDE": "Kaiserliche Passion",
         "esES": "Pasión imperial",
         "frFR": "Passion impériale",
@@ -35193,7 +35193,7 @@
         "id": 50534,
         "Key": "Dreams of Empire",
         "enUS": "Dreams of Empire",
-        "zhTW": "帝國之梦",
+        "zhTW": "帝国之梦",
         "deDE": "Träume vom Imperium",
         "esES": "Sueños de Imperio",
         "frFR": "Rêves d'empire",
@@ -35210,7 +35210,7 @@
         "id": 50535,
         "Key": "Fear and Loathing",
         "enUS": "Fear and Loathing",
-        "zhTW": "驚懼與憎恨",
+        "zhTW": "恐惧与厌恶",
         "deDE": "Furcht und Abscheu",
         "esES": "Miedo y asco",
         "frFR": "La peur et le dégoût",
@@ -35221,13 +35221,13 @@
         "jaJP": "恐怖と嫌悪",
         "ptBR": "Medo e Repugnância",
         "ruRU": "Страх и ненависть",
-        "zhCN": "惊惧与憎恨"
+        "zhCN": "恐惧与厌恶"
     },
     {
         "id": 50536,
         "Key": "The Quick and the Dead",
         "enUS": "The Quick and the Dead",
-        "zhTW": "敏捷與死亡",
+        "zhTW": "敏捷与死亡",
         "deDE": "Die Schnellen und die Toten",
         "esES": "Los rápidos y los muertos",
         "frFR": "Les morts et les rapides",
@@ -35244,7 +35244,7 @@
         "id": 50537,
         "Key": "Demand for Justice",
         "enUS": "Demand for Justice",
-        "zhTW": "正義之訴",
+        "zhTW": "要求伸张正义",
         "deDE": "Forderung nach Gerechtigkeit",
         "esES": "Exigencia de justicia",
         "frFR": "Demande de justice",
@@ -35255,7 +35255,7 @@
         "jaJP": "正義の要求",
         "ptBR": "Demanda por Justiça",
         "ruRU": "Требование справедливости",
-        "zhCN": "正义之诉"
+        "zhCN": "要求伸张正义"
     },
     {
         "id": 50538,
@@ -35278,7 +35278,7 @@
         "id": 50539,
         "Key": "Bane of All Gods",
         "enUS": "Bane of All Gods",
-        "zhTW": "衆神之禍",
+        "zhTW": "众神之祸",
         "deDE": "Der Fluch aller Götter",
         "esES": "La perdición de todos los dioses",
         "frFR": "Le fléau de tous les dieux",
@@ -35312,7 +35312,7 @@
         "id": 50541,
         "Key": "Patron of Perversity",
         "enUS": "Patron of Perversity",
-        "zhTW": "邪惡代言人",
+        "zhTW": "变态的守护神",
         "deDE": "Schutzpatron der Perversität",
         "esES": "Patrón de la perversidad",
         "frFR": "Patron de la perversité",
@@ -35323,7 +35323,7 @@
         "jaJP": "変態の守護神",
         "ptBR": "Patrono da Perversidade",
         "ruRU": "Покровитель извращений",
-        "zhCN": "邪恶代言人"
+        "zhCN": "变态的守护神"
     },
     {
         "id": 50542,
@@ -35346,7 +35346,7 @@
         "id": 50543,
         "Key": "Damsel of Destruction",
         "enUS": "Damsel of Destruction",
-        "zhTW": "毀滅少女",
+        "zhTW": "毁灭少女",
         "deDE": "Burgfräulein der Zerstörung",
         "esES": "La damisela de la destrucción",
         "frFR": "Damsel of Destruction",
@@ -35363,7 +35363,7 @@
         "id": 50544,
         "Key": "Askarian Grips",
         "enUS": "Askarian Grips",
-        "zhTW": "阿斯卡裏安之握",
+        "zhTW": "阿斯卡里亚握把",
         "deDE": "Askari-Griffe",
         "esES": "Puños Askarian",
         "frFR": "Poignées Askarian",
@@ -35374,13 +35374,13 @@
         "jaJP": "アスカリアン・グリップ",
         "ptBR": "Punhos Askarian",
         "ruRU": "Аскарийские рукоятки",
-        "zhCN": "阿斯卡里安之握"
+        "zhCN": "阿斯卡里亚握把"
     },
     {
         "id": 50545,
         "Key": "Sister of the Sun",
         "enUS": "Sister of the Sun",
-        "zhTW": "太阳的姊妹",
+        "zhTW": "太阳之妹",
         "deDE": "Schwester der Sonne",
         "esES": "Hermana del Sol",
         "frFR": "Sœur du soleil",
@@ -35391,13 +35391,13 @@
         "jaJP": "太陽の姉妹",
         "ptBR": "Irmã Solar",
         "ruRU": "Сестра Солнца",
-        "zhCN": "太阳的姊妹"
+        "zhCN": "太阳之妹"
     },
     {
         "id": 50546,
         "Key": "Father of Nations",
         "enUS": "Father of Nations",
-        "zhTW": "國父",
+        "zhTW": "国父",
         "deDE": "Vater der Nationen",
         "esES": "Padre de las Naciones",
         "frFR": "Père des Nations",
@@ -35448,7 +35448,7 @@
         "id": 50549,
         "Key": "Cold of Winter",
         "enUS": "Cold of Winter",
-        "zhTW": "冬寒瑟瑟",
+        "zhTW": "冬天的寒冷",
         "deDE": "Die Kälte des Winters",
         "esES": "Frío de invierno",
         "frFR": "Le froid de l'hiver",
@@ -35459,13 +35459,13 @@
         "jaJP": "冬の寒さ",
         "ptBR": "Frio do Inverno",
         "ruRU": "Холод зимы",
-        "zhCN": "冬寒瑟瑟"
+        "zhCN": "冬天的寒冷"
     },
     {
         "id": 50550,
         "Key": "Storms of Spring",
         "enUS": "Storms of Spring",
-        "zhTW": "春雷隆隆",
+        "zhTW": "春天的风暴",
         "deDE": "Frühlingsstürme",
         "esES": "Tormentas de primavera",
         "frFR": "Tempêtes de printemps",
@@ -35476,13 +35476,13 @@
         "jaJP": "春の嵐",
         "ptBR": "Tempestades de Primavera",
         "ruRU": "Весенние бури",
-        "zhCN": "春雷隆隆"
+        "zhCN": "春天的风暴"
     },
     {
         "id": 50551,
         "Key": "Sequence of Seasons",
         "enUS": "Sequence of Seasons",
-        "zhTW": "四季變換",
+        "zhTW": "季节顺序",
         "deDE": "Abfolge der Jahreszeiten",
         "esES": "Secuencia de estaciones",
         "frFR": "Séquence des saisons",
@@ -35493,13 +35493,13 @@
         "jaJP": "季節の移り変わり",
         "ptBR": "Sequência de Estações",
         "ruRU": "Последовательность времен года",
-        "zhCN": "四季变换"
+        "zhCN": "季节顺序"
     },
     {
         "id": 50552,
         "Key": "Shattered Dreams",
         "enUS": "Shattered Dreams",
-        "zhTW": "破碎的夢想",
+        "zhTW": "破碎的梦想",
         "deDE": "Zerbrochene Träume",
         "esES": "Sueños rotos",
         "frFR": "Rêves brisés",
@@ -35516,7 +35516,7 @@
         "id": 50553,
         "Key": "Call of the Wild",
         "enUS": "Call of the Wild",
-        "zhTW": "野性的呼喚",
+        "zhTW": "野性的呼唤",
         "deDE": "Der Ruf der Wildnis",
         "esES": "La llamada de lo salvaje",
         "frFR": "L'appel de la nature",
@@ -35533,7 +35533,7 @@
         "id": 50554,
         "Key": "Widow's Refrain",
         "enUS": "Widow's Refrain",
-        "zhTW": "寡婦的抱怨",
+        "zhTW": "寡妇的回旋曲",
         "deDE": "Refrain der Witwe",
         "esES": "Estribillo de la viuda",
         "frFR": "Refrain de la veuve",
@@ -35544,7 +35544,7 @@
         "jaJP": "未亡人のリフレイン",
         "ptBR": "Refrão de Viúva",
         "ruRU": "Припев Вдовы",
-        "zhCN": "寡妇的抱怨"
+        "zhCN": "寡妇的回旋曲"
     },
     {
         "id": 50555,
@@ -35567,7 +35567,7 @@
         "id": 50556,
         "Key": "Dance of the Cobra",
         "enUS": "Dance of the Cobra",
-        "zhTW": "眼鏡蛇之舞",
+        "zhTW": "眼镜蛇之舞",
         "deDE": "Tanz der Kobra",
         "esES": "Danza de la Cobra",
         "frFR": "La danse du cobra",
@@ -35584,7 +35584,7 @@
         "id": 50557,
         "Key": "Lion's Pride",
         "enUS": "Lion's Pride",
-        "zhTW": "獅子的驕傲",
+        "zhTW": "狮子的骄傲",
         "deDE": "Der Stolz des Löwen",
         "esES": "Orgullo de León",
         "frFR": "La fierté du lion",
@@ -35601,7 +35601,7 @@
         "id": 50558,
         "Key": "Leader of the Pack",
         "enUS": "Leader of the Pack",
-        "zhTW": "獸群領袖",
+        "zhTW": "领导者",
         "deDE": "Anführer des Rudels",
         "esES": "Líder de la manada",
         "frFR": "Chef de meute",
@@ -35612,13 +35612,13 @@
         "jaJP": "群れのリーダー",
         "ptBR": "Sedex e FedEx",
         "ruRU": "Вожак стаи",
-        "zhCN": "兽群领袖"
+        "zhCN": "领导者"
     },
     {
         "id": 50559,
         "Key": "Key to the Madhouse",
         "enUS": "Key to the Madhouse",
-        "zhTW": "瘋人院之鑰",
+        "zhTW": "疯人院的钥匙",
         "deDE": "Schlüssel zum Irrenhaus",
         "esES": "La llave del manicomio",
         "frFR": "La clé de la maison de fous",
@@ -35629,13 +35629,13 @@
         "jaJP": "マッドハウスの鍵",
         "ptBR": "Chave da Casa Maluca",
         "ruRU": "Ключ от сумасшедшего дома",
-        "zhCN": "疯人院之钥"
+        "zhCN": "疯人院的钥匙"
     },
     {
         "id": 50560,
         "Key": "Dark Demesne",
         "enUS": "Dark Demesne",
-        "zhTW": "黑暗地域",
+        "zhTW": "黑暗德谟斯涅",
         "deDE": "Dunkle Dämmerung",
         "esES": "Demasía Oscura",
         "frFR": "Dark Demesne",
@@ -35646,13 +35646,13 @@
         "jaJP": "ダーク・デーメスン",
         "ptBR": "Propriedade Sombria",
         "ruRU": "Темный Демесн",
-        "zhCN": "黑暗地域"
+        "zhCN": "黑暗德谟斯涅"
     },
     {
         "id": 50561,
         "Key": "Key to Hell",
         "enUS": "Key to Hell",
-        "zhTW": "地獄之鑰",
+        "zhTW": "通往地狱的钥匙",
         "deDE": "Schlüssel zur Hölle",
         "esES": "La llave del infierno",
         "frFR": "La clé de l'enfer",
@@ -35663,13 +35663,13 @@
         "jaJP": "地獄への鍵",
         "ptBR": "Chave para o Inferno",
         "ruRU": "Ключ от ада",
-        "zhCN": "地狱之钥"
+        "zhCN": "通往地狱的钥匙"
     },
     {
         "id": 50562,
         "Key": "Chains of the Abyss",
         "enUS": "Chains of the Abyss",
-        "zhTW": "深淵之鏈",
+        "zhTW": "深渊之链",
         "deDE": "Die Ketten des Abgrunds",
         "esES": "Cadenas del abismo",
         "frFR": "Les chaînes de l'abîme",
@@ -35686,7 +35686,7 @@
         "id": 50563,
         "Key": "Star of David",
         "enUS": "Star of David",
-        "zhTW": "大衛之星",
+        "zhTW": "大卫之星",
         "deDE": "Davidstern",
         "esES": "Estrella de David",
         "frFR": "Étoile de David",
@@ -35703,7 +35703,7 @@
         "id": 50564,
         "Key": "Star of Bethlehem",
         "enUS": "Star of Bethlehem",
-        "zhTW": "伯利恆之星",
+        "zhTW": "伯利恒之星",
         "deDE": "Stern von Bethlehem",
         "esES": "Estrella de Belén",
         "frFR": "Étoile de Bethléem",
@@ -35737,7 +35737,7 @@
         "id": 50566,
         "Key": "Blanket of Stars",
         "enUS": "Blanket of Stars",
-        "zhTW": "群星之氈",
+        "zhTW": "星毯",
         "deDE": "Sternendecke",
         "esES": "Manta de estrellas",
         "frFR": "Couverture d'étoiles",
@@ -35748,13 +35748,13 @@
         "jaJP": "星のブランケット",
         "ptBR": "Coberto de Estrelas",
         "ruRU": "Одеяло со звездами",
-        "zhCN": "群星之毡"
+        "zhCN": "星毯"
     },
     {
         "id": 50567,
         "Key": "Evening Sky",
         "enUS": "Evening Sky",
-        "zhTW": "夜空",
+        "zhTW": "晚霞",
         "deDE": "Abendhimmel",
         "esES": "Cielo nocturno",
         "frFR": "Ciel du soir",
@@ -35765,13 +35765,13 @@
         "jaJP": "夕方の空",
         "ptBR": "Céu Noturno",
         "ruRU": "Вечернее небо",
-        "zhCN": "夜空"
+        "zhCN": "晚霞"
     },
     {
         "id": 50568,
         "Key": "Edge of Forever",
         "enUS": "Edge of Forever",
-        "zhTW": "永恆邊緣",
+        "zhTW": "永远的边缘",
         "deDE": "Rand der Ewigkeit",
         "esES": "Al filo de la eternidad",
         "frFR": "Le bord de l'éternité",
@@ -35782,13 +35782,13 @@
         "jaJP": "エッジ・オブ・フォーエバー",
         "ptBR": "Beira Para Sempre",
         "ruRU": "Грань вечности",
-        "zhCN": "永恒边缘"
+        "zhCN": "永远的边缘"
     },
     {
         "id": 50569,
         "Key": "Pure Rancor",
         "enUS": "Pure Rancor",
-        "zhTW": "純粹的怨恨",
+        "zhTW": "纯粹的愤怒",
         "deDE": "Reiner Rancor",
         "esES": "Puro Rancor",
         "frFR": "Rancune pure",
@@ -35799,13 +35799,13 @@
         "jaJP": "ピュア・ランサー",
         "ptBR": "Puro Rancor",
         "ruRU": "Чистое разорение",
-        "zhCN": "纯粹的怨恨"
+        "zhCN": "纯粹的愤怒"
     },
     {
         "id": 50570,
         "Key": "Harvest of Souls",
         "enUS": "Harvest of Souls",
-        "zhTW": "靈魂收割",
+        "zhTW": "灵魂的收获",
         "deDE": "Ernte der Seelen",
         "esES": "Cosecha de almas",
         "frFR": "La moisson des âmes",
@@ -35816,13 +35816,13 @@
         "jaJP": "魂の収穫",
         "ptBR": "Colheita de Almas",
         "ruRU": "Жатва душ",
-        "zhCN": "灵魂收割"
+        "zhCN": "灵魂的收获"
     },
     {
         "id": 50571,
         "Key": "Usurper's Ambition",
         "enUS": "Usurper's Ambition",
-        "zhTW": "篡奪者的野心",
+        "zhTW": "篡夺者的野心",
         "deDE": "Der Ehrgeiz des Usurpators",
         "esES": "La ambición del usurpador",
         "frFR": "L'ambition de l'usurpateur",
@@ -35839,7 +35839,7 @@
         "id": 50572,
         "Key": "Gathering of Hawks",
         "enUS": "Gathering of Hawks",
-        "zhTW": "鷹聚",
+        "zhTW": "鹰的聚会",
         "deDE": "Ansammlung von Falken",
         "esES": "Reunión de halcones",
         "frFR": "Rassemblement des faucons",
@@ -35850,13 +35850,13 @@
         "jaJP": "鷹の集い",
         "ptBR": "Gaviões Coletados",
         "ruRU": "Собрание ястребов",
-        "zhCN": "鹰聚"
+        "zhCN": "鹰的聚会"
     },
     {
         "id": 50573,
         "Key": "Death to the Soul",
         "enUS": "Death to the Soul",
-        "zhTW": "魂消魄散",
+        "zhTW": "灵魂之死",
         "deDE": "Tod für die Seele",
         "esES": "Muerte del alma",
         "frFR": "La mort de l'âme",
@@ -35867,13 +35867,13 @@
         "jaJP": "魂に死を",
         "ptBR": "Alma da Morte",
         "ruRU": "Смерть для души",
-        "zhCN": "魂消魄散"
+        "zhCN": "灵魂之死"
     },
     {
         "id": 50574,
         "Key": "Prayer for the Dying",
         "enUS": "Prayer for the Dying",
-        "zhTW": "瀕死禱文",
+        "zhTW": "为临终者祈祷",
         "deDE": "Gebet für die Sterbenden",
         "esES": "Oración por los moribundos",
         "frFR": "Prière pour les mourants",
@@ -35884,13 +35884,13 @@
         "jaJP": "死にゆく人のための祈り",
         "ptBR": "Oração para a Morte",
         "ruRU": "Молитва за умирающих",
-        "zhCN": "濒死祷文"
+        "zhCN": "为临终者祈祷"
     },
     {
         "id": 50575,
         "Key": "The Four Winds",
         "enUS": "The Four Winds",
-        "zhTW": "四象來風",
+        "zhTW": "四道风",
         "deDE": "Die vier Winde",
         "esES": "Los cuatro vientos",
         "frFR": "Les quatre vents",
@@ -35901,7 +35901,7 @@
         "jaJP": "四つの風",
         "ptBR": "Os Quatro Ventos",
         "ruRU": "Четыре ветра",
-        "zhCN": "四象来风"
+        "zhCN": "四道风"
     },
     {
         "id": 50576,
@@ -35924,7 +35924,7 @@
         "id": 50577,
         "Key": "Stairway to Heaven",
         "enUS": "Stairway to Heaven",
-        "zhTW": "天堂階梯",
+        "zhTW": "通往天堂的阶梯",
         "deDE": "Die Treppe zum Himmel",
         "esES": "Escalera al cielo",
         "frFR": "L'escalier du paradis",
@@ -35935,13 +35935,13 @@
         "jaJP": "天国への階段",
         "ptBR": "Escada para o Céu",
         "ruRU": "Лестница в небеса",
-        "zhCN": "天堂阶梯"
+        "zhCN": "通往天堂的阶梯"
     },
     {
         "id": 50578,
         "Key": "Fortune's Fool",
         "enUS": "Fortune's Fool",
-        "zhTW": "財富的愚弄",
+        "zhTW": "财富的傻瓜",
         "deDE": "Der Narr des Schicksals",
         "esES": "El Loco de la Fortuna",
         "frFR": "Le fou de la fortune",
@@ -35952,13 +35952,13 @@
         "jaJP": "フォーチュンズ・フール",
         "ptBR": "Fortuna Idiota",
         "ruRU": "Дурак Фортуны",
-        "zhCN": "财富的愚弄"
+        "zhCN": "财富的傻瓜"
     },
     {
         "id": 50579,
         "Key": "Whirling Dervish",
         "enUS": "Whirling Dervish",
-        "zhTW": "旋舞的苦行僧",
+        "zhTW": "旋转的苦行僧",
         "deDE": "Wirbelnder Derwisch",
         "esES": "Derviche giratorio",
         "frFR": "Derviche Tourneur",
@@ -35969,13 +35969,13 @@
         "jaJP": "渦巻きダービッシュ",
         "ptBR": "Dervixe Giratório",
         "ruRU": "Вихревой дервиш",
-        "zhCN": "旋舞的苦行僧"
+        "zhCN": "旋转的苦行僧"
     },
     {
         "id": 50580,
         "Key": "Ranger's Path",
         "enUS": "Ranger's Path",
-        "zhTW": "游俠之路",
+        "zhTW": "游侠之路",
         "deDE": "Pfad des Waldläufers",
         "esES": "Senda del guardabosques",
         "frFR": "Le chemin du garde forestier",
@@ -35992,7 +35992,7 @@
         "id": 50581,
         "Key": "Crimson Crusade",
         "enUS": "Crimson Crusade",
-        "zhTW": "緋紅聖教军",
+        "zhTW": "深红十字军",
         "deDE": "Karminroter Kreuzzug",
         "esES": "Cruzada Carmesí",
         "frFR": "Crimson Crusade",
@@ -36003,7 +36003,7 @@
         "jaJP": "クリムゾン・クルセイド",
         "ptBR": "Cruzada Carmesim",
         "ruRU": "Багровый поход",
-        "zhCN": "绯红十字军"
+        "zhCN": "深红十字军"
     },
     {
         "id": 50582,
@@ -36026,7 +36026,7 @@
         "id": 50583,
         "Key": "The Art of War",
         "enUS": "The Art of War",
-        "zhTW": "孫子兵法",
+        "zhTW": "孙子兵法",
         "deDE": "Die Kunst des Krieges",
         "esES": "El arte de la guerra",
         "frFR": "L'art de la guerre",
@@ -36043,7 +36043,7 @@
         "id": 50584,
         "Key": "Antics of the Jester",
         "enUS": "Antics of the Jester",
-        "zhTW": "小丑的滑稽戲",
+        "zhTW": "小丑的滑稽表演",
         "deDE": "Die Possen des Narren",
         "esES": "Las travesuras del bufón",
         "frFR": "Les pitreries du bouffon",
@@ -36054,13 +36054,13 @@
         "jaJP": "ジェスターの戯れ",
         "ptBR": "Palhaço Abobalhado",
         "ruRU": "Выходки шута",
-        "zhCN": "小丑的滑稽戏"
+        "zhCN": "小丑的滑稽表演"
     },
     {
         "id": 50585,
         "Key": "Threat of Storms",
         "enUS": "Threat of Storms",
-        "zhTW": "風暴威脅",
+        "zhTW": "风暴威胁",
         "deDE": "Bedrohung durch Stürme",
         "esES": "Amenaza de tormentas",
         "frFR": "Menace de tempêtes",
@@ -36077,7 +36077,7 @@
         "id": 50586,
         "Key": "Grandiose Dreams",
         "enUS": "Grandiose Dreams",
-        "zhTW": "浮誇之夢",
+        "zhTW": "宏伟梦想",
         "deDE": "Grandiose Träume",
         "esES": "Sueños grandiosos",
         "frFR": "Rêves grandioses",
@@ -36088,13 +36088,13 @@
         "jaJP": "壮大な夢",
         "ptBR": "Sonhar Grande",
         "ruRU": "Грандиозные мечты",
-        "zhCN": "浮夸之梦"
+        "zhCN": "宏伟梦想"
     },
     {
         "id": 50587,
         "Key": "Troubled Thoughts",
         "enUS": "Troubled Thoughts",
-        "zhTW": "煩惱的思緒",
+        "zhTW": "烦恼的思绪",
         "deDE": "Beunruhigende Gedanken",
         "esES": "Pensamientos problemáticos",
         "frFR": "Pensées troubles",
@@ -36111,7 +36111,7 @@
         "id": 50588,
         "Key": "Embracing Solitude",
         "enUS": "Embracing Solitude",
-        "zhTW": "擁抱孤獨",
+        "zhTW": "拥抱孤独",
         "deDE": "Umarmung der Einsamkeit",
         "esES": "Abrazar la soledad",
         "frFR": "Embrasser la solitude",
@@ -36128,7 +36128,7 @@
         "id": 50589,
         "Key": "Scars of the Forefathers",
         "enUS": "Scars of the Forefathers",
-        "zhTW": "先輩的傷痕",
+        "zhTW": "先辈的伤痕",
         "deDE": "Die Narben der Vorväter",
         "esES": "Cicatrices de los antepasados",
         "frFR": "Les cicatrices des ancêtres",
@@ -36145,7 +36145,7 @@
         "id": 50590,
         "Key": "Mother's Milk",
         "enUS": "Mother's Milk",
-        "zhTW": "母親的乳汁",
+        "zhTW": "母亲的乳汁",
         "deDE": "Muttermilch",
         "esES": "Leche materna",
         "frFR": "Le lait maternel",
@@ -36162,7 +36162,7 @@
         "id": 50591,
         "Key": "Disparate Paths",
         "enUS": "Disparate Paths",
-        "zhTW": "不同的路徑",
+        "zhTW": "不同的路径",
         "deDE": "Getrennte Wege",
         "esES": "Caminos dispares",
         "frFR": "Des voies différentes",
@@ -36179,7 +36179,7 @@
         "id": 50592,
         "Key": "Broken Earth",
         "enUS": "Broken Earth",
-        "zhTW": "破碎的大地",
+        "zhTW": "破碎的地球",
         "deDE": "Zerbrochene Erde",
         "esES": "Tierra rota",
         "frFR": "Terre brisée",
@@ -36190,13 +36190,13 @@
         "jaJP": "ブロークン・アース",
         "ptBR": "Terra Quebrada",
         "ruRU": "Сломанная Земля",
-        "zhCN": "破碎的大地"
+        "zhCN": "破碎的地球"
     },
     {
         "id": 50593,
         "Key": "Shadazar's Answer",
         "enUS": "Shadazar's Answer",
-        "zhTW": "沙達扎爾的回答",
+        "zhTW": "沙达扎尔的回答",
         "deDE": "Shadazar's Antwort",
         "esES": "Respuesta de Shadazar",
         "frFR": "Réponse de Shadazar",
@@ -36213,7 +36213,7 @@
         "id": 50594,
         "Key": "Bloody Scalp",
         "enUS": "Bloody Scalp",
-        "zhTW": "帶血的頭皮",
+        "zhTW": "带血的头皮",
         "deDE": "Blutige Kopfhaut",
         "esES": "Cuero cabelludo ensangrentado",
         "frFR": "Cuir chevelu ensanglanté",
@@ -36230,7 +36230,7 @@
         "id": 50595,
         "Key": "Slayer of Trents",
         "enUS": "Slayer of Trents",
-        "zhTW": "特倫茨屠夫",
+        "zhTW": "特伦特杀手",
         "deDE": "Schlächter von Trents",
         "esES": "Cazador de Trentos",
         "frFR": "Tueuse de Trents",
@@ -36241,13 +36241,13 @@
         "jaJP": "トレント殺し",
         "ptBR": "Matador Tendencioso",
         "ruRU": "Истребитель Трентов",
-        "zhCN": "特伦茨屠夫"
+        "zhCN": "特伦特杀手"
     },
     {
         "id": 50596,
         "Key": "Woodland Beast",
         "enUS": "Woodland Beast",
-        "zhTW": "林地野獸",
+        "zhTW": "林地野兽",
         "deDE": "Das Waldtier",
         "esES": "Bestia del bosque",
         "frFR": "Bête des bois",
@@ -36258,13 +36258,13 @@
         "jaJP": "ウッドランド・ビースト",
         "ptBR": "Fera da Floresta",
         "ruRU": "Лесной зверь",
-        "zhCN": "林地野兽"
+        "zhCN": "森林野兽"
     },
     {
         "id": 50597,
         "Key": "Cryohydra",
         "enUS": "Cryohydra",
-        "zhTW": "寒冰九頭蛇",
+        "zhTW": "冷冻水",
         "deDE": "Cryohydra",
         "esES": "Cryohydra",
         "frFR": "Cryohydre",
@@ -36275,7 +36275,7 @@
         "jaJP": "クライオハイドラ",
         "ptBR": "Hidra de Gelo",
         "ruRU": "Криогидра",
-        "zhCN": "寒冰九头蛇"
+        "zhCN": "冷冻水"
     },
     {
         "id": 50598,
@@ -36298,7 +36298,7 @@
         "id": 50599,
         "Key": "Couatl",
         "enUS": "Couatl",
-        "zhTW": "羽蛇",
+        "zhTW": "Couatl",
         "deDE": "Couatl",
         "esES": "Couatl",
         "frFR": "Couatl",
@@ -36309,13 +36309,13 @@
         "jaJP": "クアトル",
         "ptBR": "Coach",
         "ruRU": "Куатль",
-        "zhCN": "羽蛇"
+        "zhCN": "Couatl"
     },
     {
         "id": 50600,
         "Key": "Nightcrawler",
         "enUS": "Nightcrawler",
-        "zhTW": "暗夜爬行者",
+        "zhTW": "夜行者",
         "deDE": "Nightcrawler",
         "esES": "Nightcrawler",
         "frFR": "Nightcrawler",
@@ -36326,13 +36326,13 @@
         "jaJP": "ナイトクローラー",
         "ptBR": "Réptil Noturno",
         "ruRU": "Nightcrawler",
-        "zhCN": "暗夜爬行者"
+        "zhCN": "夜行者"
     },
     {
         "id": 50601,
         "Key": "Marilith Edge",
         "enUS": "Marilith Edge",
-        "zhTW": "六臂蛇魔之緣",
+        "zhTW": "Marilith Edge",
         "deDE": "Marilith Edge",
         "esES": "Marilith Edge",
         "frFR": "Marilith Edge",
@@ -36343,7 +36343,7 @@
         "jaJP": "マリリス・エッジ",
         "ptBR": "Borda Marilith",
         "ruRU": "Мэрилит Эдж",
-        "zhCN": "六臂蛇魔之缘"
+        "zhCN": "Marilith Edge"
     },
     {
         "id": 50602,
@@ -36366,7 +36366,7 @@
         "id": 50603,
         "Key": "Beholder",
         "enUS": "Beholder",
-        "zhTW": "旁观者",
+        "zhTW": "集装箱",
         "deDE": "Container",
         "esES": "Contenedor",
         "frFR": "Conteneur",
@@ -36377,13 +36377,13 @@
         "jaJP": "コンテナ",
         "ptBR": "Recipiente",
         "ruRU": "Контейнер",
-        "zhCN": "旁观者"
+        "zhCN": "集装箱"
     },
     {
         "id": 50604,
         "Key": "Undead Beholder",
         "enUS": "Undead Beholder",
-        "zhTW": "不死旁观者",
+        "zhTW": "亡灵看守者",
         "deDE": "Untoter Betrachter",
         "esES": "Undead Beholder",
         "frFR": "Détenteur de la mort-vivante",
@@ -36394,13 +36394,13 @@
         "jaJP": "アンデッド・ビホルダー",
         "ptBR": "Zumbi Observador",
         "ruRU": "Нежить-зритель",
-        "zhCN": "不死旁观者"
+        "zhCN": "亡灵看守者"
     },
     {
         "id": 50605,
         "Key": "Frost Wyrm",
         "enUS": "Frost Wyrm",
-        "zhTW": "冰霜飛龍",
+        "zhTW": "冰霜巫妖",
         "deDE": "Frostwyrm",
         "esES": "Escarcha Wyrm",
         "frFR": "Wyrm de givre",
@@ -36411,13 +36411,13 @@
         "jaJP": "フロスト・ウィルム",
         "ptBR": "Dragão de Gelo",
         "ruRU": "Морозный Вирм",
-        "zhCN": "冰霜飞龙"
+        "zhCN": "冰霜巫妖"
     },
     {
         "id": 50606,
         "Key": "Elder Tojanida",
         "enUS": "Elder Tojanida",
-        "zhTW": "托蘭尼達長老",
+        "zhTW": "Tojanida 长老",
         "deDE": "Elder Tojanida",
         "esES": "Anciano Tojanida",
         "frFR": "Frère Tojanida",
@@ -36428,13 +36428,13 @@
         "jaJP": "トジャニダ長老",
         "ptBR": "Tartaruga Gigante Velha",
         "ruRU": "Старейшина Тоджанида",
-        "zhCN": "托兰尼达长老"
+        "zhCN": "Tojanida 长老"
     },
     {
         "id": 50607,
         "Key": "Light Phasm",
         "enUS": "Light Phasm",
-        "zhTW": "光之相位",
+        "zhTW": "光痉",
         "deDE": "Lichtphasmus",
         "esES": "Fasma ligero",
         "frFR": "Phasme léger",
@@ -36445,13 +36445,13 @@
         "jaJP": "ライト・ファズム",
         "ptBR": "Fase De Luz",
         "ruRU": "Легкий фазм",
-        "zhCN": "光之相位"
+        "zhCN": "光痉"
     },
     {
         "id": 50608,
         "Key": "Spirit Naga",
         "enUS": "Spirit Naga",
-        "zhTW": "靈體娜迦",
+        "zhTW": "精神娜迦",
         "deDE": "Spirit Naga",
         "esES": "Espíritu Naga",
         "frFR": "Spirit Naga",
@@ -36462,13 +36462,13 @@
         "jaJP": "スピリット・ナガ",
         "ptBR": "Espírito da Cobra Real",
         "ruRU": "Дух Нага",
-        "zhCN": "灵体娜迦"
+        "zhCN": "精神娜迦"
     },
     {
         "id": 50609,
         "Key": "Night Hag",
         "enUS": "Night Hag",
-        "zhTW": "暗夜妖婆",
+        "zhTW": "夜鹰",
         "deDE": "Nachthexe",
         "esES": "Bruja nocturna",
         "frFR": "Hagre de nuit",
@@ -36479,13 +36479,13 @@
         "jaJP": "ナイト・ハグ",
         "ptBR": "Bruxa da Noite",
         "ruRU": "Ночная карга",
-        "zhCN": "暗夜妖婆"
+        "zhCN": "夜鹰"
     },
     {
         "id": 50610,
         "Key": "Tendriculos",
         "enUS": "Tendriculos",
-        "zhTW": "殺人藤曼",
+        "zhTW": "Tendriculos",
         "deDE": "Tendriculos",
         "esES": "Tendriculos",
         "frFR": "Tendriculos",
@@ -36496,7 +36496,7 @@
         "jaJP": "テンドリキュロス",
         "ptBR": "Monstro do Pantano",
         "ruRU": "Tendriculos",
-        "zhCN": "杀人藤蔓"
+        "zhCN": "Tendriculos"
     },
     {
         "id": 50611,
@@ -36519,7 +36519,7 @@
         "id": 50612,
         "Key": "Taskmaster's Curse",
         "enUS": "Taskmaster's Curse",
-        "zhTW": "監工的詛咒",
+        "zhTW": "任务负责人的诅咒",
         "deDE": "Der Fluch des Taskmasters",
         "esES": "Maldición del Jefe de Tarea",
         "frFR": "La malédiction du maître d'œuvre",
@@ -36530,13 +36530,13 @@
         "jaJP": "タスクマスターの呪い",
         "ptBR": "Tarefa Mestre Amaldiçoada",
         "ruRU": "Проклятие таскмастера",
-        "zhCN": "监工的诅咒"
+        "zhCN": "任务负责人的诅咒"
     },
     {
         "id": 50613,
         "Key": "Mythslayer",
         "enUS": "Mythslayer",
-        "zhTW": "神話殺手",
+        "zhTW": "神话杀手",
         "deDE": "Mythentöter",
         "esES": "Cazador de Mitos",
         "frFR": "Tueur de mythes",
@@ -36553,7 +36553,7 @@
         "id": 50614,
         "Key": "Sunblighter",
         "enUS": "Sunblighter",
-        "zhTW": "陽光下的枯萎",
+        "zhTW": "Sunblighter",
         "deDE": "Sonnenvernichter",
         "esES": "Sunblighter",
         "frFR": "Eclaircisseur",
@@ -36564,13 +36564,13 @@
         "jaJP": "サンブライター",
         "ptBR": "Sol Corrompido",
         "ruRU": "Истребитель солнца",
-        "zhCN": "阳光下的枯萎"
+        "zhCN": "Sunblighter"
     },
     {
         "id": 50615,
         "Key": "Dwarven Honor",
         "enUS": "Dwarven Honor",
-        "zhTW": "矮人榮譽",
+        "zhTW": "矮人荣誉",
         "deDE": "Zwergenehre",
         "esES": "Honor enano",
         "frFR": "Honneur nain",
@@ -36587,7 +36587,7 @@
         "id": 50616,
         "Key": "Ravid's Bite",
         "enUS": "Ravid's Bite",
-        "zhTW": "拉維德之咬",
+        "zhTW": "拉维德之咬",
         "deDE": "Ravids Biss",
         "esES": "La mordedura de Ravid",
         "frFR": "La morsure de Ravid",
@@ -36604,7 +36604,7 @@
         "id": 50617,
         "Key": "Brittlequick",
         "enUS": "Brittlequick",
-        "zhTW": "易碎的迅捷",
+        "zhTW": "脆脆快",
         "deDE": "Brittlequick",
         "esES": "Brittlequick",
         "frFR": "Brittlequick",
@@ -36615,13 +36615,13 @@
         "jaJP": "ブリトルクイック",
         "ptBR": "Frágil Demais",
         "ruRU": "Brittlequick",
-        "zhCN": "易碎的迅捷"
+        "zhCN": "脆脆快"
     },
     {
         "id": 50618,
         "Key": "Ogre's Breath",
         "enUS": "Ogre's Breath",
-        "zhTW": "食人魔的呼吸",
+        "zhTW": "食人魔的气息",
         "deDE": "Der Atem des Ogers",
         "esES": "Aliento de ogro",
         "frFR": "Le souffle de l'ogre",
@@ -36632,13 +36632,13 @@
         "jaJP": "オーガズ・ブレス",
         "ptBR": "Respiração de Ogro",
         "ruRU": "Дыхание людоеда",
-        "zhCN": "食人魔的呼吸"
+        "zhCN": "食人魔的气息"
     },
     {
         "id": 50619,
         "Key": "Shapeshifter",
         "enUS": "Shapeshifter",
-        "zhTW": "變形者",
+        "zhTW": "变形金刚",
         "deDE": "Gestaltwandler",
         "esES": "Cambiaformas",
         "frFR": "Métamorphe",
@@ -36649,13 +36649,13 @@
         "jaJP": "シェイプシフター",
         "ptBR": "Metamorfo",
         "ruRU": "Перевертыш",
-        "zhCN": "变形者"
+        "zhCN": "变形金刚"
     },
     {
         "id": 50620,
         "Key": "Dyer's Eve",
         "enUS": "Dyer's Eve",
-        "zhTW": "戴爾前夜",
+        "zhTW": "戴尔前夕",
         "deDE": "Färberabend",
         "esES": "Víspera del Tintorero",
         "frFR": "La veille du teinturier",
@@ -36672,7 +36672,7 @@
         "id": 50621,
         "Key": "Heroes Welcome",
         "enUS": "Heroes Welcome",
-        "zhTW": "歡迎英雄",
+        "zhTW": "欢迎英雄",
         "deDE": "Helden willkommen",
         "esES": "Héroes Bienvenidos",
         "frFR": "Bienvenue aux héros",
@@ -36689,7 +36689,7 @@
         "id": 50622,
         "Key": "Nameless Horror",
         "enUS": "Nameless Horror",
-        "zhTW": "無可名狀的恐怖",
+        "zhTW": "无名恐怖",
         "deDE": "Namenloser Horror",
         "esES": "Horror sin nombre",
         "frFR": "Horreur sans nom",
@@ -36700,13 +36700,13 @@
         "jaJP": "ネームレス・ホラー",
         "ptBR": "Terror sem Nome",
         "ruRU": "Безымянный ужас",
-        "zhCN": "无可名状的恐怖"
+        "zhCN": "无名恐怖"
     },
     {
         "id": 50623,
         "Key": "Epee of Speed",
         "enUS": "Epee of Speed",
-        "zhTW": "極速重劍",
+        "zhTW": "速度重剑",
         "deDE": "Degen der Geschwindigkeit",
         "esES": "Espada de velocidad",
         "frFR": "Epée de vitesse",
@@ -36717,13 +36717,13 @@
         "jaJP": "スピードのエペ",
         "ptBR": "Rapieira",
         "ruRU": "Шпага скорости",
-        "zhCN": "极速重剑"
+        "zhCN": "速度重剑"
     },
     {
         "id": 50624,
         "Key": "Anadek's Sword",
         "enUS": "Anadek's Sword",
-        "zhTW": "阿納德克之剑",
+        "zhTW": "阿纳德克之剑",
         "deDE": "Anadeks Schwert",
         "esES": "Espada de Anadek",
         "frFR": "L'épée d'Anadek",
@@ -36740,7 +36740,7 @@
         "id": 50625,
         "Key": "Sajorn Jinx",
         "enUS": "Sajorn Jinx",
-        "zhTW": "撒炅厄運",
+        "zhTW": "Sajorn Jinx",
         "deDE": "Sajorn Jinx",
         "esES": "Gafe Sajorn",
         "frFR": "La guigne de Sajorn",
@@ -36751,13 +36751,13 @@
         "jaJP": "サジョーン・ジンクス",
         "ptBR": "Sajorn Azarado",
         "ruRU": "Саджорн Джинкс",
-        "zhCN": "撒炅厄运"
+        "zhCN": "Sajorn Jinx"
     },
     {
         "id": 50626,
         "Key": "Qikadar's Laughter",
         "enUS": "Qikadar's Laughter",
-        "zhTW": "齊卡達爾的笑聲",
+        "zhTW": "齐卡达尔的笑声",
         "deDE": "Das Lachen von Qikadar",
         "esES": "La risa de Qikadar",
         "frFR": "Le rire de Qikadar",
@@ -36791,7 +36791,7 @@
         "id": 50628,
         "Key": "Omni-Slash",
         "enUS": "Omni-Slash",
-        "zhTW": "全能閃擊",
+        "zhTW": "全能闪击",
         "deDE": "Omni-Slash",
         "esES": "Omni-Slash",
         "frFR": "Omni-Slash",
@@ -36808,7 +36808,7 @@
         "id": 50629,
         "Key": "Honor Guard",
         "enUS": "Honor Guard",
-        "zhTW": "榮耀守護",
+        "zhTW": "仪仗队",
         "deDE": "Ehrengarde",
         "esES": "Guardia de Honor",
         "frFR": "Garde d'honneur",
@@ -36819,13 +36819,13 @@
         "jaJP": "儀仗兵",
         "ptBR": "Guarda Honrado",
         "ruRU": "Почетный караул",
-        "zhCN": "荣耀守护"
+        "zhCN": "仪仗队"
     },
     {
         "id": 50630,
         "Key": "Orc Slayer",
         "enUS": "Orc Slayer",
-        "zhTW": "獸人殺手",
+        "zhTW": "兽人杀手",
         "deDE": "Ork-Töter",
         "esES": "Cazador de orcos",
         "frFR": "Tueur d'orques",
@@ -36842,7 +36842,7 @@
         "id": 50631,
         "Key": "Bridge of Pain",
         "enUS": "Bridge of Pain",
-        "zhTW": "痛苦之橋",
+        "zhTW": "痛苦之桥",
         "deDE": "Brücke des Schmerzes",
         "esES": "Puente del dolor",
         "frFR": "Pont de la douleur",
@@ -36859,7 +36859,7 @@
         "id": 50632,
         "Key": "Cursebreaker",
         "enUS": "Cursebreaker",
-        "zhTW": "破咒者",
+        "zhTW": "诅咒破坏者",
         "deDE": "Fluchbrecher",
         "esES": "Cursebreaker",
         "frFR": "Casse-cou",
@@ -36870,13 +36870,13 @@
         "jaJP": "呪い破り",
         "ptBR": "Quebrador de Maldições",
         "ruRU": "Cursebreaker",
-        "zhCN": "破咒者"
+        "zhCN": "诅咒破坏者"
     },
     {
         "id": 50633,
         "Key": "Deathfoe",
         "enUS": "Deathfoe",
-        "zhTW": "亡者之敵",
+        "zhTW": "死亡之蹄",
         "deDE": "Todesfahne",
         "esES": "Deathfoe",
         "frFR": "Fléole de la mort",
@@ -36887,13 +36887,13 @@
         "jaJP": "デスフォー",
         "ptBR": "Inimigo da Morte",
         "ruRU": "Deathfoe",
-        "zhCN": "亡者之敌"
+        "zhCN": "死亡之蹄"
     },
     {
         "id": 50634,
         "Key": "Deathfriend",
         "enUS": "Deathfriend",
-        "zhTW": "亡者之友",
+        "zhTW": "死亡之友",
         "deDE": "Todesfreund",
         "esES": "Amigo de la muerte",
         "frFR": "Ami de la mort",
@@ -36904,13 +36904,13 @@
         "jaJP": "デス・フレンド",
         "ptBR": "Amigo da Morte",
         "ruRU": "Друг смерти",
-        "zhCN": "亡者之友"
+        "zhCN": "死亡之友"
     },
     {
         "id": 50635,
         "Key": "Demolisher",
         "enUS": "Demolisher",
-        "zhTW": "粉碎者",
+        "zhTW": "拆除者",
         "deDE": "Demolierer",
         "esES": "Demoledor",
         "frFR": "Démolisseur",
@@ -36921,13 +36921,13 @@
         "jaJP": "デモリッシャー",
         "ptBR": "Demolidor",
         "ruRU": "Demolisher",
-        "zhCN": "粉碎者"
+        "zhCN": "拆除者"
     },
     {
         "id": 50636,
         "Key": "Fleshbleeder",
         "enUS": "Fleshbleeder",
-        "zhTW": "放血者",
+        "zhTW": "Fleshbleeder",
         "deDE": "Fleshbleeder",
         "esES": "Fleshbleeder",
         "frFR": "Fleshbleeder",
@@ -36938,13 +36938,13 @@
         "jaJP": "フレッシュブリーダー",
         "ptBR": "Carne Sangrando",
         "ruRU": "Fleshbleeder",
-        "zhCN": "放血者"
+        "zhCN": "Fleshbleeder"
     },
     {
         "id": 50637,
         "Key": "Lord of Riddles",
         "enUS": "Lord of Riddles",
-        "zhTW": "謎語之王",
+        "zhTW": "谜语之王",
         "deDE": "Herr des Rätsels",
         "esES": "Señor de los Enigmas",
         "frFR": "Le seigneur des énigmes",
@@ -36961,7 +36961,7 @@
         "id": 50638,
         "Key": "Rhyme of the Bard",
         "enUS": "Rhyme of the Bard",
-        "zhTW": "吟游詩人之韵",
+        "zhTW": "吟游诗人之韵",
         "deDE": "Reim des Barden",
         "esES": "Rima del Bardo",
         "frFR": "La rime du barde",
@@ -36978,7 +36978,7 @@
         "id": 50639,
         "Key": "Despicable Behavior",
         "enUS": "Despicable Behavior",
-        "zhTW": "卑劣行徑",
+        "zhTW": "卑劣的行为",
         "deDE": "Verachtenswertes Verhalten",
         "esES": "Comportamiento despreciable",
         "frFR": "Un comportement méprisable",
@@ -36989,13 +36989,13 @@
         "jaJP": "卑劣な振る舞い",
         "ptBR": "Comportamento Desprezível",
         "ruRU": "Отвратительное поведение",
-        "zhCN": "卑劣行径"
+        "zhCN": "卑劣的行为"
     },
     {
         "id": 50640,
         "Key": "Darkkon",
         "enUS": "Darkkon",
-        "zhTW": "黑暗聖像",
+        "zhTW": "黑暗圣像",
         "deDE": "Darkkon",
         "esES": "Darkkon",
         "frFR": "Darkkon",
@@ -37012,7 +37012,7 @@
         "id": 50641,
         "Key": "Locathah",
         "enUS": "Locathah",
-        "zhTW": "洛克薩",
+        "zhTW": "Locathah",
         "deDE": "Locathah",
         "esES": "Locathah",
         "frFR": "Locathah",
@@ -37023,13 +37023,13 @@
         "jaJP": "ロカサー",
         "ptBR": "Peixe Humanoide",
         "ruRU": "Локатх",
-        "zhCN": "洛克萨"
+        "zhCN": "Locathah"
     },
     {
         "id": 50642,
         "Key": "Pseudodragon",
         "enUS": "Pseudodragon",
-        "zhTW": "僞龍",
+        "zhTW": "伪龙",
         "deDE": "Pseudodrache",
         "esES": "Pseudodragón",
         "frFR": "Pseudodragon",
@@ -37063,7 +37063,7 @@
         "id": 50644,
         "Key": "Troglodyte",
         "enUS": "Troglodyte",
-        "zhTW": "穴居人",
+        "zhTW": "蛙人",
         "deDE": "Troglodyten",
         "esES": "Troglodita",
         "frFR": "Troglodyte",
@@ -37074,13 +37074,13 @@
         "jaJP": "穴居人",
         "ptBR": "Troglodita",
         "ruRU": "Троглодит",
-        "zhCN": "穴居人"
+        "zhCN": "蛙人"
     },
     {
         "id": 50645,
         "Key": "Sahuagin",
         "enUS": "Sahuagin",
-        "zhTW": "薩瓦金",
+        "zhTW": "萨瓦金",
         "deDE": "Sahuagin",
         "esES": "Sahuagin",
         "frFR": "Sahuagin",
@@ -37097,7 +37097,7 @@
         "id": 50646,
         "Key": "Celestial Lion",
         "enUS": "Celestial Lion",
-        "zhTW": "天獅",
+        "zhTW": "天狮",
         "deDE": "Der himmlische Löwe",
         "esES": "León Celeste",
         "frFR": "Lion céleste",
@@ -37114,7 +37114,7 @@
         "id": 50647,
         "Key": "Badger's Bite",
         "enUS": "Badger's Bite",
-        "zhTW": "獾咬",
+        "zhTW": "獾之咬",
         "deDE": "Der Biss des Dachses",
         "esES": "La mordedura del tejón",
         "frFR": "La morsure du blaireau",
@@ -37125,13 +37125,13 @@
         "jaJP": "アナグマの噛みつき",
         "ptBR": "Mordida de Texugo",
         "ruRU": "Укус барсука",
-        "zhCN": "獾咬"
+        "zhCN": "獾之咬"
     },
     {
         "id": 50648,
         "Key": "Wight's Touch",
         "enUS": "Wight's Touch",
-        "zhTW": "懷特之觸",
+        "zhTW": "怀特之触",
         "deDE": "Wight's Touch",
         "esES": "El toque de Wight",
         "frFR": "Wight's Touch",
@@ -37148,7 +37148,7 @@
         "id": 50649,
         "Key": "Rhinoceros Strength",
         "enUS": "Rhinoceros Strength",
-        "zhTW": "犀牛之力",
+        "zhTW": "犀牛的力量",
         "deDE": "Rhinozeros Stärke",
         "esES": "Fuerza del rinoceronte",
         "frFR": "La force du rhinocéros",
@@ -37159,7 +37159,7 @@
         "jaJP": "サイの強さ",
         "ptBR": "Força do Rinoceronte",
         "ruRU": "Сила носорога",
-        "zhCN": "犀牛之力"
+        "zhCN": "犀牛的力量"
     },
     {
         "id": 50650,
@@ -37182,7 +37182,7 @@
         "id": 50651,
         "Key": "Fury of the Owlbear",
         "enUS": "Fury of the Owlbear",
-        "zhTW": "鴞熊之怒",
+        "zhTW": "猫头鹰之怒",
         "deDE": "Der Zorn des Eulenbären",
         "esES": "La furia del oso búho",
         "frFR": "La fureur de l'ours hibou",
@@ -37193,13 +37193,13 @@
         "jaJP": "フクロウベアの怒り",
         "ptBR": "Fúria do urso-coruja",
         "ruRU": "Ярость совиного медведя",
-        "zhCN": "鸮熊之怒"
+        "zhCN": "猫头鹰之怒"
     },
     {
         "id": 50652,
         "Key": "Cloaker Beast",
         "enUS": "Cloaker Beast",
-        "zhTW": "隱形野獸",
+        "zhTW": "隐形兽",
         "deDE": "Tarnkappen-Bestie",
         "esES": "Bestia camufladora",
         "frFR": "Bête d'occultation",
@@ -37210,13 +37210,13 @@
         "jaJP": "クローカー・ビースト",
         "ptBR": "Besta Camufladora",
         "ruRU": "Маскировочный зверь",
-        "zhCN": "隐形野兽"
+        "zhCN": "隐形兽"
     },
     {
         "id": 50653,
         "Key": "Blink Dog",
         "enUS": "Blink Dog",
-        "zhTW": "閃爍獵犬",
+        "zhTW": "眨眼狗",
         "deDE": "Blinkender Hund",
         "esES": "Perro Blink",
         "frFR": "Chien clignotant",
@@ -37227,7 +37227,7 @@
         "jaJP": "ブリンク・ドッグ",
         "ptBR": "Cachorro Piscou",
         "ruRU": "Собака-мигалка",
-        "zhCN": "闪烁猎犬"
+        "zhCN": "眨眼狗"
     },
     {
         "id": 50654,
@@ -37250,7 +37250,7 @@
         "id": 50655,
         "Key": "Ettercap",
         "enUS": "Ettercap",
-        "zhTW": "埃特爾卡普",
+        "zhTW": "Ettercap",
         "deDE": "Ettercap",
         "esES": "Ettercap",
         "frFR": "Ettercap",
@@ -37261,7 +37261,7 @@
         "jaJP": "エテルキャップ",
         "ptBR": "Capsula Etter",
         "ruRU": "Эттеркап",
-        "zhCN": "埃特尔卡普"
+        "zhCN": "Ettercap"
     },
     {
         "id": 50656,
@@ -37284,7 +37284,7 @@
         "id": 50657,
         "Key": "Cheetah Speed",
         "enUS": "Cheetah Speed",
-        "zhTW": "獵豹之速",
+        "zhTW": "猎豹速度",
         "deDE": "Gepardengeschwindigkeit",
         "esES": "Velocidad de guepardo",
         "frFR": "Vitesse du guépard",
@@ -37295,7 +37295,7 @@
         "jaJP": "チーターのスピード",
         "ptBR": "Guepardo",
         "ruRU": "Скорость гепарда",
-        "zhCN": "猎豹之速"
+        "zhCN": "猎豹速度"
     },
     {
         "id": 50658,
@@ -37335,7 +37335,7 @@
         "id": 50660,
         "Key": "Lachdanan's Bracers",
         "enUS": "Lachdanan's Bracers",
-        "zhTW": "拉赫達南的護腕",
+        "zhTW": "拉赫达南的臂铠",
         "deDE": "Lachdanans Armschienen",
         "esES": "Brazales de Lachdanan",
         "frFR": "Les bracelets de Lachdanan",
@@ -37346,13 +37346,13 @@
         "jaJP": "ラフダナンのブレイサー",
         "ptBR": "Braçadeiras de Lachdanan",
         "ruRU": "Браслеты Лахданана",
-        "zhCN": "拉赫达南的护腕"
+        "zhCN": "拉赫达南的臂铠"
     },
     {
         "id": 50661,
         "Key": "Lachdanan's Wrap",
         "enUS": "Lachdanan's Wrap",
-        "zhTW": "拉赫達南的裹腰",
+        "zhTW": "拉赫达南的包裹",
         "deDE": "Lachdanan's Wrap",
         "esES": "Envoltura de Lachdanan",
         "frFR": "L'enveloppement de Lachdanan",
@@ -37363,13 +37363,13 @@
         "jaJP": "ラフダナンのラップ",
         "ptBR": "Envoltório de Lachdanan",
         "ruRU": "Обертывание Лахданана",
-        "zhCN": "拉赫达南的腰带"
+        "zhCN": "拉赫达南的包裹"
     },
     {
         "id": 50662,
         "Key": "Lachdanan's Heart",
         "enUS": "Lachdanan's Heart",
-        "zhTW": "拉赫達南之心",
+        "zhTW": "拉赫达南之心",
         "deDE": "Das Herz von Lachdanan",
         "esES": "Corazón de Lachdanan",
         "frFR": "Le cœur de Lachdanan",
@@ -37386,7 +37386,7 @@
         "id": 50663,
         "Key": "Lachdanan's Guard",
         "enUS": "Lachdanan's Guard",
-        "zhTW": "拉赫達南的衛盾",
+        "zhTW": "拉赫达南卫队",
         "deDE": "Lachdanans Wache",
         "esES": "Guardia de Lachdanan",
         "frFR": "Garde de Lachdanan",
@@ -37397,7 +37397,7 @@
         "jaJP": "ラハダナンの護衛",
         "ptBR": "Guarda de Lachdanan",
         "ruRU": "Страж Лахданана",
-        "zhCN": "拉赫达南的卫盾"
+        "zhCN": "拉赫达南卫队"
     },
     {
         "id": 50664,
@@ -37420,7 +37420,7 @@
         "id": 50665,
         "Key": "Harpy's Call",
         "enUS": "Harpy's Call",
-        "zhTW": "哈比的呼喚",
+        "zhTW": "哈比的呼唤",
         "deDE": "Der Ruf der Harpyie",
         "esES": "Llamada de la arpía",
         "frFR": "L'appel de la harpie",
@@ -37437,7 +37437,7 @@
         "id": 50666,
         "Key": "Satyr's Speech",
         "enUS": "Satyr's Speech",
-        "zhTW": "薩提爾的演講",
+        "zhTW": "萨提尔的演讲",
         "deDE": "Die Rede des Satyrs",
         "esES": "Discurso del Sátiro",
         "frFR": "Discours du satyre",
@@ -37454,7 +37454,7 @@
         "id": 50667,
         "Key": "Crocodile Wrap",
         "enUS": "Crocodile Wrap",
-        "zhTW": "鰐魚裹腰",
+        "zhTW": "鳄鱼皮包裹",
         "deDE": "Krokodil-Wickel",
         "esES": "Envoltura de cocodrilo",
         "frFR": "Enveloppe en crocodile",
@@ -37465,7 +37465,7 @@
         "jaJP": "クロコダイル・ラップ",
         "ptBR": "Envoltório do Lacoste",
         "ruRU": "Крокодиловое обертывание",
-        "zhCN": "鳄鱼腰带"
+        "zhCN": "鳄鱼皮包裹"
     },
     {
         "id": 50668,
@@ -37488,7 +37488,7 @@
         "id": 50669,
         "Key": "Baal's Wing",
         "enUS": "Baal's Wing",
-        "zhTW": "巴爾之翼",
+        "zhTW": "巴尔之翼",
         "deDE": "Baals Flügel",
         "esES": "Ala de Baal",
         "frFR": "L'aile de Baal",
@@ -37505,7 +37505,7 @@
         "id": 50670,
         "Key": "Diablo's Scale",
         "enUS": "Diablo's Scale",
-        "zhTW": "迪亞布羅之鱗",
+        "zhTW": "暗黑破坏神的天平",
         "deDE": "Diablo-Skala",
         "esES": "Escala de Diablo",
         "frFR": "L'échelle de Diablo",
@@ -37516,13 +37516,13 @@
         "jaJP": "ディアブロのスケール",
         "ptBR": "Escala de Diablo",
         "ruRU": "Шкала Дьябло",
-        "zhCN": "迪亚波罗之鳞"
+        "zhCN": "暗黑破坏神的天平"
     },
     {
         "id": 50671,
         "Key": "Hippogriff Wing",
         "enUS": "Hippogriff Wing",
-        "zhTW": "半鷹马之翼",
+        "zhTW": "河马之翼",
         "deDE": "Hippogriff Wing",
         "esES": "Ala de hipogrifo",
         "frFR": "Hippogriffe Wing",
@@ -37533,13 +37533,13 @@
         "jaJP": "ヒッポグリフ・ウィング",
         "ptBR": "Asa de Hipogrifo",
         "ruRU": "Крыло гиппогрифа",
-        "zhCN": "半鹰马之翼"
+        "zhCN": "河马之翼"
     },
     {
         "id": 50672,
         "Key": "Kuo-Toa's Plague",
         "enUS": "Kuo-Toa's Plague",
-        "zhTW": "闊托的瘟疫",
+        "zhTW": "郭涛的瘟疫",
         "deDE": "Kuo-Toas Seuche",
         "esES": "La plaga de Kuo-Toa",
         "frFR": "La peste de Kuo-Toa",
@@ -37550,13 +37550,13 @@
         "jaJP": "クオトアの疫病",
         "ptBR": "A praga de Kuo-Toa",
         "ruRU": "Чума Куо-Тоа",
-        "zhCN": "阔托的瘟疫"
+        "zhCN": "郭涛的瘟疫"
     },
     {
         "id": 50673,
         "Key": "Ice Mephit",
         "enUS": "Ice Mephit",
-        "zhTW": "冰霜梅菲特",
+        "zhTW": "冰雪梅菲特",
         "deDE": "Eis Mephit",
         "esES": "Mephit de hielo",
         "frFR": "Méphite de glace",
@@ -37567,7 +37567,7 @@
         "jaJP": "アイス・メフィット",
         "ptBR": "Mefito de Gelo",
         "ruRU": "Ледяной мефит",
-        "zhCN": "冰霜梅菲特"
+        "zhCN": "冰雪梅菲特"
     },
     {
         "id": 50674,
@@ -37607,7 +37607,7 @@
         "id": 50676,
         "Key": "Assassin Vine",
         "enUS": "Assassin Vine",
-        "zhTW": "藤曼刺客",
+        "zhTW": "刺客藤",
         "deDE": "Assassinen-Rebe",
         "esES": "Enredadera asesina",
         "frFR": "Assassin Vine",
@@ -37618,7 +37618,7 @@
         "jaJP": "アサシン・バイン",
         "ptBR": "Vinha Assassina",
         "ruRU": "Вайна ассасина",
-        "zhCN": "藤曼刺客"
+        "zhCN": "刺客藤"
     },
     {
         "id": 50677,
@@ -37641,7 +37641,7 @@
         "id": 50678,
         "Key": "Pegasus Wing",
         "enUS": "Pegasus Wing",
-        "zhTW": "飛馬之翼",
+        "zhTW": "飞马翼",
         "deDE": "Pegasusflügel",
         "esES": "Ala Pegaso",
         "frFR": "Aile de Pégase",
@@ -37652,13 +37652,13 @@
         "jaJP": "ペガサスウィング",
         "ptBR": "Asas de Pegasus",
         "ruRU": "Крыло Пегаса",
-        "zhCN": "飞马之翼"
+        "zhCN": "飞马翼"
     },
     {
         "id": 50679,
         "Key": "Celestial Unicorn",
         "enUS": "Celestial Unicorn",
-        "zhTW": "星空獨角獸",
+        "zhTW": "天上独角兽",
         "deDE": "Himmlisches Einhorn",
         "esES": "Unicornio Celestial",
         "frFR": "Licorne céleste",
@@ -37669,13 +37669,13 @@
         "jaJP": "セレスティアル・ユニコーン",
         "ptBR": "Unicornio Celestial",
         "ruRU": "Небесный единорог",
-        "zhCN": "星空独角兽"
+        "zhCN": "天上独角兽"
     },
     {
         "id": 50680,
         "Key": "Will-O'-Wisp",
         "enUS": "Will-O'-Wisp",
-        "zhTW": "鬼火",
+        "zhTW": "Will-O'-Wisp",
         "deDE": "Will-O'-Wisp",
         "esES": "Will-O'-Wisp",
         "frFR": "Will-O'-Wisp",
@@ -37686,13 +37686,13 @@
         "jaJP": "ウィル・オ・ウィスプ",
         "ptBR": "Fogo-Fátuo",
         "ruRU": "Уилл-о'-Висп",
-        "zhCN": "鬼火"
+        "zhCN": "Will-O'-Wisp"
     },
     {
         "id": 50681,
         "Key": "Na-Krul's Power",
         "enUS": "Na-Krul's Power",
-        "zhTW": "納-克魯爾之力",
+        "zhTW": "纳-克鲁尔的力量",
         "deDE": "Na-Kruls Macht",
         "esES": "El poder de Na-Krul",
         "frFR": "Le pouvoir de Na-Krul",
@@ -37703,13 +37703,13 @@
         "jaJP": "ナ・クルールの力",
         "ptBR": "Poder de Na-Krul",
         "ruRU": "Сила На-Крула",
-        "zhCN": "纳-克鲁尔之力"
+        "zhCN": "纳-克鲁尔的力量"
     },
     {
         "id": 50682,
         "Key": "Gharbad's Cry",
         "enUS": "Gharbad's Cry",
-        "zhTW": "加爾巴德的哭泣",
+        "zhTW": "加尔巴德的哭泣",
         "deDE": "Der Schrei von Gharbad",
         "esES": "Grito de Gharbad",
         "frFR": "Le cri de Gharbad",
@@ -37726,7 +37726,7 @@
         "id": 50683,
         "Key": "Shirotachi",
         "enUS": "Shirotachi",
-        "zhTW": "矗立城堡",
+        "zhTW": "城立",
         "deDE": "Shirotachi",
         "esES": "Shirotachi",
         "frFR": "Shirotachi",
@@ -37737,13 +37737,13 @@
         "jaJP": "シロタチ",
         "ptBR": "Espada de Shock",
         "ruRU": "Широтачи",
-        "zhCN": "矗立城堡"
+        "zhCN": "城立"
     },
     {
         "id": 50684,
         "Key": "Thunderclap",
         "enUS": "Thunderclap",
-        "zhTW": "雷鳴",
+        "zhTW": "雷鸣",
         "deDE": "Thunderclap",
         "esES": "Thunderclap",
         "frFR": "Coup de tonnerre",
@@ -37760,7 +37760,7 @@
         "id": 50685,
         "Key": "The Mangler",
         "enUS": "The Mangler",
-        "zhTW": "莽漢",
+        "zhTW": "莽汉",
         "deDE": "Der Mangler",
         "esES": "El mangante",
         "frFR": "L'homme d'affaires",
@@ -37794,7 +37794,7 @@
         "id": 50687,
         "Key": "Thundercall",
         "enUS": "Thundercall",
-        "zhTW": "雷電呼喚",
+        "zhTW": "雷电呼叫",
         "deDE": "Donnergrollen",
         "esES": "Thundercall",
         "frFR": "Appel du tonnerre",
@@ -37805,13 +37805,13 @@
         "jaJP": "サンダーコール",
         "ptBR": "Chamada do Trovão",
         "ruRU": "Громовой вызов",
-        "zhCN": "雷电呼唤"
+        "zhCN": "雷电呼叫"
     },
     {
         "id": 50688,
         "Key": "Dragon's Breach",
         "enUS": "Dragon's Breach",
-        "zhTW": "巨龍裂隙",
+        "zhTW": "龙之裂口",
         "deDE": "Die Drachenbresche",
         "esES": "Brecha del Dragón",
         "frFR": "La brèche du dragon",
@@ -37822,7 +37822,7 @@
         "jaJP": "ドラゴンズブリーチ",
         "ptBR": "Violação do Dragão",
         "ruRU": "Пролом дракона",
-        "zhCN": "巨龙裂隙"
+        "zhCN": "龙之裂口"
     },
     {
         "id": 50689,
@@ -37845,7 +37845,7 @@
         "id": 50690,
         "Key": "Splitting Skulls",
         "enUS": "Splitting Skulls",
-        "zhTW": "裂顱",
+        "zhTW": "分裂头骨",
         "deDE": "Schädel spalten",
         "esES": "Cráneos partidos",
         "frFR": "Fendre les crânes",
@@ -37856,13 +37856,13 @@
         "jaJP": "スプリッティング・スカルズ",
         "ptBR": "Dividindo Crânios",
         "ruRU": "Разбитые черепа",
-        "zhCN": "裂颅"
+        "zhCN": "分裂头骨"
     },
     {
         "id": 50691,
         "Key": "Deadly Hunter",
         "enUS": "Deadly Hunter",
-        "zhTW": "致命獵手",
+        "zhTW": "致命猎手",
         "deDE": "Tödlicher Jäger",
         "esES": "Cazador mortal",
         "frFR": "Chasseur mortel",
@@ -37896,7 +37896,7 @@
         "id": 50693,
         "Key": "Falcon Talon",
         "enUS": "Falcon Talon",
-        "zhTW": "獵鷹利爪",
+        "zhTW": "猎鹰利爪",
         "deDE": "Falkenschwanztalon",
         "esES": "Halcón Talon",
         "frFR": "Talon Falcon",
@@ -37913,7 +37913,7 @@
         "id": 50694,
         "Key": "Staff of Shadows",
         "enUS": "Staff of Shadows",
-        "zhTW": "陰影之杖",
+        "zhTW": "阴影之杖",
         "deDE": "Stab der Schatten",
         "esES": "Bastón de las Sombras",
         "frFR": "Le bâton des ombres",
@@ -37930,7 +37930,7 @@
         "id": 50695,
         "Key": "The Defiler's Flesh",
         "enUS": "The Defiler's Flesh",
-        "zhTW": "褻瀆者的血肉",
+        "zhTW": "玷污者的肉体",
         "deDE": "Das Fleisch des Beschmutzers",
         "esES": "La carne del profanador",
         "frFR": "La chair du profanateur",
@@ -37941,13 +37941,13 @@
         "jaJP": "汚れなき肉",
         "ptBR": "Carne do Profanador",
         "ruRU": "Плоть осквернителя",
-        "zhCN": "亵渎者的血肉"
+        "zhCN": "玷污者的肉体"
     },
     {
         "id": 50696,
         "Key": "Ogden's Shroud",
         "enUS": "Ogden's Shroud",
-        "zhTW": "奧格登的壽衣",
+        "zhTW": "奥格登的裹尸布",
         "deDE": "Das Leichentuch von Ogden",
         "esES": "Sudario de Ogden",
         "frFR": "Linceul d'Ogden",
@@ -37958,13 +37958,13 @@
         "jaJP": "オグデンのシュラウド",
         "ptBR": "Sudário de Ogden",
         "ruRU": "Саван Огдена",
-        "zhCN": "奥格登的寿衣"
+        "zhCN": "奥格登的裹尸布"
     },
     {
         "id": 50697,
         "Key": "Gloomform",
         "enUS": "Gloomform",
-        "zhTW": "憂鬱形態",
+        "zhTW": "Gloomform",
         "deDE": "Gloomform",
         "esES": "Gloomform",
         "frFR": "Gloomform",
@@ -37975,13 +37975,13 @@
         "jaJP": "グロームフォーム",
         "ptBR": "Gloomform",
         "ruRU": "Gloomform",
-        "zhCN": "忧郁形态"
+        "zhCN": "Gloomform"
     },
     {
         "id": 50698,
         "Key": "Scavanger's Carapace",
         "enUS": "Scavanger's Carapace",
-        "zhTW": "清道夫的甲殼",
+        "zhTW": "清道夫的甲壳",
         "deDE": "Scavanger's Carapace",
         "esES": "Caparazón de carroñero",
         "frFR": "Carapace de scavanger",
@@ -37998,7 +37998,7 @@
         "id": 50699,
         "Key": "Torn Flesh of Souls",
         "enUS": "Torn Flesh of Souls",
-        "zhTW": "靈肉分離",
+        "zhTW": "撕裂的灵魂之肉",
         "deDE": "Zerrissenes Fleisch der Seelen",
         "esES": "Carne desgarrada de las almas",
         "frFR": "La chair déchirée des âmes",
@@ -38009,7 +38009,7 @@
         "jaJP": "引き裂かれた魂の肉",
         "ptBR": "Carne das Almas Rasgadas",
         "ruRU": "Разорванная плоть душ",
-        "zhCN": "灵肉分离"
+        "zhCN": "撕裂的灵魂之肉"
     },
     {
         "id": 50700,
@@ -38032,7 +38032,7 @@
         "id": 50701,
         "Key": "Demonspike Coat",
         "enUS": "Demonspike Coat",
-        "zhTW": "魔刺外袍",
+        "zhTW": "恶魔矛外套",
         "deDE": "Demonspike-Mantel",
         "esES": "Abrigo Demonspike",
         "frFR": "Manteau Demonspike",
@@ -38043,7 +38043,7 @@
         "jaJP": "デーモンスパイク・コート",
         "ptBR": "Casaco Pregado Demoníaco",
         "ruRU": "Плащ для демона",
-        "zhCN": "魔刺外衣"
+        "zhCN": "恶魔矛外套"
     },
     {
         "id": 50702,
@@ -38066,7 +38066,7 @@
         "id": 50703,
         "Key": "Gotterdamerung",
         "enUS": "Gotterdamerung",
-        "zhTW": "黃昏終結",
+        "zhTW": "获得",
         "deDE": "Gotterdamerung",
         "esES": "Gotterdamerung",
         "frFR": "Gotterdamerung",
@@ -38077,13 +38077,13 @@
         "jaJP": "ゴッテルダムング",
         "ptBR": "Crepúsculo dos Deuses",
         "ruRU": "Gotterdamerung",
-        "zhCN": "黄昏终结"
+        "zhCN": "获得"
     },
     {
         "id": 50704,
         "Key": "Fool's Crest",
         "enUS": "Fool's Crest",
-        "zhTW": "愚者之冠",
+        "zhTW": "愚人峰",
         "deDE": "Narrenwappen",
         "esES": "Cresta del Tonto",
         "frFR": "L'écusson du fou",
@@ -38094,7 +38094,7 @@
         "jaJP": "フールズ・クレスト",
         "ptBR": "Crista do Tolo",
         "ruRU": "Гребень дурака",
-        "zhCN": "愚者之冠"
+        "zhCN": "愚人峰"
     },
     {
         "id": 50705,
@@ -38117,7 +38117,7 @@
         "id": 50706,
         "Key": "Gillian's Tiara",
         "enUS": "Gillian's Tiara",
-        "zhTW": "吉莉安的頭飾",
+        "zhTW": "吉莉安的头饰",
         "deDE": "Gillian's Diadem",
         "esES": "Tiara de Gillian",
         "frFR": "Le diadème de Gillian",
@@ -38134,7 +38134,7 @@
         "id": 50707,
         "Key": "Ogden's Wisdom",
         "enUS": "Ogden's Wisdom",
-        "zhTW": "奧格登的智慧",
+        "zhTW": "奥格登的智慧",
         "deDE": "Ogdens Weisheit",
         "esES": "La sabiduría de Ogden",
         "frFR": "La sagesse d'Ogden",
@@ -38168,7 +38168,7 @@
         "id": 50709,
         "Key": "Pepin's Grace",
         "enUS": "Pepin's Grace",
-        "zhTW": "佩潘的優雅",
+        "zhTW": "佩潘的恩典",
         "deDE": "Pepins Gnade",
         "esES": "La gracia de Pepín",
         "frFR": "La grâce de Pepin",
@@ -38179,13 +38179,13 @@
         "jaJP": "ペピンの恩寵",
         "ptBR": "Graça de Pepin",
         "ruRU": "Милость Пепина",
-        "zhCN": "佩潘的优雅"
+        "zhCN": "佩潘的恩典"
     },
     {
         "id": 50710,
         "Key": "Gryphon's Claw",
         "enUS": "Gryphon's Claw",
-        "zhTW": "鷹頭獅之爪",
+        "zhTW": "麒麟爪",
         "deDE": "Greifenklaue",
         "esES": "Garra de grifo",
         "frFR": "Griffe de Gryphon",
@@ -38196,13 +38196,13 @@
         "jaJP": "グリフォンズ・クロー",
         "ptBR": "Garra de Grifo",
         "ruRU": "Коготь грифона",
-        "zhCN": "鹰头狮之爪"
+        "zhCN": "麒麟爪"
     },
     {
         "id": 50711,
         "Key": "Wisdom's Wrap",
         "enUS": "Wisdom's Wrap",
-        "zhTW": "智慧裹腰",
+        "zhTW": "智慧包装",
         "deDE": "Wisdom's Wrap",
         "esES": "Wisdom's Wrap",
         "frFR": "L'emballage de la sagesse",
@@ -38213,13 +38213,13 @@
         "jaJP": "ウィズダムラップ",
         "ptBR": "Envoltório de Sabedoria",
         "ruRU": "Обертывание мудрости",
-        "zhCN": "智慧腰带"
+        "zhCN": "智慧包装"
     },
     {
         "id": 50712,
         "Key": "Royal Diadem",
         "enUS": "Royal Diadem",
-        "zhTW": "皇家權冠",
+        "zhTW": "皇家徽章",
         "deDE": "Königliches Diadem",
         "esES": "Diadema real",
         "frFR": "Diadème royal",
@@ -38230,13 +38230,13 @@
         "jaJP": "王冠",
         "ptBR": "Diadema Real",
         "ruRU": "Королевская диадема",
-        "zhCN": "皇家权冠"
+        "zhCN": "皇家徽章"
     },
     {
         "id": 50713,
         "Key": "Gnat Sting",
         "enUS": "Gnat Sting",
-        "zhTW": "蠓蟲之刺",
+        "zhTW": "蜚蠊叮咬",
         "deDE": "Mückenstich",
         "esES": "Picadura de mosquito",
         "frFR": "Piqûre de moucheron",
@@ -38247,13 +38247,13 @@
         "jaJP": "ヌート・スティング",
         "ptBR": "Picada de Aedes Aegypti",
         "ruRU": "Укус мошки",
-        "zhCN": "蠓虫之刺"
+        "zhCN": "蜚蠊叮咬"
     },
     {
         "id": 50714,
         "Key": "Hammer of Jholm",
         "enUS": "Hammer of Jholm",
-        "zhTW": "喬姆之錘",
+        "zhTW": "乔姆之锤",
         "deDE": "Hammer von Jholm",
         "esES": "Martillo de Jholm",
         "frFR": "Marteau de Jholm",
@@ -38270,7 +38270,7 @@
         "id": 50715,
         "Key": "Gladiator's Strike",
         "enUS": "Gladiator's Strike",
-        "zhTW": "角鬥士的突襲",
+        "zhTW": "角斗士出击",
         "deDE": "Gladiatorenstreik",
         "esES": "Golpe de Gladiador",
         "frFR": "Le coup du gladiateur",
@@ -38281,7 +38281,7 @@
         "jaJP": "剣闘士の一撃",
         "ptBR": "Golpe do Gladiador",
         "ruRU": "Удар гладиатора",
-        "zhCN": "角斗士的突袭"
+        "zhCN": "角斗士出击"
     },
     {
         "id": 50716,
@@ -38304,7 +38304,7 @@
         "id": 50717,
         "Key": "Gornnagal's Dirk",
         "enUS": "Gornnagal's Dirk",
-        "zhTW": "戈納加爾的短刀",
+        "zhTW": "戈纳加尔的德克",
         "deDE": "Gornnagal's Dirk",
         "esES": "Dirk de Gornnagal",
         "frFR": "Dirk de Gornnagal",
@@ -38315,13 +38315,13 @@
         "jaJP": "ゴーンナガルのダーク",
         "ptBR": "Adaga de Gornnagal",
         "ruRU": "Кортик Горнагала",
-        "zhCN": "戈纳加尔的短刀"
+        "zhCN": "戈纳加尔的德克"
     },
     {
         "id": 50718,
         "Key": "Acolyte's Wand",
         "enUS": "Acolyte's Wand",
-        "zhTW": "聖徒魔杖",
+        "zhTW": "圣徒魔杖",
         "deDE": "Stab des Akolythen",
         "esES": "Varita de acólito",
         "frFR": "Baguette d'acolyte",
@@ -38355,7 +38355,7 @@
         "id": 50720,
         "Key": "Astral Dreadnought",
         "enUS": "Astral Dreadnought",
-        "zhTW": "星空無畏艦",
+        "zhTW": "星际无畏舰",
         "deDE": "Astral-Dreadnought",
         "esES": "Acorazado Astral",
         "frFR": "Cuirassé astral",
@@ -38366,13 +38366,13 @@
         "jaJP": "アストラル・ドレッドノート",
         "ptBR": "Forasteiros Gigantescos",
         "ruRU": "Астральный дредноут",
-        "zhCN": "星空无畏舰"
+        "zhCN": "星际无畏舰"
     },
     {
         "id": 50721,
         "Key": "Doom Avatar",
         "enUS": "Doom Avatar",
-        "zhTW": "末日化身",
+        "zhTW": "末日头像",
         "deDE": "Weltuntergangs-Avatar",
         "esES": "Avatar de Doom",
         "frFR": "Avatar de Doom",
@@ -38383,13 +38383,13 @@
         "jaJP": "ドゥーム・アバター",
         "ptBR": "Avatar Condenado",
         "ruRU": "Аватар Doom",
-        "zhCN": "末日化身"
+        "zhCN": "末日头像"
     },
     {
         "id": 50722,
         "Key": "Bramble Oak",
         "enUS": "Bramble Oak",
-        "zhTW": "黑莓橡樹",
+        "zhTW": "树莓橡树",
         "deDE": "Eiche Brombeere",
         "esES": "Roble Bramble",
         "frFR": "Chêne ronce",
@@ -38400,13 +38400,13 @@
         "jaJP": "ブランブル・オーク",
         "ptBR": "Carvalho Espinheiro",
         "ruRU": "Дуб брэмбл",
-        "zhCN": "黑莓橡树"
+        "zhCN": "树莓橡树"
     },
     {
         "id": 50723,
         "Key": "Troll's Nail",
         "enUS": "Troll's Nail",
-        "zhTW": "食人妖指甲",
+        "zhTW": "巨怪的指甲",
         "deDE": "Trollnagel",
         "esES": "Uña de trol",
         "frFR": "L'ongle du troll",
@@ -38417,7 +38417,7 @@
         "jaJP": "トロールの爪",
         "ptBR": "Prego de Troll",
         "ruRU": "Гвоздь тролля",
-        "zhCN": "巨魔指甲"
+        "zhCN": "巨怪的指甲"
     },
     {
         "id": 50724,
@@ -38440,7 +38440,7 @@
         "id": 50725,
         "Key": "Umbral's Bat",
         "enUS": "Umbral's Bat",
-        "zhTW": "烏姆巴爾的蝙蝠",
+        "zhTW": "乌姆巴尔的蝙蝠",
         "deDE": "Umbrale Fledermaus",
         "esES": "Murciélago de Umbral",
         "frFR": "Chauve-souris d'Umbral",
@@ -38457,7 +38457,7 @@
         "id": 50726,
         "Key": "Stirgi's Club",
         "enUS": "Stirgi's Club",
-        "zhTW": "斯戴吉俱樂部",
+        "zhTW": "Stirgi's 俱乐部",
         "deDE": "Stirgi's Club",
         "esES": "Club Stirgi",
         "frFR": "Stirgi's Club",
@@ -38468,13 +38468,13 @@
         "jaJP": "スティルギズ・クラブ",
         "ptBR": "Clube de Stirgi",
         "ruRU": "Клуб Стирги",
-        "zhCN": "斯戴吉俱乐部"
+        "zhCN": "Stirgi's 俱乐部"
     },
     {
         "id": 50727,
         "Key": "Famorian's Club",
         "enUS": "Famorian's Club",
-        "zhTW": "法莫瑞俱樂部",
+        "zhTW": "法莫瑞俱乐部",
         "deDE": "Famorian's Club",
         "esES": "Famorian's Club",
         "frFR": "Club des Famoriens",
@@ -38491,7 +38491,7 @@
         "id": 50728,
         "Key": "Hill Giant's Bludgeon",
         "enUS": "Hill Giant's Bludgeon",
-        "zhTW": "山丘巨人的重錘",
+        "zhTW": "山丘巨人之锤",
         "deDE": "Knüppel des Bergriesen",
         "esES": "Garrote del gigante de la colina",
         "frFR": "Massue du géant des collines",
@@ -38502,13 +38502,13 @@
         "jaJP": "ヒル・ジャイアントのブラッジョン",
         "ptBR": "Montes Gigantes Clavado",
         "ruRU": "Дубина горного великана",
-        "zhCN": "山丘巨人的重锤"
+        "zhCN": "山丘巨人之锤"
     },
     {
         "id": 50729,
         "Key": "Konnan's Maul",
         "enUS": "Konnan's Maul",
-        "zhTW": "科南的巨錘",
+        "zhTW": "Konnan's Maul",
         "deDE": "Konnans Maulwurf",
         "esES": "Maul de Konnan",
         "frFR": "Le Maul de Konnan",
@@ -38519,7 +38519,7 @@
         "jaJP": "コーナンのモール",
         "ptBR": "Konnan Espancado",
         "ruRU": "Маул Коннана",
-        "zhCN": "科南的巨锤"
+        "zhCN": "Konnan's Maul"
     },
     {
         "id": 50730,
@@ -38542,7 +38542,7 @@
         "id": 50731,
         "Key": "Dawn's Mist",
         "enUS": "Dawn's Mist",
-        "zhTW": "黎明迷霧",
+        "zhTW": "黎明之雾",
         "deDE": "Morgennebel",
         "esES": "Niebla del amanecer",
         "frFR": "Brume de l'aube",
@@ -38553,13 +38553,13 @@
         "jaJP": "夜明けの霧",
         "ptBR": "Amanhecer Neblinoso",
         "ruRU": "Туман рассвета",
-        "zhCN": "黎明迷雾"
+        "zhCN": "黎明之雾"
     },
     {
         "id": 50732,
         "Key": "Cat Tail",
         "enUS": "Cat Tail",
-        "zhTW": "貓尾",
+        "zhTW": "猫尾巴",
         "deDE": "Katzenschwanz",
         "esES": "Cola de gato",
         "frFR": "Queue de chat",
@@ -38570,7 +38570,7 @@
         "jaJP": "猫のしっぽ",
         "ptBR": "Cauda de Gato",
         "ruRU": "Кошачий хвост",
-        "zhCN": "猫尾"
+        "zhCN": "猫尾巴"
     },
     {
         "id": 50733,
@@ -38593,7 +38593,7 @@
         "id": 50734,
         "Key": "Genoa's Trust",
         "enUS": "Genoa's Trust",
-        "zhTW": "吉諾雅的信任",
+        "zhTW": "热那亚的信任",
         "deDE": "Genuas Vertrauen",
         "esES": "La confianza de Génova",
         "frFR": "La confiance de Gênes",
@@ -38604,7 +38604,7 @@
         "jaJP": "ジェノアの信頼",
         "ptBR": "Confiança de Gênova",
         "ruRU": "Генуэзский трест",
-        "zhCN": "吉诺雅的信任"
+        "zhCN": "热那亚的信任"
     },
     {
         "id": 50735,
@@ -38644,7 +38644,7 @@
         "id": 50737,
         "Key": "Avenger's Honor",
         "enUS": "Avenger's Honor",
-        "zhTW": "復仇者的榮譽",
+        "zhTW": "复仇者荣誉",
         "deDE": "Rächerehre",
         "esES": "Honor de Vengador",
         "frFR": "L'honneur du vengeur",
@@ -38655,13 +38655,13 @@
         "jaJP": "アベンジャーの名誉",
         "ptBR": "Vingador Horando",
         "ruRU": "Честь мстителя",
-        "zhCN": "复仇者的荣誉"
+        "zhCN": "复仇者荣誉"
     },
     {
         "id": 50738,
         "Key": "Crusader's Wrath",
         "enUS": "Crusader's Wrath",
-        "zhTW": "聖教軍之怒",
+        "zhTW": "十字军之怒",
         "deDE": "Zorn des Kreuzritters",
         "esES": "La ira del cruzado",
         "frFR": "La colère des croisés",
@@ -38678,7 +38678,7 @@
         "id": 50739,
         "Key": "Runestar",
         "enUS": "Runestar",
-        "zhTW": "符文之星",
+        "zhTW": "Runestar",
         "deDE": "Runestar",
         "esES": "Runestar",
         "frFR": "Runestar",
@@ -38689,13 +38689,13 @@
         "jaJP": "ルーンスター",
         "ptBR": "Estrela Rúnica",
         "ruRU": "Runestar",
-        "zhCN": "符文之星"
+        "zhCN": "Runestar"
     },
     {
         "id": 50740,
         "Key": "Trianthalon's Sprinkler",
         "enUS": "Trianthalon's Sprinkler",
-        "zhTW": "特里亞塔倫噴泉",
+        "zhTW": "特里亚塔伦喷泉",
         "deDE": "Trianthalons Sprinkleranlage",
         "esES": "Aspersor de Trianthalon",
         "frFR": "L'arroseur du Trianthalon",
@@ -38712,7 +38712,7 @@
         "id": 50741,
         "Key": "Celestial Knight",
         "enUS": "Celestial Knight",
-        "zhTW": "天界騎士",
+        "zhTW": "天界骑士",
         "deDE": "Himmelsritter",
         "esES": "Caballero Celestial",
         "frFR": "Chevalier céleste",
@@ -38729,7 +38729,7 @@
         "id": 50742,
         "Key": "Vampire's Fang",
         "enUS": "Vampire's Fang",
-        "zhTW": "吸血鬼獠牙",
+        "zhTW": "吸血鬼之牙",
         "deDE": "Vampirzahn",
         "esES": "Colmillo de vampiro",
         "frFR": "Croc de vampire",
@@ -38740,13 +38740,13 @@
         "jaJP": "吸血鬼の牙",
         "ptBR": "Presas de Vampiro",
         "ruRU": "Клык вампира",
-        "zhCN": "吸血鬼獠牙"
+        "zhCN": "吸血鬼之牙"
     },
     {
         "id": 50743,
         "Key": "Dragon Talon",
         "enUS": "Dragon Talon",
-        "zhTW": "龍爪",
+        "zhTW": "龙爪",
         "deDE": "Drachenkralle",
         "esES": "Talón de dragón",
         "frFR": "Talon du dragon",
@@ -38780,7 +38780,7 @@
         "id": 50745,
         "Key": "Cyan Bloodbane",
         "enUS": "Cyan Bloodbane",
-        "zhTW": "青色血禍",
+        "zhTW": "青色血刃",
         "deDE": "Zyanisches Blutkraut",
         "esES": "Cyan Bloodbane",
         "frFR": "Épée de sang cyan",
@@ -38791,7 +38791,7 @@
         "jaJP": "シアン・ブラッドベイン",
         "ptBR": "Sangue Ciano Amaldiçoado",
         "ruRU": "Циан Кровавая баба",
-        "zhCN": "青色血祸"
+        "zhCN": "青色血刃"
     },
     {
         "id": 50746,
@@ -38814,7 +38814,7 @@
         "id": 50747,
         "Key": "Rattlesnake Bite",
         "enUS": "Rattlesnake Bite",
-        "zhTW": "響尾蛇之咬",
+        "zhTW": "响尾蛇咬伤",
         "deDE": "Klapperschlangenbiss",
         "esES": "Mordedura de serpiente de cascabel",
         "frFR": "Morsure de crotale",
@@ -38825,7 +38825,7 @@
         "jaJP": "ガラガラヘビに噛まれる",
         "ptBR": "Picada de Cascavel",
         "ruRU": "Укус гремучей змеи",
-        "zhCN": "响尾蛇之咬"
+        "zhCN": "响尾蛇咬伤"
     },
     {
         "id": 50748,
@@ -38848,7 +38848,7 @@
         "id": 50749,
         "Key": "Thief's Lockpicker",
         "enUS": "Thief's Lockpicker",
-        "zhTW": "盜賊的开锁器",
+        "zhTW": "小偷的开锁匠",
         "deDE": "Diebischer Lockpicker",
         "esES": "Ganzúa de ladrón",
         "frFR": "Lockpicker du voleur",
@@ -38859,13 +38859,13 @@
         "jaJP": "シーフズ・ロックピッカー",
         "ptBR": "Ladrão de Fechaduras",
         "ruRU": "Отмычка вора",
-        "zhCN": "盗贼的开锁器"
+        "zhCN": "小偷的开锁匠"
     },
     {
         "id": 50750,
         "Key": "Basilisk's Touch",
         "enUS": "Basilisk's Touch",
-        "zhTW": "巴斯裏斯克之觸",
+        "zhTW": "巴斯里斯克之触",
         "deDE": "Die Berührung des Basilisken",
         "esES": "Toque de basilisco",
         "frFR": "Le toucher du basilic",
@@ -38882,7 +38882,7 @@
         "id": 50751,
         "Key": "Forbidden Rites",
         "enUS": "Forbidden Rites",
-        "zhTW": "禁忌儀式",
+        "zhTW": "禁忌仪式",
         "deDE": "Verbotene Riten",
         "esES": "Ritos prohibidos",
         "frFR": "Rites interdits",
@@ -38899,7 +38899,7 @@
         "id": 50752,
         "Key": "Elven Mystral",
         "enUS": "Elven Mystral",
-        "zhTW": "精靈秘境",
+        "zhTW": "精灵秘境",
         "deDE": "Elfen Mystral",
         "esES": "Elven Mystral",
         "frFR": "Mystral elfique",
@@ -38916,7 +38916,7 @@
         "id": 50753,
         "Key": "Dagger of Kara'Tir",
         "enUS": "Dagger of Kara'Tir",
-        "zhTW": "卡拉提爾匕首",
+        "zhTW": "卡拉提尔匕首",
         "deDE": "Dolch von Kara'Tir",
         "esES": "Daga de Kara'Tir",
         "frFR": "Dague de Kara'Tir",
@@ -38933,7 +38933,7 @@
         "id": 50754,
         "Key": "Sleepthorn",
         "enUS": "Sleepthorn",
-        "zhTW": "致眠之刺",
+        "zhTW": "Sleepthorn",
         "deDE": "Schlafdorn",
         "esES": "Sleepthorn",
         "frFR": "Sommeil",
@@ -38944,13 +38944,13 @@
         "jaJP": "スリープソーン",
         "ptBR": "Sono Espinhal",
         "ruRU": "Терновник",
-        "zhCN": "致眠之刺"
+        "zhCN": "Sleepthorn"
     },
     {
         "id": 50755,
         "Key": "Mako's Pierce",
         "enUS": "Mako's Pierce",
-        "zhTW": "馬科的穿刺",
+        "zhTW": "马科的皮尔斯",
         "deDE": "Mako's Pierce",
         "esES": "Pierce de Mako",
         "frFR": "Mako's Pierce",
@@ -38961,13 +38961,13 @@
         "jaJP": "マコのピアス",
         "ptBR": "Perfuração de Mako",
         "ruRU": "Пирс Мако",
-        "zhCN": "马科的穿刺"
+        "zhCN": "马科的皮尔斯"
     },
     {
         "id": 50756,
         "Key": "Spear of Hydragoon",
         "enUS": "Spear of Hydragoon",
-        "zhTW": "九頭龍之矛",
+        "zhTW": "水银之矛",
         "deDE": "Speer von Hydragoon",
         "esES": "Lanza de Hidragoon",
         "frFR": "Lance d'Hydragoon",
@@ -38978,13 +38978,13 @@
         "jaJP": "ハイドラグーンの槍",
         "ptBR": "Lança de Hydragoon",
         "ruRU": "Копье Гидрагуна",
-        "zhCN": "九头龙之矛"
+        "zhCN": "水银之矛"
     },
     {
         "id": 50757,
         "Key": "Dragon Turtle",
         "enUS": "Dragon Turtle",
-        "zhTW": "龍龜",
+        "zhTW": "龙龟",
         "deDE": "Drachen-Schildkröte",
         "esES": "Tortuga Dragón",
         "frFR": "Tortue Dragon",
@@ -39001,7 +39001,7 @@
         "id": 50758,
         "Key": "Footman's Picket",
         "enUS": "Footman's Picket",
-        "zhTW": "侍者的尖樁",
+        "zhTW": "脚夫栅栏",
         "deDE": "Streikposten für Fußgänger",
         "esES": "Piquete de lacayos",
         "frFR": "Piquet de pied",
@@ -39012,7 +39012,7 @@
         "jaJP": "フットマンズ・ピケット",
         "ptBR": "Piquete de Lacaio",
         "ruRU": "Пикет лакея",
-        "zhCN": "侍者的尖桩"
+        "zhCN": "脚夫栅栏"
     },
     {
         "id": 50759,
@@ -39035,7 +39035,7 @@
         "id": 50760,
         "Key": "Mandrake",
         "enUS": "Mandrake",
-        "zhTW": "曼德雷克",
+        "zhTW": "曼德拉",
         "deDE": "Alraune",
         "esES": "Mandrágora",
         "frFR": "Mandrake",
@@ -39046,13 +39046,13 @@
         "jaJP": "マンドレイク",
         "ptBR": "Mandrágora",
         "ruRU": "Мандрагора",
-        "zhCN": "曼德雷克"
+        "zhCN": "曼德拉"
     },
     {
         "id": 50761,
         "Key": "Flametongue",
         "enUS": "Flametongue",
-        "zhTW": "火舌",
+        "zhTW": "火焰虫",
         "deDE": "Flammenzunge",
         "esES": "Lengua de fuego",
         "frFR": "Langue de feu",
@@ -39063,13 +39063,13 @@
         "jaJP": "火炎舌",
         "ptBR": "Língua de Fogo",
         "ruRU": "Фламетонга",
-        "zhCN": "火舌"
+        "zhCN": "火焰虫"
     },
     {
         "id": 50762,
         "Key": "Frostband Tine",
         "enUS": "Frostband Tine",
-        "zhTW": "霜帶之牙",
+        "zhTW": "防霜胶带细牙",
         "deDE": "Frostband Zinken",
         "esES": "Cinta antihielo Tine",
         "frFR": "Ruban de givre Dent",
@@ -39080,13 +39080,13 @@
         "jaJP": "フロストテープ タイン",
         "ptBR": "Dente Ponta de Gelo",
         "ruRU": "Морозостойкая лента Лапка",
-        "zhCN": "霜带之牙"
+        "zhCN": "防霜胶带细牙"
     },
     {
         "id": 50763,
         "Key": "Dragoon's Shank",
         "enUS": "Dragoon's Shank",
-        "zhTW": "巨龍脛骨",
+        "zhTW": "龙骨",
         "deDE": "Dragonerschenkel",
         "esES": "Jarrete de dragón",
         "frFR": "Jarret de dragon",
@@ -39097,13 +39097,13 @@
         "jaJP": "ドラグーンズ・シャンク",
         "ptBR": "Perna do Dragão",
         "ruRU": "Хвостовик драгуна",
-        "zhCN": "巨龙胫骨"
+        "zhCN": "龙骨"
     },
     {
         "id": 50764,
         "Key": "Dragon Soul",
         "enUS": "Dragon Soul",
-        "zhTW": "龍魂",
+        "zhTW": "龙魂",
         "deDE": "Drachenseele",
         "esES": "Alma de dragón",
         "frFR": "L'âme du dragon",
@@ -39120,7 +39120,7 @@
         "id": 50765,
         "Key": "Imperial Dragonlance",
         "enUS": "Imperial Dragonlance",
-        "zhTW": "帝國龍槍",
+        "zhTW": "帝国龙骑士",
         "deDE": "Kaiserliche Drachenlanze",
         "esES": "Dragonlance imperial",
         "frFR": "Dragonlance impériale",
@@ -39131,13 +39131,13 @@
         "jaJP": "帝政ドラゴンランス",
         "ptBR": "Lança Dragão Imperial",
         "ruRU": "Имперский Драгонлэнс",
-        "zhCN": "帝国龙枪"
+        "zhCN": "帝国龙骑士"
     },
     {
         "id": 50766,
         "Key": "Spirit of Lachdanan",
         "enUS": "Spirit of Lachdanan",
-        "zhTW": "拉赫達納之魂",
+        "zhTW": "拉赫达纳精神",
         "deDE": "Der Geist von Lachdanan",
         "esES": "Espíritu de Lachdanan",
         "frFR": "Esprit de Lachdanan",
@@ -39148,7 +39148,7 @@
         "jaJP": "ラハダナンの魂",
         "ptBR": "Espírito de Lachdanan",
         "ruRU": "Дух Лахданана",
-        "zhCN": "拉赫达纳之魂"
+        "zhCN": "拉赫达纳精神"
     },
     {
         "id": 50767,
@@ -39171,7 +39171,7 @@
         "id": 50768,
         "Key": "Simpering Edge",
         "enUS": "Simpering Edge",
-        "zhTW": "造作之刃",
+        "zhTW": "Simpering Edge",
         "deDE": "Flüsternde Kante",
         "esES": "El filo de la sonrisa",
         "frFR": "Bordure de chuchotement",
@@ -39182,13 +39182,13 @@
         "jaJP": "シンピング・エッジ",
         "ptBR": "Margem Simulada",
         "ruRU": "Симперинг Эдж",
-        "zhCN": "造作之刃"
+        "zhCN": "Simpering Edge"
     },
     {
         "id": 50769,
         "Key": "Slayer of Fields",
         "enUS": "Slayer of Fields",
-        "zhTW": "田野殺手",
+        "zhTW": "田野杀手",
         "deDE": "Schlächter der Felder",
         "esES": "Cazador de campos",
         "frFR": "Tueur de champs",
@@ -39205,7 +39205,7 @@
         "id": 50770,
         "Key": "Axe of Sytherdan",
         "enUS": "Axe of Sytherdan",
-        "zhTW": "希瑟丹之斧",
+        "zhTW": "瑟瑟丹之斧",
         "deDE": "Axt von Sytherdan",
         "esES": "Hacha de Sytherdan",
         "frFR": "Hache de Sytherdan",
@@ -39216,7 +39216,7 @@
         "jaJP": "シサーダンの斧",
         "ptBR": "Machado de Sytherdan ",
         "ruRU": "Топор Ситердана",
-        "zhCN": "希瑟丹之斧"
+        "zhCN": "瑟瑟丹之斧"
     },
     {
         "id": 50771,
@@ -39239,7 +39239,7 @@
         "id": 50772,
         "Key": "Sommerstrike Edge",
         "enUS": "Sommerstrike Edge",
-        "zhTW": "唯擊之刃",
+        "zhTW": "夏日锋芒",
         "deDE": "Sommerstreik Kante",
         "esES": "Huelga de verano Edge",
         "frFR": "L'avantage de la grève de l'été",
@@ -39250,13 +39250,13 @@
         "jaJP": "サマーストライク・エッジ",
         "ptBR": "Sommer Borda Grave",
         "ruRU": "Летний удар по краю",
-        "zhCN": "唯击之刃"
+        "zhCN": "夏日锋芒"
     },
     {
         "id": 50773,
         "Key": "Count Kidran's Axe",
         "enUS": "Count Kidran's Axe",
-        "zhTW": "基德蘭伯爵之斧",
+        "zhTW": "基德兰伯爵之斧",
         "deDE": "Die Axt des Grafen Kidran",
         "esES": "Hacha del Conde Kidran",
         "frFR": "Hache du comte Kidran",
@@ -39273,7 +39273,7 @@
         "id": 50774,
         "Key": "Griefspawn Touch",
         "enUS": "Griefspawn Touch",
-        "zhTW": "催悲之觸",
+        "zhTW": "悲伤催生之触",
         "deDE": "Griefspawn Touch",
         "esES": "Toque de Griefspawn",
         "frFR": "Griefspawn Touch",
@@ -39284,13 +39284,13 @@
         "jaJP": "グリーフスポーン・タッチ",
         "ptBR": "Luto gera Toque",
         "ruRU": "Griefspawn Touch",
-        "zhCN": "催悲之触"
+        "zhCN": "悲伤催生之触"
     },
     {
         "id": 50775,
         "Key": "Harbormaster's Victory",
         "enUS": "Harbormaster's Victory",
-        "zhTW": "港監的勝利",
+        "zhTW": "船长的胜利",
         "deDE": "Der Sieg des Hafenmeisters",
         "esES": "Victoria del capitán de puerto",
         "frFR": "Victoire du capitaine de port",
@@ -39301,13 +39301,13 @@
         "jaJP": "ハーバーマスターの勝利",
         "ptBR": "Vitória do Mestre do Porto",
         "ruRU": "Победа капитана порта",
-        "zhCN": "港监的胜利"
+        "zhCN": "船长的胜利"
     },
     {
         "id": 50776,
         "Key": "Moonlight Edge",
         "enUS": "Moonlight Edge",
-        "zhTW": "月光之刃",
+        "zhTW": "月光边缘",
         "deDE": "Mondscheinkante",
         "esES": "El borde de la luna",
         "frFR": "Clair de lune",
@@ -39318,13 +39318,13 @@
         "jaJP": "ムーンライト・エッジ",
         "ptBR": "Borda da Luz da Lua",
         "ruRU": "Лунный край",
-        "zhCN": "月光之刃"
+        "zhCN": "月光边缘"
     },
     {
         "id": 50777,
         "Key": "Kritchan's Ire",
         "enUS": "Kritchan's Ire",
-        "zhTW": "奎特陳的憤怒",
+        "zhTW": "Kritchan's Ire",
         "deDE": "Kritchans Ire",
         "esES": "Kritchan's Ire",
         "frFR": "L'Ire de Kritchan",
@@ -39335,13 +39335,13 @@
         "jaJP": "クリチャンの地雷",
         "ptBR": "Ira de Kritchan",
         "ruRU": "Ире Критчан",
-        "zhCN": "奎特陈的憤怒"
+        "zhCN": "Kritchan's Ire"
     },
     {
         "id": 50778,
         "Key": "Killer's Glee",
         "enUS": "Killer's Glee",
-        "zhTW": "殺手的得意",
+        "zhTW": "杀手的欢乐",
         "deDE": "Killer's Glee",
         "esES": "El regocijo del asesino",
         "frFR": "La joie du tueur",
@@ -39352,13 +39352,13 @@
         "jaJP": "キラーズ・グリー",
         "ptBR": "Assassino de Glee",
         "ruRU": "Ликование убийцы",
-        "zhCN": "杀手的得意"
+        "zhCN": "杀手的欢乐"
     },
     {
         "id": 50779,
         "Key": "Dawn of the Dead",
         "enUS": "Dawn of the Dead",
-        "zhTW": "亡者黎明",
+        "zhTW": "死亡黎明",
         "deDE": "Die Morgendämmerung der Toten",
         "esES": "El Amanecer de los Muertos",
         "frFR": "L'aube des morts",
@@ -39369,13 +39369,13 @@
         "jaJP": "ドーン・オブ・ザ・デッド",
         "ptBR": "Madrugada dos Mortos",
         "ruRU": "Рассвет мертвецов",
-        "zhCN": "亡者黎明"
+        "zhCN": "死亡黎明"
     },
     {
         "id": 50780,
         "Key": "Ogre Chieftain's Law",
         "enUS": "Ogre Chieftain's Law",
-        "zhTW": "巨魔酋長的鐵律",
+        "zhTW": "食人魔酋长法则",
         "deDE": "Das Gesetz des Ogerhäuptlings",
         "esES": "Ley del Cacique Ogro",
         "frFR": "Loi du chef ogre",
@@ -39386,7 +39386,7 @@
         "jaJP": "オーガ酋長の法則",
         "ptBR": "Lei do Ogro Chefe",
         "ruRU": "Закон вождя огров",
-        "zhCN": "食人魔酋长的铁律"
+        "zhCN": "食人魔酋长法则"
     },
     {
         "id": 50781,
@@ -39426,7 +39426,7 @@
         "id": 50783,
         "Key": "Cloud Giant's Axe",
         "enUS": "Cloud Giant's Axe",
-        "zhTW": "雲端巨人之斧",
+        "zhTW": "云巨人之斧",
         "deDE": "Axt des Wolkenriesen",
         "esES": "Hacha del gigante de las nubes",
         "frFR": "Hache du géant des nuages",
@@ -39437,13 +39437,13 @@
         "jaJP": "雲の巨人の斧",
         "ptBR": "Gigante Machado Nuvem",
         "ruRU": "Топор облачного гиганта",
-        "zhCN": "云端巨人之斧"
+        "zhCN": "云巨人之斧"
     },
     {
         "id": 50784,
         "Key": "Kraken's Fury",
         "enUS": "Kraken's Fury",
-        "zhTW": "海怪的怒火",
+        "zhTW": "克拉肯之怒",
         "deDE": "Der Zorn des Kraken",
         "esES": "La furia del Kraken",
         "frFR": "La fureur du Kraken",
@@ -39454,13 +39454,13 @@
         "jaJP": "クラーケンの怒り",
         "ptBR": "Lula Gigante Folgado",
         "ruRU": "Ярость Кракена",
-        "zhCN": "深海巨妖的怒火"
+        "zhCN": "克拉肯之怒"
     },
     {
         "id": 50785,
         "Key": "Warmth of Ash",
         "enUS": "Warmth of Ash",
-        "zhTW": "灰燼餘溫",
+        "zhTW": "灰烬的温暖",
         "deDE": "Wärme der Asche",
         "esES": "Calor de ceniza",
         "frFR": "La chaleur des cendres",
@@ -39471,13 +39471,13 @@
         "jaJP": "灰のぬくもり",
         "ptBR": "Calor das Cinzas",
         "ruRU": "Тепло пепла",
-        "zhCN": "灰烬余温"
+        "zhCN": "灰烬的温暖"
     },
     {
         "id": 50786,
         "Key": "Arctic Frost",
         "enUS": "Arctic Frost",
-        "zhTW": "北極寒霜",
+        "zhTW": "北极寒霜",
         "deDE": "Arktischer Frost",
         "esES": "Escarcha ártica",
         "frFR": "Givre arctique",
@@ -39494,7 +39494,7 @@
         "id": 50787,
         "Key": "Touch of Evil",
         "enUS": "Touch of Evil",
-        "zhTW": "邪惡之觸",
+        "zhTW": "触摸邪恶",
         "deDE": "Der Hauch des Bösen",
         "esES": "Toque de maldad",
         "frFR": "La touche du mal",
@@ -39505,13 +39505,13 @@
         "jaJP": "タッチ・オブ・イーブル",
         "ptBR": "Toque do Mal",
         "ruRU": "Прикосновение зла",
-        "zhCN": "邪恶之触"
+        "zhCN": "触摸邪恶"
     },
     {
         "id": 50788,
         "Key": "Staff of the Arch-Magus",
         "enUS": "Staff of the Arch-Magus",
-        "zhTW": "大魔導師之杖",
+        "zhTW": "大魔导师之杖",
         "deDE": "Stab des Erzmagus",
         "esES": "Bastón del archimago",
         "frFR": "Personnel de l'Archimage",
@@ -39528,7 +39528,7 @@
         "id": 50789,
         "Key": "Wizard's Rule",
         "enUS": "Wizard's Rule",
-        "zhTW": "巫師法則",
+        "zhTW": "巫师规则",
         "deDE": "Die Regel des Zauberers",
         "esES": "Regla del mago",
         "frFR": "Règle du sorcier",
@@ -39539,13 +39539,13 @@
         "jaJP": "魔法使いのルール",
         "ptBR": "Regra do Feiticeiro",
         "ruRU": "Правило волшебника",
-        "zhCN": "巫师法则"
+        "zhCN": "巫师规则"
     },
     {
         "id": 50790,
         "Key": "Ter'Angreal",
         "enUS": "Ter'Angreal",
-        "zhTW": "特安格爾",
+        "zhTW": "特安格尔",
         "deDE": "Ter'Angreal",
         "esES": "Ter'Angreal",
         "frFR": "Ter'Angreal",
@@ -39562,7 +39562,7 @@
         "id": 50791,
         "Key": "Staff of Valere",
         "enUS": "Staff of Valere",
-        "zhTW": "瓦萊雇員",
+        "zhTW": "瓦莱工作人员",
         "deDE": "Personal von Valere",
         "esES": "Personal de Valere",
         "frFR": "Personnel de Valère",
@@ -39573,13 +39573,13 @@
         "jaJP": "ヴァレールのスタッフ",
         "ptBR": "Cajado de Valere",
         "ruRU": "Персонал Валеры",
-        "zhCN": "瓦莱雇员"
+        "zhCN": "瓦莱工作人员"
     },
     {
         "id": 50792,
         "Key": "Knight's Prophet",
         "enUS": "Knight's Prophet",
-        "zhTW": "騎士先知",
+        "zhTW": "骑士先知",
         "deDE": "Der Prophet des Ritters",
         "esES": "El profeta de los caballeros",
         "frFR": "Le prophète des chevaliers",
@@ -39596,7 +39596,7 @@
         "id": 50793,
         "Key": "Arcane Protection",
         "enUS": "Arcane Protection",
-        "zhTW": "奧術防護",
+        "zhTW": "奥术保护",
         "deDE": "Arkaner Schutz",
         "esES": "Protección Arcana",
         "frFR": "Protection des arcanes",
@@ -39607,7 +39607,7 @@
         "jaJP": "アルケイン・プロテクション",
         "ptBR": "Proteção Arcana",
         "ruRU": "Защита от арканов",
-        "zhCN": "奥术防护"
+        "zhCN": "奥术保护"
     },
     {
         "id": 50794,
@@ -39630,7 +39630,7 @@
         "id": 50795,
         "Key": "Ladrina's Enchantment",
         "enUS": "Ladrina's Enchantment",
-        "zhTW": "拉德麗娜的强化",
+        "zhTW": "拉德丽娜的魅力",
         "deDE": "Ladrina's Verzauberung",
         "esES": "El encanto de Ladrina",
         "frFR": "L'enchantement de Ladrina",
@@ -39641,13 +39641,13 @@
         "jaJP": "ラドリナの魔法",
         "ptBR": "Encantamento de Ladrina",
         "ruRU": "Зачарование Ладрины",
-        "zhCN": "拉德丽娜的强化"
+        "zhCN": "拉德丽娜的魅力"
     },
     {
         "id": 50796,
         "Key": "Dracolich Fang",
         "enUS": "Dracolich Fang",
-        "zhTW": "龍巫妖之獠牙",
+        "zhTW": "德拉古利奇方",
         "deDE": "Dracolich Fang",
         "esES": "Colmillo Dracolich",
         "frFR": "Dracolich Fang",
@@ -39658,13 +39658,13 @@
         "jaJP": "ドラコリッチ・ファング",
         "ptBR": "Presa do Dragão Lich",
         "ruRU": "Клык Драколича",
-        "zhCN": "龙巫妖的獠牙"
+        "zhCN": "德拉古利奇方"
     },
     {
         "id": 50797,
         "Key": "Skeleton's Claw",
         "enUS": "Skeleton's Claw",
-        "zhTW": "骷髏之爪",
+        "zhTW": "骷髅之爪",
         "deDE": "Skelettklaue",
         "esES": "Garra de esqueleto",
         "frFR": "Griffe de squelette",
@@ -39681,7 +39681,7 @@
         "id": 50798,
         "Key": "Apocalypse Fire",
         "enUS": "Apocalypse Fire",
-        "zhTW": "天啓之火",
+        "zhTW": "天启之火",
         "deDE": "Apokalypse Feuer",
         "esES": "Apocalipsis Fuego",
         "frFR": "Feu de l'apocalypse",
@@ -39698,7 +39698,7 @@
         "id": 50799,
         "Key": "Gravedancer's Union",
         "enUS": "Gravedancer's Union",
-        "zhTW": "墓上舞者联盟",
+        "zhTW": "掘墓人联盟",
         "deDE": "Gewerkschaft der Totengräber",
         "esES": "Sindicato de Sepultureros",
         "frFR": "Union des fossoyeurs",
@@ -39709,13 +39709,13 @@
         "jaJP": "グレイブダンサーズ・ユニオン",
         "ptBR": "União do Coveiro",
         "ruRU": "Союз могильщиков",
-        "zhCN": "墓上舞者联盟"
+        "zhCN": "掘墓人联盟"
     },
     {
         "id": 50800,
         "Key": "Asylum's Ward",
         "enUS": "Asylum's Ward",
-        "zhTW": "精神庇護",
+        "zhTW": "庇护所病房",
         "deDE": "Krankenstation des Asyls",
         "esES": "Pabellón del manicomio",
         "frFR": "Quartier de l'asile",
@@ -39726,13 +39726,13 @@
         "jaJP": "精神病院病棟",
         "ptBR": "Enfermaria de Asilo",
         "ruRU": "Палата убежища",
-        "zhCN": "精神庇护"
+        "zhCN": "庇护所病房"
     },
     {
         "id": 50801,
         "Key": "Huclavee's Flinch",
         "enUS": "Huclavee's Flinch",
-        "zhTW": "哈克拉維的退縮",
+        "zhTW": "Huclavee's Flinch",
         "deDE": "Huclavees Zucken",
         "esES": "Huclavee's Flinch",
         "frFR": "Le flinch de Huclavee",
@@ -39743,13 +39743,13 @@
         "jaJP": "フクラヴィーのフリンチ",
         "ptBR": "Vacilante de Huclavee",
         "ruRU": "Вздрагивание Хаклави",
-        "zhCN": "哈克拉维的退縮"
+        "zhCN": "Huclavee's Flinch"
     },
     {
         "id": 50802,
         "Key": "Centaur's Arc",
         "enUS": "Centaur's Arc",
-        "zhTW": "半人馬之弧",
+        "zhTW": "半人马的弧线",
         "deDE": "Zentaurenbogen",
         "esES": "Arco del Centauro",
         "frFR": "Arc du Centaure",
@@ -39760,13 +39760,13 @@
         "jaJP": "ケンタウロス・アーク",
         "ptBR": "Arco do Centauro",
         "ruRU": "Дуга кентавра",
-        "zhCN": "半人马之弧"
+        "zhCN": "半人马的弧线"
     },
     {
         "id": 50803,
         "Key": "Freedom's Flight",
         "enUS": "Freedom's Flight",
-        "zhTW": "自由飛翔",
+        "zhTW": "自由飞翔",
         "deDE": "Der Flug der Freiheit",
         "esES": "El vuelo de la libertad",
         "frFR": "Le vol de la liberté",
@@ -39783,7 +39783,7 @@
         "id": 50804,
         "Key": "Elven Bow of Duadon",
         "enUS": "Elven Bow of Duadon",
-        "zhTW": "杜亞頓精靈弓",
+        "zhTW": "杜亚顿精灵弓",
         "deDE": "Elfenbogen von Duadon",
         "esES": "Arco élfico de Duadon",
         "frFR": "Arc elfique de Duadon",
@@ -39800,7 +39800,7 @@
         "id": 50805,
         "Key": "Silver Oak Bow",
         "enUS": "Silver Oak Bow",
-        "zhTW": "銀橡樹弓",
+        "zhTW": "银橡树弓",
         "deDE": "Silber Eiche Bogen",
         "esES": "Arco de roble plateado",
         "frFR": "Arc en chêne argenté",
@@ -39817,7 +39817,7 @@
         "id": 50806,
         "Key": "Adamantine Bow",
         "enUS": "Adamantine Bow",
-        "zhTW": "金剛弓",
+        "zhTW": "金刚弓",
         "deDE": "Adamantiner Bogen",
         "esES": "Arco Adamantino",
         "frFR": "Arc adamantin",
@@ -39851,7 +39851,7 @@
         "id": 50808,
         "Key": "Radament's Bite",
         "enUS": "Radament's Bite",
-        "zhTW": "拉達孟特之噬咬",
+        "zhTW": "拉達孟之噬",
         "deDE": "Radaments Biss",
         "esES": "Mordedura de Radament",
         "frFR": "Morsure de Radament",
@@ -39862,13 +39862,13 @@
         "jaJP": "ラダメントの牙",
         "ptBR": "Mordida de Radament",
         "ruRU": "Укус Радамента",
-        "zhCN": "拉达孟特的噬咬"
+        "zhCN": "拉达孟的咬噬"
     },
     {
         "id": 50809,
         "Key": "Sylvan Battle Bow",
         "enUS": "Sylvan Battle Bow",
-        "zhTW": "希爾凡戰弓",
+        "zhTW": "希尔凡战弓",
         "deDE": "Sylvanischer Kampfbogen",
         "esES": "Arco de batalla silvano",
         "frFR": "Arc de combat sylvestre",
@@ -39885,7 +39885,7 @@
         "id": 50810,
         "Key": "Shayira's Flight",
         "enUS": "Shayira's Flight",
-        "zhTW": "夏伊拉的飛行",
+        "zhTW": "夏伊拉的飞行",
         "deDE": "Shayiras Flug",
         "esES": "El vuelo de Shayira",
         "frFR": "Le vol de Shayira",
@@ -39902,7 +39902,7 @@
         "id": 50811,
         "Key": "Kirre Strike",
         "enUS": "Kirre Strike",
-        "zhTW": "基爾的襲擊",
+        "zhTW": "基尔罢工",
         "deDE": "Kirreschlag",
         "esES": "Huelga Kirre",
         "frFR": "Grève de Kirre",
@@ -39913,13 +39913,13 @@
         "jaJP": "キレ・ストライク",
         "ptBR": "Ataque de Kirre",
         "ruRU": "Кирре Страйк",
-        "zhCN": "基尔的袭击"
+        "zhCN": "基尔罢工"
     },
     {
         "id": 50812,
         "Key": "Telena's War Bow",
         "enUS": "Telena's War Bow",
-        "zhTW": "泰萊娜戰弓",
+        "zhTW": "泰莱娜战弓",
         "deDE": "Telenas Kriegsbogen",
         "esES": "Arco de guerra de Telena",
         "frFR": "L'arc de guerre de Telena",
@@ -39936,7 +39936,7 @@
         "id": 50813,
         "Key": "Teldicia's Sting",
         "enUS": "Teldicia's Sting",
-        "zhTW": "特爾迪西亞之刺",
+        "zhTW": "特尔迪西亚之刺",
         "deDE": "Teldicia-Stachel",
         "esES": "Picadura de Teldicia",
         "frFR": "L'aiguillon de Teldicia",
@@ -39953,7 +39953,7 @@
         "id": 50814,
         "Key": "Sadira",
         "enUS": "Sadira",
-        "zhTW": "薩迪拉",
+        "zhTW": "萨迪拉",
         "deDE": "Sadira",
         "esES": "Sadira",
         "frFR": "Sadira",
@@ -39970,7 +39970,7 @@
         "id": 50815,
         "Key": "Ravenclaw",
         "enUS": "Ravenclaw",
-        "zhTW": "烏鴉之爪",
+        "zhTW": "拉文克劳",
         "deDE": "Ravenclaw",
         "esES": "Ravenclaw",
         "frFR": "Corbeau",
@@ -39981,13 +39981,13 @@
         "jaJP": "レイブンクロー",
         "ptBR": "Garra de Raven",
         "ruRU": "Рейвенкло",
-        "zhCN": "乌鸦之爪"
+        "zhCN": "拉文克劳"
     },
     {
         "id": 50816,
         "Key": "Larissa's Aim",
         "enUS": "Larissa's Aim",
-        "zhTW": "拉麗莎的目標",
+        "zhTW": "拉丽莎的目标",
         "deDE": "Larissas Ziel",
         "esES": "Objetivo de Larissa",
         "frFR": "L'objectif de Larissa",
@@ -40004,7 +40004,7 @@
         "id": 50817,
         "Key": "Hailstrike",
         "enUS": "Hailstrike",
-        "zhTW": "冰雹打擊",
+        "zhTW": "冰雹",
         "deDE": "Hagelsturm",
         "esES": "Hailstrike",
         "frFR": "Grêle",
@@ -40015,7 +40015,7 @@
         "jaJP": "ヘイルストライク",
         "ptBR": "Ataque Saraiva",
         "ruRU": "Хейлстрайк",
-        "zhCN": "冰雹打击"
+        "zhCN": "冰雹"
     },
     {
         "id": 50818,
@@ -40038,7 +40038,7 @@
         "id": 50819,
         "Key": "Dune Runner",
         "enUS": "Dune Runner",
-        "zhTW": "沙丘轉輪",
+        "zhTW": "沙丘转轮",
         "deDE": "Dünenläufer",
         "esES": "Corredor de dunas",
         "frFR": "Coureur de dunes",
@@ -40055,7 +40055,7 @@
         "id": 50820,
         "Key": "Remorhaz",
         "enUS": "Remorhaz",
-        "zhTW": "冰蠕蟲",
+        "zhTW": "Remorhaz",
         "deDE": "Remorhaz",
         "esES": "Remorhaz",
         "frFR": "Remorhaz",
@@ -40066,13 +40066,13 @@
         "jaJP": "レモラズ",
         "ptBR": "Verme Polar",
         "ruRU": "Реморхаз",
-        "zhCN": "冰蠕虫"
+        "zhCN": "Remorhaz"
     },
     {
         "id": 50821,
         "Key": "Ghost Mount",
         "enUS": "Ghost Mount",
-        "zhTW": "幽靈坐騎",
+        "zhTW": "幽灵坐骑",
         "deDE": "Geisterberg",
         "esES": "Montaje fantasma",
         "frFR": "Mont fantôme",
@@ -40089,7 +40089,7 @@
         "id": 50822,
         "Key": "Arachnid's Bite",
         "enUS": "Arachnid's Bite",
-        "zhTW": "巨蛛之撕咬",
+        "zhTW": "蛛形纲动物的撕咬",
         "deDE": "Arachnidenbiss",
         "esES": "Mordedura de arácnido",
         "frFR": "Morsure d'arachnide",
@@ -40100,13 +40100,13 @@
         "jaJP": "アラクニド・バイト",
         "ptBR": "Mordida de Aracnídeo",
         "ruRU": "Укус арахнида",
-        "zhCN": "巨蛛之撕咬"
+        "zhCN": "蛛形纲动物的撕咬"
     },
     {
         "id": 50823,
         "Key": "Foxfire Leaf",
         "enUS": "Foxfire Leaf",
-        "zhTW": "火狐之葉",
+        "zhTW": "狐火叶",
         "deDE": "Fuchsschwanz-Blatt",
         "esES": "Hoja Foxfire",
         "frFR": "Feuille de feu de renard",
@@ -40117,13 +40117,13 @@
         "jaJP": "フォックスファイヤー・リーフ",
         "ptBR": "Folha Fogo de Fada",
         "ruRU": "Лист лисьего огня",
-        "zhCN": "火狐之叶"
+        "zhCN": "狐火叶"
     },
     {
         "id": 50824,
         "Key": "Golgomere",
         "enUS": "Golgomere",
-        "zhTW": "戈爾戈梅爾",
+        "zhTW": "戈尔戈梅尔",
         "deDE": "Golgomere",
         "esES": "Golgomere",
         "frFR": "Golgomère",
@@ -40140,7 +40140,7 @@
         "id": 50825,
         "Key": "Rethral Bolt",
         "enUS": "Rethral Bolt",
-        "zhTW": "瑞瑟爾弩矢",
+        "zhTW": "Rethral Bolt",
         "deDE": "Rethral-Schraube",
         "esES": "Tornillo Rethral",
         "frFR": "Boulon de rétroréflexion",
@@ -40151,13 +40151,13 @@
         "jaJP": "レトラル・ボルト",
         "ptBR": "Parafuso Retral",
         "ruRU": "Ретраловый болт",
-        "zhCN": "瑞瑟尔弩矢"
+        "zhCN": "Rethral Bolt"
     },
     {
         "id": 50826,
         "Key": "Piercing Bolt",
         "enUS": "Piercing Bolt",
-        "zhTW": "穿刺弩矢",
+        "zhTW": "穿刺螺栓",
         "deDE": "Piercing Bolt",
         "esES": "Perno perforador",
         "frFR": "Boulon perforant",
@@ -40168,7 +40168,7 @@
         "jaJP": "ピアスボルト",
         "ptBR": "Parafuso Perfurante",
         "ruRU": "Пронзающий болт",
-        "zhCN": "穿刺弩矢"
+        "zhCN": "穿刺螺栓"
     },
     {
         "id": 50827,
@@ -40191,7 +40191,7 @@
         "id": 50828,
         "Key": "Synthalus",
         "enUS": "Synthalus",
-        "zhTW": "辛薩魯斯",
+        "zhTW": "Synthalus",
         "deDE": "Synthalus",
         "esES": "Synthalus",
         "frFR": "Synthalus",
@@ -40202,13 +40202,13 @@
         "jaJP": "シンタラス",
         "ptBR": "Síntalo",
         "ruRU": "Синталус",
-        "zhCN": "辛萨鲁斯"
+        "zhCN": "Synthalus"
     },
     {
         "id": 50829,
         "Key": "Kyuss' Crossbow",
         "enUS": "Kyuss' Crossbow",
-        "zhTW": "凱沃斯的十字弓",
+        "zhTW": "Kyuss 的十字弓",
         "deDE": "Kyuss' Armbrust",
         "esES": "Ballesta de Kyuss",
         "frFR": "L'arbalète de Kyuss",
@@ -40219,13 +40219,13 @@
         "jaJP": "キウスのクロスボウ",
         "ptBR": "Cruz Arco de Kyuss",
         "ruRU": "Арбалет Кюсса",
-        "zhCN": "凯沃斯的十字弓"
+        "zhCN": "Kyuss 的十字弓"
     },
     {
         "id": 50830,
         "Key": "Garlana Firebolt",
         "enUS": "Garlana Firebolt",
-        "zhTW": "蓋爾拉娜火弩",
+        "zhTW": "Garlana Firebolt",
         "deDE": "Garlana Feuerblitz",
         "esES": "Garlana Rayo de Fuego",
         "frFR": "Garlana Firebolt",
@@ -40236,13 +40236,13 @@
         "jaJP": "ガルラナ・ファイアボルト",
         "ptBR": "Parafuso Fogo de Garlana",
         "ruRU": "Гарлана Файерболт",
-        "zhCN": "盖尔拉娜火弩"
+        "zhCN": "Garlana Firebolt"
     },
     {
         "id": 50831,
         "Key": "Giant Hair Crossbow",
         "enUS": "Giant Hair Crossbow",
-        "zhTW": "巨型毛髮弩",
+        "zhTW": "巨型毛发弩",
         "deDE": "Riesenhaar-Armbrust",
         "esES": "Ballesta de pelo gigante",
         "frFR": "Arbalète à poils géants",
@@ -40259,7 +40259,7 @@
         "id": 50832,
         "Key": "Raven Myst",
         "enUS": "Raven Myst",
-        "zhTW": "烏鴉之謎",
+        "zhTW": "乌鸦之谜",
         "deDE": "Raven Myst",
         "esES": "Raven Myst",
         "frFR": "Raven Myst",
@@ -40276,7 +40276,7 @@
         "id": 50833,
         "Key": "Whyte Stag",
         "enUS": "Whyte Stag",
-        "zhTW": "懷特獵鹿弩",
+        "zhTW": "怀特雄鹿",
         "deDE": "Whyte Stag",
         "esES": "Ciervo Whyte",
         "frFR": "Whyte Stag",
@@ -40287,13 +40287,13 @@
         "jaJP": "ホワイティ・スタッグ",
         "ptBR": "Especulador Branco",
         "ruRU": "Олень Уайт",
-        "zhCN": "怀特猎鹿弩"
+        "zhCN": "怀特雄鹿"
     },
     {
         "id": 50834,
         "Key": "Senmet's Boltcaster",
         "enUS": "Senmet's Boltcaster",
-        "zhTW": "森美特連弩",
+        "zhTW": "森美特螺栓铸件",
         "deDE": "Braunkehlchenschraubenzieher",
         "esES": "Tenaza de Senmet",
         "frFR": "La boulonnerie de Senmet",
@@ -40304,13 +40304,13 @@
         "jaJP": "センメのボルトキャスター",
         "ptBR": "Lançador de Raio Sermet's",
         "ruRU": "Болткастер Сенмета",
-        "zhCN": "森美特连弩"
+        "zhCN": "森美特螺栓铸件"
     },
     {
         "id": 50835,
         "Key": "Ashira's Stunbeam",
         "enUS": "Ashira's Stunbeam",
-        "zhTW": "阿希拉的眩暈光束",
+        "zhTW": "阿希拉的眩晕光束",
         "deDE": "Ashiras Betäubungsstrahl",
         "esES": "Rayo aturdidor de Ashira",
         "frFR": "Le rayon étourdissant d'Ashira",
@@ -40327,7 +40327,7 @@
         "id": 50836,
         "Key": "Stoneblaster",
         "enUS": "Stoneblaster",
-        "zhTW": "爆石者",
+        "zhTW": "石匠",
         "deDE": "Steinputzer",
         "esES": "Yesero",
         "frFR": "Pierre de taille",
@@ -40338,13 +40338,13 @@
         "jaJP": "ストーンブラスター",
         "ptBR": "Explosão de Pedra",
         "ruRU": "Каменщик",
-        "zhCN": "爆石者"
+        "zhCN": "石匠"
     },
     {
         "id": 50837,
         "Key": "Wightslayer",
         "enUS": "Wightslayer",
-        "zhTW": "幽靈屠夫",
+        "zhTW": "Wightslayer",
         "deDE": "Wightslayer",
         "esES": "Wightslayer",
         "frFR": "Tisseur de phares",
@@ -40355,13 +40355,13 @@
         "jaJP": "ウェイツレイヤー",
         "ptBR": "Criatura Assassina",
         "ruRU": "Wightslayer",
-        "zhCN": "幽灵屠夫"
+        "zhCN": "Wightslayer"
     },
     {
         "id": 50838,
         "Key": "Bluebeard",
         "enUS": "Bluebeard",
-        "zhTW": "藍鬍子",
+        "zhTW": "蓝胡子",
         "deDE": "Blaubart",
         "esES": "Barbazul",
         "frFR": "Barbe bleue",
@@ -40378,7 +40378,7 @@
         "id": 50839,
         "Key": "Thor's Bolt",
         "enUS": "Thor's Bolt",
-        "zhTW": "索爾之弩",
+        "zhTW": "雷神之锤",
         "deDE": "Thors Bolzen",
         "esES": "El rayo de Thor",
         "frFR": "L'éclair de Thor",
@@ -40389,7 +40389,7 @@
         "jaJP": "トールのボルト",
         "ptBR": "Raio de Thor",
         "ruRU": "Болт Тора",
-        "zhCN": "索尔之弩"
+        "zhCN": "雷神之锤"
     },
     {
         "id": 50840,
@@ -40412,7 +40412,7 @@
         "id": 50841,
         "Key": "Amazon's Kiss",
         "enUS": "Amazon's Kiss",
-        "zhTW": "亞馬遜之吻",
+        "zhTW": "亚马逊之吻",
         "deDE": "Der Kuss der Amazone",
         "esES": "El beso del Amazonas",
         "frFR": "Le baiser d'Amazon",
@@ -40429,7 +40429,7 @@
         "id": 50842,
         "Key": "Cadin'Sor",
         "enUS": "Cadin'Sor",
-        "zhTW": "卡丁瑟",
+        "zhTW": "Cadin'Sor",
         "deDE": "Cadin's Sor",
         "esES": "Cadin'Sor",
         "frFR": "Cadin'Sor",
@@ -40440,13 +40440,13 @@
         "jaJP": "カディンソール",
         "ptBR": "Uniforme Das Guerreiras de Aiel",
         "ruRU": "Кадин'Сор",
-        "zhCN": "卡丁瑟"
+        "zhCN": "Cadin'Sor"
     },
     {
         "id": 50843,
         "Key": "Aiel Javelins",
         "enUS": "Aiel Javelins",
-        "zhTW": "艾爾標槍",
+        "zhTW": "艾尔标枪",
         "deDE": "Aiel Speere",
         "esES": "Jabalinas Aiel",
         "frFR": "Javelots d'Aiel",
@@ -40463,7 +40463,7 @@
         "id": 50844,
         "Key": "Artemis's Spiculum",
         "enUS": "Artemis's Spiculum",
-        "zhTW": "阿爾忒弥斯的闊矛",
+        "zhTW": "阿耳忒弥斯的刺球",
         "deDE": "Spiculum der Artemis",
         "esES": "Espícula de Artemisa",
         "frFR": "Spicule d'Artémis",
@@ -40474,7 +40474,7 @@
         "jaJP": "アルテミスのスピキュラム",
         "ptBR": "Espéculo de Artimus",
         "ruRU": "Спикула Артемиды",
-        "zhCN": "阿尔忒弥斯的阔矛"
+        "zhCN": "阿耳忒弥斯的刺球"
     },
     {
         "id": 50845,
@@ -40497,7 +40497,7 @@
         "id": 50846,
         "Key": "Gnomebane",
         "enUS": "Gnomebane",
-        "zhTW": "地精禍根",
+        "zhTW": "地精课程",
         "deDE": "Zwergkurs",
         "esES": "Curso para gnomos",
         "frFR": "Cours Gnome",
@@ -40508,13 +40508,13 @@
         "jaJP": "ノームコース",
         "ptBR": "Maldição do Gnomo",
         "ruRU": "Курс гномов",
-        "zhCN": "地精祸根"
+        "zhCN": "地精课程"
     },
     {
         "id": 50847,
         "Key": "Silver-Tipped Harpoons",
         "enUS": "Silver-Tipped Harpoons",
-        "zhTW": "銀尖魚叉",
+        "zhTW": "银尖鱼叉",
         "deDE": "Harpunen mit Silberspitzen",
         "esES": "Arpones con punta de plata",
         "frFR": "Harpons à pointe argentée",
@@ -40531,7 +40531,7 @@
         "id": 50848,
         "Key": "Flight of Confusion",
         "enUS": "Flight of Confusion",
-        "zhTW": "混亂飛行",
+        "zhTW": "混乱的飞行",
         "deDE": "Flucht der Verwirrung",
         "esES": "Vuelo de la confusión",
         "frFR": "Le vol de la confusion",
@@ -40542,13 +40542,13 @@
         "jaJP": "混乱の飛翔",
         "ptBR": "Vôo Confuso",
         "ruRU": "Полет в смятении",
-        "zhCN": "混乱飞行"
+        "zhCN": "混乱的飞行"
     },
     {
         "id": 50849,
         "Key": "Clockwork Horror",
         "enUS": "Clockwork Horror",
-        "zhTW": "機械恐懼",
+        "zhTW": "发条恐怖",
         "deDE": "Uhrwerk-Horror",
         "esES": "Horror mecánico",
         "frFR": "Horreur de l'horloge",
@@ -40559,13 +40559,13 @@
         "jaJP": "時計じかけのホラー",
         "ptBR": "Horror Mecânico",
         "ruRU": "Заводной ужас",
-        "zhCN": "机械恐惧"
+        "zhCN": "发条恐怖"
     },
     {
         "id": 50850,
         "Key": "Serpent Lord",
         "enUS": "Serpent Lord",
-        "zhTW": "巨蛇之王",
+        "zhTW": "蛇王",
         "deDE": "Serpent Lord",
         "esES": "Señor Serpiente",
         "frFR": "Serpent Lord",
@@ -40576,13 +40576,13 @@
         "jaJP": "サーペント・ロード",
         "ptBR": "Senhor Serpente",
         "ruRU": "Повелитель змей",
-        "zhCN": "巨蛇之王"
+        "zhCN": "蛇王"
     },
     {
         "id": 50851,
         "Key": "Spectral Slayer",
         "enUS": "Spectral Slayer",
-        "zhTW": "幽靈殺手",
+        "zhTW": "光谱杀手",
         "deDE": "Spektraltöter",
         "esES": "Cazador espectral",
         "frFR": "Tueur spectral",
@@ -40593,13 +40593,13 @@
         "jaJP": "スペクトラル・スレイヤー",
         "ptBR": "Fantasma Espectral",
         "ruRU": "Спектральный истребитель",
-        "zhCN": "幽灵杀手"
+        "zhCN": "光谱杀手"
     },
     {
         "id": 50852,
         "Key": "Invisible Stalker",
         "enUS": "Invisible Stalker",
-        "zhTW": "隱形跟蹤者",
+        "zhTW": "隐形跟踪者",
         "deDE": "Unsichtbarer Stalker",
         "esES": "Acosador invisible",
         "frFR": "Harceleur invisible",
@@ -40616,7 +40616,7 @@
         "id": 50853,
         "Key": "Oakplume",
         "enUS": "Oakplume",
-        "zhTW": "橡樹之綹",
+        "zhTW": "橡树翎",
         "deDE": "Oakplume",
         "esES": "Oakplume",
         "frFR": "Oakplume",
@@ -40627,7 +40627,7 @@
         "jaJP": "オークプルーム",
         "ptBR": "Pluma de Carvalho",
         "ruRU": "Oakplume",
-        "zhCN": "橡树之绺"
+        "zhCN": "橡树翎"
     },
     {
         "id": 50854,
@@ -40650,7 +40650,7 @@
         "id": 50855,
         "Key": "Winged Serpent",
         "enUS": "Winged Serpent",
-        "zhTW": "飛翼巨蛇",
+        "zhTW": "有翼之蛇",
         "deDE": "Geflügelte Schlange",
         "esES": "Serpiente alada",
         "frFR": "Serpent ailé",
@@ -40661,7 +40661,7 @@
         "jaJP": "ウイング・サーペント",
         "ptBR": "Serpente Alada",
         "ruRU": "Крылатый змей",
-        "zhCN": "飞翼巨蛇"
+        "zhCN": "有翼之蛇"
     },
     {
         "id": 50856,
@@ -40684,7 +40684,7 @@
         "id": 50857,
         "Key": "Golden Wyndlass",
         "enUS": "Golden Wyndlass",
-        "zhTW": "金色絞盤",
+        "zhTW": "Golden Wyndlass",
         "deDE": "Golden Wyndlass",
         "esES": "El alféizar dorado",
         "frFR": "Golden Wyndlass",
@@ -40695,13 +40695,13 @@
         "jaJP": "ゴールデン・ウィンドラス",
         "ptBR": "Molinete Dourado",
         "ruRU": "Золотой Виндлас",
-        "zhCN": "金色绞盘"
+        "zhCN": "Golden Wyndlass"
     },
     {
         "id": 50858,
         "Key": "Ravenstar",
         "enUS": "Ravenstar",
-        "zhTW": "烏鴉之星",
+        "zhTW": "乌鸦星",
         "deDE": "Ravenstar",
         "esES": "Ravenstar",
         "frFR": "Ravenstar",
@@ -40712,13 +40712,13 @@
         "jaJP": "レイブンスター",
         "ptBR": "Corvo Estrela",
         "ruRU": "Ravenstar",
-        "zhCN": "乌鸦之星"
+        "zhCN": "乌鸦星"
     },
     {
         "id": 50859,
         "Key": "Fallen Glory",
         "enUS": "Fallen Glory",
-        "zhTW": "隕落的榮耀",
+        "zhTW": "陨落的荣耀",
         "deDE": "Fallen Glory",
         "esES": "Gloria caída",
         "frFR": "Fallen Glory",
@@ -40735,7 +40735,7 @@
         "id": 50860,
         "Key": "Silt Runner",
         "enUS": "Silt Runner",
-        "zhTW": "淤泥轉輪",
+        "zhTW": "淤泥转轮",
         "deDE": "Schlickrinne",
         "esES": "Corredor de limo",
         "frFR": "Couloir de décantation",
@@ -40752,7 +40752,7 @@
         "id": 50861,
         "Key": "Swarming Blades",
         "enUS": "Swarming Blades",
-        "zhTW": "蜂群之刃",
+        "zhTW": "蜂拥而至的刀片",
         "deDE": "Schwarmklingen",
         "esES": "Cuchillas de enjambre",
         "frFR": "Lames essaimantes",
@@ -40763,13 +40763,13 @@
         "jaJP": "スウォーミング・ブレード",
         "ptBR": "Lâminas de Enxame",
         "ruRU": "Роящиеся клинки",
-        "zhCN": "蜂群之刃"
+        "zhCN": "蜂拥而至的刀片"
     },
     {
         "id": 50862,
         "Key": "Sheera's Knives",
         "enUS": "Sheera's Knives",
-        "zhTW": "謝拉之刃",
+        "zhTW": "谢拉的刀",
         "deDE": "Sheeras Messer",
         "esES": "Cuchillos Sheera",
         "frFR": "Couteaux de Sheera",
@@ -40780,13 +40780,13 @@
         "jaJP": "シェラのナイフ",
         "ptBR": "Facas de Sheera",
         "ruRU": "Ножи Ширы",
-        "zhCN": "谢拉之刃"
+        "zhCN": "谢拉的刀"
     },
     {
         "id": 50863,
         "Key": "Butcher's Paring Knives",
         "enUS": "Butcher's Paring Knives",
-        "zhTW": "屠夫的削皮刀",
+        "zhTW": "屠夫之削皮刀",
         "deDE": "Schälmesser des Schlächters",
         "esES": "Cuchillos de trinchar del Carnicero",
         "frFR": "Couteaux d’épluchage du Boucher",
@@ -40797,13 +40797,13 @@
         "jaJP": "ブッチャーの皮むきナイフ",
         "ptBR": "Facas de Descascar do Açougueiro",
         "ruRU": "Очистные ножи Мясника",
-        "zhCN": "屠夫的削皮刀"
+        "zhCN": "屠夫削皮刀"
     },
     {
         "id": 50864,
         "Key": "Darts of Evermeet",
         "enUS": "Darts of Evermeet",
-        "zhTW": "永聚之飛鏢",
+        "zhTW": "常美飞镖",
         "deDE": "Darts von Evermeet",
         "esES": "Dardos de Evermeet",
         "frFR": "Fléchettes de l'Evermeet",
@@ -40814,13 +40814,13 @@
         "jaJP": "エバーミートのダーツ",
         "ptBR": "Dardos de Evermeet",
         "ruRU": "Дротики Эвермита",
-        "zhCN": "永聚之飞镖"
+        "zhCN": "常美飞镖"
     },
     {
         "id": 50865,
         "Key": "Spirit of the Land",
         "enUS": "Spirit of the Land",
-        "zhTW": "大地之魂",
+        "zhTW": "土地精神",
         "deDE": "Geist des Landes",
         "esES": "Espíritu de la tierra",
         "frFR": "L'esprit de la terre",
@@ -40831,13 +40831,13 @@
         "jaJP": "土地の精神",
         "ptBR": "Espírito da Terra",
         "ruRU": "Дух земли",
-        "zhCN": "大地之魂"
+        "zhCN": "土地精神"
     },
     {
         "id": 50866,
         "Key": "Scarab of Protection",
         "enUS": "Scarab of Protection",
-        "zhTW": "防衛聖甲蟲",
+        "zhTW": "保护刀疤",
         "deDE": "Skarabäus des Schutzes",
         "esES": "Escarabajo de protección",
         "frFR": "Scarabée de protection",
@@ -40848,13 +40848,13 @@
         "jaJP": "スカラベ・オブ・プロテクション",
         "ptBR": "Escaravelho Protetor",
         "ruRU": "Скарабей защиты",
-        "zhCN": "防卫圣甲虫"
+        "zhCN": "保护刀疤"
     },
     {
         "id": 50867,
         "Key": "Frostbite Shard",
         "enUS": "Frostbite Shard",
-        "zhTW": "霜咬碎片",
+        "zhTW": "冻伤碎片",
         "deDE": "Frostbiss-Scherbe",
         "esES": "Fragmento de congelación",
         "frFR": "Éclat de givre",
@@ -40865,13 +40865,13 @@
         "jaJP": "フロストバイト・シャード",
         "ptBR": "Fragmento Congelado",
         "ruRU": "Осколок обморожения",
-        "zhCN": "霜咬碎片"
+        "zhCN": "冻伤碎片"
     },
     {
         "id": 50868,
         "Key": "The Shadowed One",
         "enUS": "The Shadowed One",
-        "zhTW": "暗影天尊",
+        "zhTW": "阴影之人",
         "deDE": "Der Schattenhafte",
         "esES": "El Sombrío",
         "frFR": "L'homme de l'ombre",
@@ -40882,13 +40882,13 @@
         "jaJP": "影のある者",
         "ptBR": "O Sombreado",
         "ruRU": "Теневой",
-        "zhCN": "暗影天尊"
+        "zhCN": "阴影之人"
     },
     {
         "id": 50869,
         "Key": "Red Dragon Scales",
         "enUS": "Red Dragon Scales",
-        "zhTW": "紅龍鱗甲",
+        "zhTW": "红龙鳞片",
         "deDE": "Rote Drachenschuppen",
         "esES": "Escamas de dragón rojo",
         "frFR": "Écailles de dragon rouge",
@@ -40899,13 +40899,13 @@
         "jaJP": "レッド・ドラゴンの鱗",
         "ptBR": "Escamas de Dragão Vermelho",
         "ruRU": "Чешуя красного дракона",
-        "zhCN": "红龙鳞甲"
+        "zhCN": "红龙鳞片"
     },
     {
         "id": 50870,
         "Key": "Ghostly Chainmail",
         "enUS": "Ghostly Chainmail",
-        "zhTW": "幽靈鏈甲",
+        "zhTW": "幽灵链甲",
         "deDE": "Geisterhaftes Kettenhemd",
         "esES": "Cota de malla fantasmal",
         "frFR": "Cotte de mailles fantôme",
@@ -40939,7 +40939,7 @@
         "id": 50872,
         "Key": "Will of the Zakarum",
         "enUS": "Will of the Zakarum",
-        "zhTW": "撒卡蘭姆的意志",
+        "zhTW": "扎卡鲁姆的意志",
         "deDE": "Der Wille des Zakarum",
         "esES": "Voluntad del Zakarum",
         "frFR": "Volonté du Zakarum",
@@ -40950,13 +40950,13 @@
         "jaJP": "ザカルムの意志",
         "ptBR": "Vontade do Zakarum",
         "ruRU": "Воля Закарума",
-        "zhCN": "萨卡兰姆的意志"
+        "zhCN": "扎卡鲁姆的意志"
     },
     {
         "id": 50873,
         "Key": "Adamantine Mail",
         "enUS": "Adamantine Mail",
-        "zhTW": "金剛甲",
+        "zhTW": "金刚邮件",
         "deDE": "Adamantine Mail",
         "esES": "Correo Adamantino",
         "frFR": "Courrier adamantin",
@@ -40967,13 +40967,13 @@
         "jaJP": "アダマンタイン・メール",
         "ptBR": "Correspondencia Adamantina",
         "ruRU": "Адамантиновая почта",
-        "zhCN": "金刚甲"
+        "zhCN": "金刚邮件"
     },
     {
         "id": 50874,
         "Key": "Zaratan Hide",
         "enUS": "Zaratan Hide",
-        "zhTW": "扎拉坦的隱藏",
+        "zhTW": "扎拉坦隐藏",
         "deDE": "Zaratan verstecken",
         "esES": "Zaratán Hide",
         "frFR": "Zaratan Hide",
@@ -40984,13 +40984,13 @@
         "jaJP": "ザラタン・ヒデ",
         "ptBR": "Couro de Zaratan",
         "ruRU": "Заратан Хидэ",
-        "zhCN": "扎拉坦的隐藏"
+        "zhCN": "扎拉坦隐藏"
     },
     {
         "id": 50875,
         "Key": "Drow Mesh",
         "enUS": "Drow Mesh",
-        "zhTW": "卓爾精靈之網",
+        "zhTW": "乌鸦网",
         "deDE": "Drow-Netz",
         "esES": "Malla Drow",
         "frFR": "Maille Drow",
@@ -41001,7 +41001,7 @@
         "jaJP": "ドロー・メッシュ",
         "ptBR": "Malha de Drow",
         "ruRU": "Сетка дроу",
-        "zhCN": "卓尔精灵网纹"
+        "zhCN": "乌鸦网"
     },
     {
         "id": 50876,
@@ -41024,7 +41024,7 @@
         "id": 50877,
         "Key": "Greyhawk Dragon",
         "enUS": "Greyhawk Dragon",
-        "zhTW": "灰鷹巨龍",
+        "zhTW": "灰鹰龙",
         "deDE": "Greyhawk-Drache",
         "esES": "Dragón de Greyhawk",
         "frFR": "Dragon de Greyhawk",
@@ -41035,7 +41035,7 @@
         "jaJP": "グレイホーク・ドラゴン",
         "ptBR": "Dragão Falcão Cinzento",
         "ruRU": "Дракон Грейхаука",
-        "zhCN": "灰鹰巨龙"
+        "zhCN": "灰鹰龙"
     },
     {
         "id": 50878,
@@ -41058,7 +41058,7 @@
         "id": 50879,
         "Key": "Dreamscape",
         "enUS": "Dreamscape",
-        "zhTW": "夢境",
+        "zhTW": "梦境",
         "deDE": "Traumlandschaft",
         "esES": "Paisaje onírico",
         "frFR": "Paysage de rêve",
@@ -41075,7 +41075,7 @@
         "id": 50880,
         "Key": "A Knight's Tale",
         "enUS": "A Knight's Tale",
-        "zhTW": "騎士傳説",
+        "zhTW": "骑士的故事",
         "deDE": "Das Märchen eines Ritters",
         "esES": "Historia de un caballero",
         "frFR": "Un conte de chevalier",
@@ -41086,13 +41086,13 @@
         "jaJP": "騎士物語",
         "ptBR": "o Conto do Cavaleiro",
         "ruRU": "Рыцарская сказка",
-        "zhCN": "骑士传说"
+        "zhCN": "骑士的故事"
     },
     {
         "id": 50881,
         "Key": "Kaz's Battle Armor",
         "enUS": "Kaz's Battle Armor",
-        "zhTW": "卡兹的戰甲",
+        "zhTW": "卡兹的战甲",
         "deDE": "Kaz' Kampfrüstung",
         "esES": "Armadura de batalla de Kaz",
         "frFR": "L'armure de Kaz",
@@ -41109,7 +41109,7 @@
         "id": 50882,
         "Key": "Weightless Grace",
         "enUS": "Weightless Grace",
-        "zhTW": "失重的優雅",
+        "zhTW": "失重的优雅",
         "deDE": "Schwerelose Anmut",
         "esES": "Gracia ingrávida",
         "frFR": "La grâce en apesanteur",
@@ -41126,7 +41126,7 @@
         "id": 50883,
         "Key": "Anaconda Skin",
         "enUS": "Anaconda Skin",
-        "zhTW": "巨蚺之皮",
+        "zhTW": "巨蟒皮肤",
         "deDE": "Anakonda-Haut",
         "esES": "Piel de anaconda",
         "frFR": "Peau d'anaconda",
@@ -41137,13 +41137,13 @@
         "jaJP": "アナコンダ・スキン",
         "ptBR": "Pele de Anaconda",
         "ruRU": "Кожа анаконды",
-        "zhCN": "巨蚺之皮"
+        "zhCN": "巨蟒皮肤"
     },
     {
         "id": 50884,
         "Key": "Shambling Mound",
         "enUS": "Shambling Mound",
-        "zhTW": "蹣跚之丘",
+        "zhTW": "晃动的土丘",
         "deDE": "Wackelhügel",
         "esES": "Túmulo Tembloroso",
         "frFR": "Le tumulus",
@@ -41154,13 +41154,13 @@
         "jaJP": "シャンブリング・マウンド",
         "ptBR": "Bambolear do Monte",
         "ruRU": "Азартный курган",
-        "zhCN": "蹒跚之丘"
+        "zhCN": "晃动的土丘"
     },
     {
         "id": 50885,
         "Key": "Royal Plate",
         "enUS": "Royal Plate",
-        "zhTW": "皇家板甲",
+        "zhTW": "皇家盘",
         "deDE": "Königlicher Teller",
         "esES": "Plato Real",
         "frFR": "Assiette royale",
@@ -41171,7 +41171,7 @@
         "jaJP": "ロイヤルプレート",
         "ptBR": "Armadura Real",
         "ruRU": "Королевская тарелка",
-        "zhCN": "皇家板甲"
+        "zhCN": "皇家盘"
     },
     {
         "id": 50886,
@@ -41194,7 +41194,7 @@
         "id": 50887,
         "Key": "The Strongest Link",
         "enUS": "The Strongest Link",
-        "zhTW": "至强之鏈",
+        "zhTW": "最紧密的联系",
         "deDE": "Das stärkste Glied",
         "esES": "El eslabón más fuerte",
         "frFR": "Le lien le plus fort",
@@ -41205,13 +41205,13 @@
         "jaJP": "最強のリンク",
         "ptBR": "O Elo mais Forte",
         "ruRU": "Самое сильное звено",
-        "zhCN": "至强之链"
+        "zhCN": "最紧密的联系"
     },
     {
         "id": 50888,
         "Key": "Tesla's Cuirass",
         "enUS": "Tesla's Cuirass",
-        "zhTW": "特斯拉胸甲",
+        "zhTW": "特斯拉的铠甲",
         "deDE": "Teslas Kürass",
         "esES": "Coraza de Tesla",
         "frFR": "La cuirasse de Tesla",
@@ -41222,13 +41222,13 @@
         "jaJP": "テスラの手甲",
         "ptBR": "Couraça Tesla",
         "ruRU": "Кираса Теслы",
-        "zhCN": "特斯拉胸甲"
+        "zhCN": "特斯拉的铠甲"
     },
     {
         "id": 50889,
         "Key": "Brimstone Hearth",
         "enUS": "Brimstone Hearth",
-        "zhTW": "硫磺爐",
+        "zhTW": "硫磺炉",
         "deDE": "Schwefelherd",
         "esES": "Hogar de Brimstone",
         "frFR": "Foyer Brimstone",
@@ -41262,7 +41262,7 @@
         "id": 50891,
         "Key": "Plate of Fistandantilus",
         "enUS": "Plate of Fistandantilus",
-        "zhTW": "費斯坦丹提洛思之甲",
+        "zhTW": "Fistandantilus 板",
         "deDE": "Platte von Fistandantilus",
         "esES": "Placa de Fistandantilus",
         "frFR": "Plaque de Fistandantilus",
@@ -41273,13 +41273,13 @@
         "jaJP": "フィスタンダンティルス",
         "ptBR": "Armadura de Fistandantilus",
         "ruRU": "Пластина Фистандантилус",
-        "zhCN": "费斯坦丹提洛思之甲"
+        "zhCN": "Fistandantilus 板"
     },
     {
         "id": 50892,
         "Key": "Wyrmbane",
         "enUS": "Wyrmbane",
-        "zhTW": "巨龍剋星",
+        "zhTW": "巫妖轨道",
         "deDE": "Wyrm-Schiene",
         "esES": "Pista Wyrm",
         "frFR": "Piste de Wyrm",
@@ -41290,13 +41290,13 @@
         "jaJP": "ウィルム・トラック",
         "ptBR": "Maldição da Wyrm",
         "ruRU": "След Вирма",
-        "zhCN": "巨龙克星"
+        "zhCN": "巫妖轨道"
     },
     {
         "id": 50893,
         "Key": "Ancient Dragon",
         "enUS": "Ancient Dragon",
-        "zhTW": "上古巨龍",
+        "zhTW": "古龙",
         "deDE": "Ancient Dragon",
         "esES": "Dragón antiguo",
         "frFR": "Ancient Dragon",
@@ -41307,13 +41307,13 @@
         "jaJP": "エンシェント・ドラゴン",
         "ptBR": "Dragão Antigo",
         "ruRU": "Древний дракон",
-        "zhCN": "上古古龙"
+        "zhCN": "古龙"
     },
     {
         "id": 50894,
         "Key": "Gaiden's Loss",
         "enUS": "Gaiden's Loss",
-        "zhTW": "蓋登之損",
+        "zhTW": "外传的损失",
         "deDE": "Der Verlust von Gaiden",
         "esES": "La pérdida de Gaiden",
         "frFR": "La perte de Gaiden",
@@ -41324,13 +41324,13 @@
         "jaJP": "外電の敗戦",
         "ptBR": "Gaiden Perdeu",
         "ruRU": "Потеря Гейдена",
-        "zhCN": "盖登之损"
+        "zhCN": "外传的损失"
     },
     {
         "id": 50895,
         "Key": "Neonate's Sallet",
         "enUS": "Neonate's Sallet",
-        "zhTW": "尼爾涅特便盔",
+        "zhTW": "新生儿沙拉",
         "deDE": "Neugeborenensalat",
         "esES": "Salchichón de neonato",
         "frFR": "Salade pour nouveau-nés",
@@ -41341,7 +41341,7 @@
         "jaJP": "ネオネート・サレ",
         "ptBR": "Capacete Sallet Neonato",
         "ruRU": "Салат для новорожденных",
-        "zhCN": "尼尔涅特轻盔"
+        "zhCN": "新生儿沙拉"
     },
     {
         "id": 50896,
@@ -41364,7 +41364,7 @@
         "id": 50897,
         "Key": "Knight's Crest",
         "enUS": "Knight's Crest",
-        "zhTW": "騎士之冠",
+        "zhTW": "骑士纹章",
         "deDE": "Ritterwappen",
         "esES": "Escudo de caballero",
         "frFR": "Cimier du chevalier",
@@ -41375,13 +41375,13 @@
         "jaJP": "騎士の紋章",
         "ptBR": "Elmo do Cavaleiro",
         "ruRU": "Рыцарский герб",
-        "zhCN": "骑士之冠"
+        "zhCN": "骑士纹章"
     },
     {
         "id": 50898,
         "Key": "Skull of Fistandantilus",
         "enUS": "Skull of Fistandantilus",
-        "zhTW": "菲斯坦提魯斯之顱",
+        "zhTW": "菲斯坦提鲁斯的头骨",
         "deDE": "Schädel von Fistandantilus",
         "esES": "Cráneo de Fistandantilus",
         "frFR": "Crâne de Fistandantilus",
@@ -41392,7 +41392,7 @@
         "jaJP": "フィスタンダンティルスの頭骨",
         "ptBR": "Crânio de Fistandantilus",
         "ruRU": "Череп Фистандантилуса",
-        "zhCN": "菲斯坦提鲁斯之颅"
+        "zhCN": "菲斯坦提鲁斯的头骨"
     },
     {
         "id": 50899,
@@ -41415,7 +41415,7 @@
         "id": 50900,
         "Key": "Lilith's Crest",
         "enUS": "Lilith's Crest",
-        "zhTW": "莉莉絲之冠",
+        "zhTW": "莉莉丝之冠",
         "deDE": "Liliths Wappen",
         "esES": "Cresta de Lilith",
         "frFR": "L'écusson de Lilith",
@@ -41432,7 +41432,7 @@
         "id": 50901,
         "Key": "Conch of Dismay",
         "enUS": "Conch of Dismay",
-        "zhTW": "驚愕之螺",
+        "zhTW": "沮丧的海螺",
         "deDE": "Muschel des Missvergnügens",
         "esES": "Concha de la consternación",
         "frFR": "Conque de désarroi",
@@ -41443,13 +41443,13 @@
         "jaJP": "狼狽のコンク",
         "ptBR": "Concha do Desânimo",
         "ruRU": "Конх разочарования",
-        "zhCN": "惊愕之螺"
+        "zhCN": "沮丧的海螺"
     },
     {
         "id": 50902,
         "Key": "King Conan's Rule",
         "enUS": "King Conan's Rule",
-        "zhTW": "柯南王之律",
+        "zhTW": "柯南国王的统治",
         "deDE": "Die Herrschaft von König Conan",
         "esES": "El gobierno del rey Conan",
         "frFR": "La règle du roi Conan",
@@ -41460,7 +41460,7 @@
         "jaJP": "コナン王の支配",
         "ptBR": "Regra do Rei Conan",
         "ruRU": "Правило короля Конана",
-        "zhCN": "柯南王之律"
+        "zhCN": "柯南国王的统治"
     },
     {
         "id": 50903,
@@ -41483,7 +41483,7 @@
         "id": 50904,
         "Key": "Golgomere's Shield",
         "enUS": "Golgomere's Shield",
-        "zhTW": "格爾戈梅爾之盾",
+        "zhTW": "戈尔戈梅尔之盾",
         "deDE": "Golgomeres Schild",
         "esES": "Escudo de Golgomere",
         "frFR": "Bouclier de Golgomère",
@@ -41494,13 +41494,13 @@
         "jaJP": "ゴルゴメアの盾",
         "ptBR": "Escudo de Golgomere",
         "ruRU": "Щит Голгомера",
-        "zhCN": "格尔戈梅尔之盾"
+        "zhCN": "戈尔戈梅尔之盾"
     },
     {
         "id": 50905,
         "Key": "Crest of the Horned Society",
         "enUS": "Crest of the Horned Society",
-        "zhTW": "號角協會头冠",
+        "zhTW": "号角协会头冠",
         "deDE": "Wappen der Gehörnten Gesellschaft",
         "esES": "Escudo de la Sociedad de los Cuernos",
         "frFR": "Cimier de la Société Cornue",
@@ -41517,7 +41517,7 @@
         "id": 50906,
         "Key": "Undead Buckler",
         "enUS": "Undead Buckler",
-        "zhTW": "不死者圓盾",
+        "zhTW": "亡灵战斧",
         "deDE": "Untoter Buckler",
         "esES": "Broquel no muerto",
         "frFR": "Bouclier mort-vivant",
@@ -41528,13 +41528,13 @@
         "jaJP": "アンデッドバックラー",
         "ptBR": "Broquel Zumbi",
         "ruRU": "Неживой баклер",
-        "zhCN": "不死者圆盾"
+        "zhCN": "亡灵战斧"
     },
     {
         "id": 50907,
         "Key": "Fanged Shield",
         "enUS": "Fanged Shield",
-        "zhTW": "尖齒盾",
+        "zhTW": "獠牙盾",
         "deDE": "Fanged Shield",
         "esES": "Escudo con colmillos",
         "frFR": "Bouclier à franges",
@@ -41545,13 +41545,13 @@
         "jaJP": "ファングド・シールド",
         "ptBR": "Escudo com Presas",
         "ruRU": "Клыкастый щит",
-        "zhCN": "牙骨盾"
+        "zhCN": "獠牙盾"
     },
     {
         "id": 50908,
         "Key": "Crest of Avalon",
         "enUS": "Crest of Avalon",
-        "zhTW": "阿瓦隆尖峰",
+        "zhTW": "阿瓦隆峰顶",
         "deDE": "Wappen von Avalon",
         "esES": "Cresta de Avalon",
         "frFR": "Crête d'Avalon",
@@ -41562,13 +41562,13 @@
         "jaJP": "クレスト・オブ・アヴァロン",
         "ptBR": "Elmo de Avalon",
         "ruRU": "Гребень Авалона",
-        "zhCN": "阿瓦隆尖峰"
+        "zhCN": "阿瓦隆峰顶"
     },
     {
         "id": 50909,
         "Key": "Bigby's Crushing Fist",
         "enUS": "Bigby's Crushing Fist",
-        "zhTW": "比格比粉碎之拳",
+        "zhTW": "比格比的粉碎拳",
         "deDE": "Bigbys Brecherfaust",
         "esES": "Puño aplastante de Bigby",
         "frFR": "Poing écrasant de Bigby",
@@ -41579,13 +41579,13 @@
         "jaJP": "ビグビーの破砕拳",
         "ptBR": "Punho Esmagador de Bigby",
         "ruRU": "Сокрушительный кулак Бигби",
-        "zhCN": "比格比粉碎之拳"
+        "zhCN": "比格比的粉碎拳"
     },
     {
         "id": 50910,
         "Key": "Pathfinder",
         "enUS": "Pathfinder",
-        "zhTW": "開拓者",
+        "zhTW": "开拓者",
         "deDE": "Pfadfinder",
         "esES": "Pathfinder",
         "frFR": "Éclaireur",
@@ -41602,7 +41602,7 @@
         "id": 50911,
         "Key": "Yemista's Defender",
         "enUS": "Yemista's Defender",
-        "zhTW": "耶米斯塔衛盾",
+        "zhTW": "耶米斯塔卫士",
         "deDE": "Jemistas Verteidigerin",
         "esES": "Defensor de Yemista",
         "frFR": "Le défenseur de Yemista",
@@ -41613,13 +41613,13 @@
         "jaJP": "イエミスタのディフェンダー",
         "ptBR": "Yemista Defensora",
         "ruRU": "Защитник Емисты",
-        "zhCN": "耶米斯塔卫盾"
+        "zhCN": "耶米斯塔卫士"
     },
     {
         "id": 50912,
         "Key": "Mongolian Trust",
         "enUS": "Mongolian Trust",
-        "zhTW": "蒙古之證",
+        "zhTW": "蒙古信托基金",
         "deDE": "Mongolische Stiftung",
         "esES": "Confianza mongola",
         "frFR": "Fiducie mongole",
@@ -41630,13 +41630,13 @@
         "jaJP": "モンゴル・トラスト",
         "ptBR": "Mongol Confiante",
         "ruRU": "Монгольский трест",
-        "zhCN": "蒙古之证"
+        "zhCN": "蒙古信托基金"
     },
     {
         "id": 50913,
         "Key": "Savant Sin",
         "enUS": "Savant Sin",
-        "zhTW": "學者的罪惡",
+        "zhTW": "Savant Sin",
         "deDE": "Savant Sin",
         "esES": "Pecado Savant",
         "frFR": "Savant Sin",
@@ -41647,13 +41647,13 @@
         "jaJP": "サヴァン・シン",
         "ptBR": "Pecado da Sabedoria",
         "ruRU": "Савант Грех",
-        "zhCN": "学者的罪惡"
+        "zhCN": "Savant Sin"
     },
     {
         "id": 50914,
         "Key": "Shieldmaiden's Pavise",
         "enUS": "Shieldmaiden's Pavise",
-        "zhTW": "女戰士大盾",
+        "zhTW": "盾牌女郎的帕维斯",
         "deDE": "Schildmaidenpavian",
         "esES": "Pavise de la escudera",
         "frFR": "Pavé de la demoiselle de bouclier",
@@ -41664,13 +41664,13 @@
         "jaJP": "シールドメイデンのパヴィーズ",
         "ptBR": "Escudo da Donzela",
         "ruRU": "Павиза щитоносная",
-        "zhCN": "女战士大盾"
+        "zhCN": "盾牌女郎的帕维斯"
     },
     {
         "id": 50915,
         "Key": "Under Dragon's Wing",
         "enUS": "Under Dragon's Wing",
-        "zhTW": "龍翼之下",
+        "zhTW": "龙翼之下",
         "deDE": "Unter dem Flügel des Drachen",
         "esES": "Bajo el ala del dragón",
         "frFR": "Sous l'aile du dragon",
@@ -41687,7 +41687,7 @@
         "id": 50916,
         "Key": "Crusader's Wall",
         "enUS": "Crusader's Wall",
-        "zhTW": "聖教軍之墙",
+        "zhTW": "十字军墙",
         "deDE": "Kreuzfahrer-Mauer",
         "esES": "Muro del Cruzado",
         "frFR": "Mur du croisé",
@@ -41698,13 +41698,13 @@
         "jaJP": "クルセイダーの壁",
         "ptBR": "Muro dos Cruzados",
         "ruRU": "Стена крестоносца",
-        "zhCN": "十字军之墙"
+        "zhCN": "十字军墙"
     },
     {
         "id": 50917,
         "Key": "Adamantine Shield",
         "enUS": "Adamantine Shield",
-        "zhTW": "金剛不壞之盾",
+        "zhTW": "金刚盾",
         "deDE": "Adamantin-Schild",
         "esES": "Escudo Adamantino",
         "frFR": "Bouclier adamantin",
@@ -41715,7 +41715,7 @@
         "jaJP": "アダマンタイン・シールド",
         "ptBR": "Escudo Adamantino",
         "ruRU": "Адамантиновый щит",
-        "zhCN": "金刚不坏之盾"
+        "zhCN": "金刚盾"
     },
     {
         "id": 50918,
@@ -41738,7 +41738,7 @@
         "id": 50919,
         "Key": "Razorbite Deflector",
         "enUS": "Razorbite Deflector",
-        "zhTW": "剃咬偏轉之盾",
+        "zhTW": "雷蛇偏转器",
         "deDE": "Razorbit-Deflektor",
         "esES": "Deflector Razorbite",
         "frFR": "Déflecteur Razorbite",
@@ -41749,13 +41749,13 @@
         "jaJP": "レイゾルバイト・ディフレクター",
         "ptBR": "Defletor Mordida Navalha",
         "ruRU": "Отражатель Разорбита",
-        "zhCN": "剃咬偏转之盾"
+        "zhCN": "雷蛇偏转器"
     },
     {
         "id": 50920,
         "Key": "Chill of Winter",
         "enUS": "Chill of Winter",
-        "zhTW": "冬日之寒意",
+        "zhTW": "冬天的寒意",
         "deDE": "Die Kälte des Winters",
         "esES": "Frío invernal",
         "frFR": "Le froid de l'hiver",
@@ -41766,13 +41766,13 @@
         "jaJP": "冬の寒さ",
         "ptBR": "Frio do Inverno",
         "ruRU": "Зимняя прохлада",
-        "zhCN": "冬日之寒意"
+        "zhCN": "冬天的寒意"
     },
     {
         "id": 50921,
         "Key": "Solar Eclipse",
         "enUS": "Solar Eclipse",
-        "zhTW": "日蝕",
+        "zhTW": "日食",
         "deDE": "Sonnenfinsternis",
         "esES": "Eclipse solar",
         "frFR": "Eclipse solaire",
@@ -41783,13 +41783,13 @@
         "jaJP": "日食",
         "ptBR": "Eclipse Solar",
         "ruRU": "Солнечное затмение",
-        "zhCN": "日蚀"
+        "zhCN": "日食"
     },
     {
         "id": 50922,
         "Key": "Shield of Myth",
         "enUS": "Shield of Myth",
-        "zhTW": "神話之盾",
+        "zhTW": "神话之盾",
         "deDE": "Schild des Mythos",
         "esES": "Escudo del mito",
         "frFR": "Bouclier du mythe",
@@ -41806,7 +41806,7 @@
         "id": 50923,
         "Key": "Healing Touch",
         "enUS": "Healing Touch",
-        "zhTW": "治愈之觸",
+        "zhTW": "治愈之触",
         "deDE": "Heilende Berührung",
         "esES": "Toque curativo",
         "frFR": "Toucher de guérison",
@@ -41823,7 +41823,7 @@
         "id": 50924,
         "Key": "Horseman's Gloves",
         "enUS": "Horseman's Gloves",
-        "zhTW": "騎手手套",
+        "zhTW": "骑士手套",
         "deDE": "Handschuhe für Reiter",
         "esES": "Guantes de jinete",
         "frFR": "Gants de cavalier",
@@ -41834,13 +41834,13 @@
         "jaJP": "ホースマン・グローブ",
         "ptBR": "Luvas de Cavaleiro",
         "ruRU": "Перчатки всадника",
-        "zhCN": "骑手手套"
+        "zhCN": "骑士手套"
     },
     {
         "id": 50925,
         "Key": "Prismatic Gauntlets",
         "enUS": "Prismatic Gauntlets",
-        "zhTW": "棱鏡臂鎧",
+        "zhTW": "棱镜臂铠",
         "deDE": "Prismatische Stulpen",
         "esES": "Guanteletes prismáticos",
         "frFR": "Gantelets prismatiques",
@@ -41857,7 +41857,7 @@
         "id": 50926,
         "Key": "Viridian Gloves",
         "enUS": "Viridian Gloves",
-        "zhTW": "鉻綠手套",
+        "zhTW": "Viridian 手套",
         "deDE": "Viridian Handschuhe",
         "esES": "Guantes Viridian",
         "frFR": "Gants Viridian",
@@ -41868,13 +41868,13 @@
         "jaJP": "ビリジアン・グローブ",
         "ptBR": "Luvas Viridianas",
         "ruRU": "Перчатки Viridian",
-        "zhCN": "铬绿手套"
+        "zhCN": "Viridian 手套"
     },
     {
         "id": 50927,
         "Key": "Marauder's Claw",
         "enUS": "Marauder's Claw",
-        "zhTW": "掠奪者之爪",
+        "zhTW": "掠夺者之爪",
         "deDE": "Plündererkralle",
         "esES": "Garra del merodeador",
         "frFR": "Griffe de Maraudeur",
@@ -41891,7 +41891,7 @@
         "id": 50928,
         "Key": "Spikefiend Bracers",
         "enUS": "Spikefiend Bracers",
-        "zhTW": "刺魔護腕",
+        "zhTW": "尖鳍手镯",
         "deDE": "Armschienen mit Stachelflossen",
         "esES": "Brazales con aletas de espiga",
         "frFR": "Bracelets à nageoires en épi",
@@ -41902,13 +41902,13 @@
         "jaJP": "スパイクフィンブレーサー",
         "ptBR": "Bracelete do Demonio Prego",
         "ruRU": "Браслеты с шипами",
-        "zhCN": "刺魔护腕"
+        "zhCN": "尖鳍手镯"
     },
     {
         "id": 50929,
         "Key": "Warlock's Touch",
         "enUS": "Warlock's Touch",
-        "zhTW": "術士之觸",
+        "zhTW": "术士之触",
         "deDE": "Die Berührung des Hexenmeisters",
         "esES": "Toque de Brujo",
         "frFR": "Toucher du sorcier",
@@ -41925,7 +41925,7 @@
         "id": 50930,
         "Key": "Burning Soul",
         "enUS": "Burning Soul",
-        "zhTW": "燃燒之魂",
+        "zhTW": "燃烧的灵魂",
         "deDE": "Brennende Seele",
         "esES": "Alma en llamas",
         "frFR": "Âme brûlante",
@@ -41936,13 +41936,13 @@
         "jaJP": "燃える魂",
         "ptBR": "Alma Ardente",
         "ruRU": "Горящая душа",
-        "zhCN": "燃烧之魂"
+        "zhCN": "燃烧的灵魂"
     },
     {
         "id": 50931,
         "Key": "Grip of the Faithful",
         "enUS": "Grip of the Faithful",
-        "zhTW": "信仰之握",
+        "zhTW": "信徒之握",
         "deDE": "Der Griff der Gläubigen",
         "esES": "Agarre de los fieles",
         "frFR": "L'emprise des fidèles",
@@ -41953,13 +41953,13 @@
         "jaJP": "信者のグリップ",
         "ptBR": "Punho dos fiéis",
         "ruRU": "Хватка верных",
-        "zhCN": "信仰之握"
+        "zhCN": "信徒之握"
     },
     {
         "id": 50932,
         "Key": "Black Lotus",
         "enUS": "Black Lotus",
-        "zhTW": "黑蓮",
+        "zhTW": "黑莲",
         "deDE": "Schwarzer Lotus",
         "esES": "Loto negro",
         "frFR": "Lotus noir",
@@ -41976,7 +41976,7 @@
         "id": 50933,
         "Key": "Dawn Scion",
         "enUS": "Dawn Scion",
-        "zhTW": "黎明貴族",
+        "zhTW": "Dawn Scion",
         "deDE": "Morgenröte Scion",
         "esES": "Amanecer Scion",
         "frFR": "Scion de l'aube",
@@ -41987,13 +41987,13 @@
         "jaJP": "ドーン・サイオン",
         "ptBR": "Enxerto Alvorecido",
         "ruRU": "Рассвет Сайон",
-        "zhCN": "黎明贵族"
+        "zhCN": "Dawn Scion"
     },
     {
         "id": 50934,
         "Key": "Dark Familiar",
         "enUS": "Dark Familiar",
-        "zhTW": "黑暗密友",
+        "zhTW": "黑暗法师",
         "deDE": "Dunkler Vertrauter",
         "esES": "Familiar oscuro",
         "frFR": "Familier sombre",
@@ -42004,13 +42004,13 @@
         "jaJP": "ダーク・ファミリア",
         "ptBR": "Familiar Sombrio",
         "ruRU": "Темный знакомый",
-        "zhCN": "黑暗密友"
+        "zhCN": "黑暗法师"
     },
     {
         "id": 50935,
         "Key": "Halbu's Gift",
         "enUS": "Halbu's Gift",
-        "zhTW": "哈爾布的禮物",
+        "zhTW": "哈尔布的礼物",
         "deDE": "Halbu's Geschenk",
         "esES": "Regalo de Halbu",
         "frFR": "Le cadeau d'Halbu",
@@ -42044,7 +42044,7 @@
         "id": 50937,
         "Key": "River Stalker",
         "enUS": "River Stalker",
-        "zhTW": "河流潛行者",
+        "zhTW": "河流潜行者",
         "deDE": "River Stalker",
         "esES": "Acechador del río",
         "frFR": "Traqueur de rivière",
@@ -42061,7 +42061,7 @@
         "id": 50938,
         "Key": "Meshif's Coil",
         "enUS": "Meshif's Coil",
-        "zhTW": "梅西夫腰帶",
+        "zhTW": "梅西夫的线圈",
         "deDE": "Meshifs Spule",
         "esES": "Bobina de Meshif",
         "frFR": "La bobine de Meshif",
@@ -42072,13 +42072,13 @@
         "jaJP": "メシフのコイル",
         "ptBR": "Bobina de Malha",
         "ruRU": "Катушка Мешифа",
-        "zhCN": "梅西夫腰带"
+        "zhCN": "梅西夫的线圈"
     },
     {
         "id": 50939,
         "Key": "Kashya's Ward",
         "enUS": "Kashya's Ward",
-        "zhTW": "卡西亞的防衛",
+        "zhTW": "卡西亚病房",
         "deDE": "Kashyas Station",
         "esES": "Sala de Kashya",
         "frFR": "Quartier de Kashya",
@@ -42089,13 +42089,13 @@
         "jaJP": "カーシャ病棟",
         "ptBR": "Kashya Enfermeira",
         "ruRU": "Палата Кашия",
-        "zhCN": "卡西亚的防卫"
+        "zhCN": "卡西亚病房"
     },
     {
         "id": 50940,
         "Key": "Ratman's Rope",
         "enUS": "Ratman's Rope",
-        "zhTW": "鼠人繩索",
+        "zhTW": "鼠人的绳子",
         "deDE": "Rattenfänger-Seil",
         "esES": "Cuerda de Ratman",
         "frFR": "Corde de l'homme-rat",
@@ -42106,13 +42106,13 @@
         "jaJP": "ネズミのロープ",
         "ptBR": "Corda de Ratman",
         "ruRU": "Веревка ратмана",
-        "zhCN": "鼠人绳索"
+        "zhCN": "鼠人的绳子"
     },
     {
         "id": 50941,
         "Key": "Warriv's Snakeskin",
         "enUS": "Warriv's Snakeskin",
-        "zhTW": "瓦瑞夫的蛇皮腰帶",
+        "zhTW": "Warriv 的蛇皮",
         "deDE": "Warrivs Schlangenhaut",
         "esES": "Piel de serpiente de Warriv",
         "frFR": "Peau de serpent de Warriv",
@@ -42123,13 +42123,13 @@
         "jaJP": "ワリブの蛇皮",
         "ptBR": "Pele Cobra de Warriv",
         "ruRU": "Змеиная кожа Варрива",
-        "zhCN": "瓦瑞夫的蛇皮腰带"
+        "zhCN": "Warriv 的蛇皮"
     },
     {
         "id": 50942,
         "Key": "Belt of Evil",
         "enUS": "Belt of Evil",
-        "zhTW": "邪惡腰帶",
+        "zhTW": "邪恶腰带",
         "deDE": "Gürtel des Bösen",
         "esES": "Cinturón del mal",
         "frFR": "Ceinture du mal",
@@ -42146,7 +42146,7 @@
         "id": 50943,
         "Key": "Megaladon Wrap",
         "enUS": "Megaladon Wrap",
-        "zhTW": "巨齒鯊裹腰",
+        "zhTW": "Megaladon 包裹",
         "deDE": "Megaladon-Verpackung",
         "esES": "Envoltura Megaladon",
         "frFR": "Enveloppe du mégaladon",
@@ -42157,13 +42157,13 @@
         "jaJP": "メガラドンラップ",
         "ptBR": "Envoltório de Megalodon",
         "ruRU": "Мегаладонская обертка",
-        "zhCN": "巨齿鲨腰带"
+        "zhCN": "Megaladon 包裹"
     },
     {
         "id": 50944,
         "Key": "Kashya's Retort",
         "enUS": "Kashya's Retort",
-        "zhTW": "卡西亚的反駁",
+        "zhTW": "卡西亚的反驳",
         "deDE": "Kashyas Erwiderung",
         "esES": "La réplica de Kashya",
         "frFR": "La réplique de Kashya",
@@ -42180,7 +42180,7 @@
         "id": 50945,
         "Key": "Abyssal Torment",
         "enUS": "Abyssal Torment",
-        "zhTW": "深淵折磨",
+        "zhTW": "深渊折磨",
         "deDE": "Abgrundtiefe Qualen",
         "esES": "Tormento abisal",
         "frFR": "Le tourment abyssal",
@@ -42197,7 +42197,7 @@
         "id": 50946,
         "Key": "Laurana's Elven Bow",
         "enUS": "Laurana's Elven Bow",
-        "zhTW": "劳拉娜精靈弓",
+        "zhTW": "劳拉娜的精灵弓",
         "deDE": "Laurannas Elfenbogen",
         "esES": "Arco élfico de Laurana",
         "frFR": "L'arc elfique de Laurana",
@@ -42208,13 +42208,13 @@
         "jaJP": "ローラナのエルフの弓",
         "ptBR": "Arco Élfico de Laurana",
         "ruRU": "Эльфийский лук Лаураны",
-        "zhCN": "劳拉娜精灵弓"
+        "zhCN": "劳拉娜的精灵弓"
     },
     {
         "id": 50947,
         "Key": "Distant Thunder",
         "enUS": "Distant Thunder",
-        "zhTW": "遠方之雷",
+        "zhTW": "遥远的雷声",
         "deDE": "Fernes Donnern",
         "esES": "Truenos lejanos",
         "frFR": "Tonnerre lointain",
@@ -42225,13 +42225,13 @@
         "jaJP": "遠雷",
         "ptBR": "Trovão distante",
         "ruRU": "Далекий гром",
-        "zhCN": "远方之雷"
+        "zhCN": "遥远的雷声"
     },
     {
         "id": 50948,
         "Key": "Shieldmaiden's Toss",
         "enUS": "Shieldmaiden's Toss",
-        "zhTW": "女戰士之擲",
+        "zhTW": "盾女的抛掷",
         "deDE": "Der Wurf der Schildmaid",
         "esES": "Lanzamiento de la escudera",
         "frFR": "Lancer de la demoiselle de bouclier",
@@ -42242,13 +42242,13 @@
         "jaJP": "シールドメイデンのトス",
         "ptBR": "Arremesso das Escudeiras",
         "ruRU": "Бросок девы щита",
-        "zhCN": "女战士之掷"
+        "zhCN": "盾女的抛掷"
     },
     {
         "id": 50949,
         "Key": "Amanda's Point",
         "enUS": "Amanda's Point",
-        "zhTW": "阿曼達的觀點",
+        "zhTW": "阿曼达的观点",
         "deDE": "Amandas Spitze",
         "esES": "Punta de Amanda",
         "frFR": "Le point d'Amanda",
@@ -42265,7 +42265,7 @@
         "id": 50950,
         "Key": "Valkyrie's Calling",
         "enUS": "Valkyrie's Calling",
-        "zhTW": "女武神的召喚",
+        "zhTW": "女武神的召唤",
         "deDE": "Die Berufung der Walküre",
         "esES": "La llamada de la valquiria",
         "frFR": "L'appel de la Walkyrie",
@@ -42282,7 +42282,7 @@
         "id": 50951,
         "Key": "Vile Temptress",
         "enUS": "Vile Temptress",
-        "zhTW": "卑劣蕩婦",
+        "zhTW": "卑鄙的诱惑者",
         "deDE": "Abscheuliche Verführerin",
         "esES": "Tentadora vil",
         "frFR": "La vile tentatrice",
@@ -42293,7 +42293,7 @@
         "jaJP": "卑劣な誘惑者",
         "ptBR": "Vil Tentadora",
         "ruRU": "Мерзкая искусительница",
-        "zhCN": "卑劣荡妇"
+        "zhCN": "卑鄙的诱惑者"
     },
     {
         "id": 50952,
@@ -42316,7 +42316,7 @@
         "id": 50953,
         "Key": "Drehya's Globe",
         "enUS": "Drehya's Globe",
-        "zhTW": "瑞雅的法球",
+        "zhTW": "Drehya's Globe",
         "deDE": "Drehya's Globe",
         "esES": "Globo de Drehya",
         "frFR": "Le globe de Drehya",
@@ -42327,13 +42327,13 @@
         "jaJP": "ドレヒャのグローブ",
         "ptBR": "Globo de Drehya",
         "ruRU": "Глобус Дрехии",
-        "zhCN": "瑞雅的法球"
+        "zhCN": "Drehya's Globe"
     },
     {
         "id": 50954,
         "Key": "Nihlathak's Spirit",
         "enUS": "Nihlathak's Spirit",
-        "zhTW": "尼拉塞克之魂",
+        "zhTW": "尼赫拉萨克精神",
         "deDE": "Der Geist von Nihlathak",
         "esES": "Espíritu de Nihlathak",
         "frFR": "L'esprit de Nihlathak",
@@ -42344,13 +42344,13 @@
         "jaJP": "ニヒラタクの魂",
         "ptBR": "Espírito de Nihlathak",
         "ruRU": "Дух Нихлатхака",
-        "zhCN": "尼拉塞克之魂"
+        "zhCN": "尼赫拉萨克精神"
     },
     {
         "id": 50955,
         "Key": "Putrid Defiler",
         "enUS": "Putrid Defiler",
-        "zhTW": "腐臭褻瀆者",
+        "zhTW": "腐臭的诽谤者",
         "deDE": "Verfaulter Schänder",
         "esES": "Profanador pútrido",
         "frFR": "Défoliateur putride",
@@ -42361,13 +42361,13 @@
         "jaJP": "腐敗した汚職者",
         "ptBR": "Defiler Pútrido",
         "ruRU": "Гнилой осквернитель",
-        "zhCN": "腐臭亵渎者"
+        "zhCN": "腐臭的诽谤者"
     },
     {
         "id": 50956,
         "Key": "Venomlord's Visage",
         "enUS": "Venomlord's Visage",
-        "zhTW": "毒液領主的面容",
+        "zhTW": "毒液领主的面容",
         "deDE": "Venomlord's Visage",
         "esES": "Visaje de Venomlord",
         "frFR": "Visage du Venomlord",
@@ -42384,7 +42384,7 @@
         "id": 50957,
         "Key": "Death Mauler",
         "enUS": "Death Mauler",
-        "zhTW": "死亡戰士",
+        "zhTW": "死亡战士",
         "deDE": "Death Mauler",
         "esES": "Mauler de la muerte",
         "frFR": "Mauler de la mort",
@@ -42401,7 +42401,7 @@
         "id": 50958,
         "Key": "Steel Weevil",
         "enUS": "Steel Weevil",
-        "zhTW": "鋼鐵象甲蟲",
+        "zhTW": "钢铁象鼻虫",
         "deDE": "Stahlrüsselkäfer",
         "esES": "Gorgojo de acero",
         "frFR": "Charançon de l'acier",
@@ -42412,13 +42412,13 @@
         "jaJP": "スティール・ゾウムシ",
         "ptBR": "Gorgulho de Aço",
         "ruRU": "Стальной долгоносик",
-        "zhCN": "钢铁象甲虫"
+        "zhCN": "钢铁象鼻虫"
     },
     {
         "id": 50959,
         "Key": "King Tut",
         "enUS": "King Tut",
-        "zhTW": "圖坦王",
+        "zhTW": "图坦王",
         "deDE": "König Tut",
         "esES": "Rey Tut",
         "frFR": "Le roi Tut",
@@ -42435,7 +42435,7 @@
         "id": 50960,
         "Key": "Fallen Hero's Disgrace",
         "enUS": "Fallen Hero's Disgrace",
-        "zhTW": "墮落英雄的恥辱",
+        "zhTW": "堕落英雄的耻辱",
         "deDE": "Die Schande des gefallenen Helden",
         "esES": "La desgracia del héroe caído",
         "frFR": "La disgrâce d'un héros déchu",
@@ -42452,7 +42452,7 @@
         "id": 50961,
         "Key": "Crusader's Will",
         "enUS": "Crusader's Will",
-        "zhTW": "聖教軍的意志",
+        "zhTW": "十字军的意志",
         "deDE": "Der Wille des Kreuzritters",
         "esES": "Voluntad del Cruzado",
         "frFR": "La volonté du croisé",
@@ -42469,7 +42469,7 @@
         "id": 50962,
         "Key": "Defender of Innocence",
         "enUS": "Defender of Innocence",
-        "zhTW": "無辜捍衛者",
+        "zhTW": "清白的捍卫者",
         "deDE": "Verteidiger der Unschuld",
         "esES": "Defensor de la inocencia",
         "frFR": "Défenseur de l'innocence",
@@ -42480,13 +42480,13 @@
         "jaJP": "イノセンスの擁護者",
         "ptBR": "Defensor da Inocência",
         "ruRU": "Защитник невинности",
-        "zhCN": "无辜捍卫者"
+        "zhCN": "清白的捍卫者"
     },
     {
         "id": 50963,
         "Key": "Knight's Holy Sigil",
         "enUS": "Knight's Holy Sigil",
-        "zhTW": "騎士聖徽",
+        "zhTW": "骑士圣徽",
         "deDE": "Heiliges Siegel des Ritters",
         "esES": "Sello sagrado del caballero",
         "frFR": "Sceau sacré du chevalier",
@@ -42503,7 +42503,7 @@
         "id": 50964,
         "Key": "King's Guard",
         "enUS": "King's Guard",
-        "zhTW": "國王的守護",
+        "zhTW": "国王卫队",
         "deDE": "Königswache",
         "esES": "Guardia del Rey",
         "frFR": "Garde du Roi",
@@ -42514,13 +42514,13 @@
         "jaJP": "キングス・ガード",
         "ptBR": "Guarda do Rei",
         "ruRU": "Королевская гвардия",
-        "zhCN": "国王的守护"
+        "zhCN": "国王卫队"
     },
     {
         "id": 50965,
         "Key": "Bastion of Hope",
         "enUS": "Bastion of Hope",
-        "zhTW": "希望堡壘",
+        "zhTW": "希望堡垒",
         "deDE": "Bastion der Hoffnung",
         "esES": "Bastión de esperanza",
         "frFR": "Bastion de l'espoir",
@@ -42537,7 +42537,7 @@
         "id": 50966,
         "Key": "Felix's Brace",
         "enUS": "Felix's Brace",
-        "zhTW": "菲利克斯支架",
+        "zhTW": "菲利克斯的支架",
         "deDE": "Felix' Spange",
         "esES": "El corsé de Félix",
         "frFR": "L'attelle de Felix",
@@ -42548,13 +42548,13 @@
         "jaJP": "フェリックスのブレース",
         "ptBR": "Braçadeira de Fenix",
         "ruRU": "Браслет Феликса",
-        "zhCN": "菲利克斯支架"
+        "zhCN": "菲利克斯的支架"
     },
     {
         "id": 50967,
         "Key": "Swiftfoot Slash",
         "enUS": "Swiftfoot Slash",
-        "zhTW": "快行斜擋",
+        "zhTW": "快脚斜线",
         "deDE": "Schnellfuß-Schrägstrich",
         "esES": "Tajo Swiftfoot",
         "frFR": "Pieds de martinet Slash",
@@ -42565,13 +42565,13 @@
         "jaJP": "スウィフトフット・スラッシュ",
         "ptBR": "Golpe do Pé Veloz",
         "ruRU": "Swiftfoot Slash",
-        "zhCN": "快行斜挡"
+        "zhCN": "快脚斜线"
     },
     {
         "id": 50968,
         "Key": "Kygragond",
         "enUS": "Kygragond",
-        "zhTW": "凱拉岡德",
+        "zhTW": "凯格拉冈",
         "deDE": "Kygragond",
         "esES": "Kygragond",
         "frFR": "Kygragond",
@@ -42582,13 +42582,13 @@
         "jaJP": "キグラゴンド",
         "ptBR": "Cuidado Kygra",
         "ruRU": "Кайграгонд",
-        "zhCN": "凯拉冈德"
+        "zhCN": "凯格拉冈"
     },
     {
         "id": 50969,
         "Key": "Invader's Glee",
         "enUS": "Invader's Glee",
-        "zhTW": "入侵者的歡樂",
+        "zhTW": "入侵者的欢乐",
         "deDE": "Glee des Eindringlings",
         "esES": "Glee del invasor",
         "frFR": "La joie des envahisseurs",
@@ -42605,7 +42605,7 @@
         "id": 50970,
         "Key": "Helms Deep",
         "enUS": "Helms Deep",
-        "zhTW": "深淵之盔",
+        "zhTW": "赫尔姆斯深渊",
         "deDE": "Helme tief",
         "esES": "Helms Deep",
         "frFR": "La profondeur de l'enfer",
@@ -42616,13 +42616,13 @@
         "jaJP": "ヘルムス・ディープ",
         "ptBR": "Elmo Profundo",
         "ruRU": "Хельмс Дип",
-        "zhCN": "深渊之盔"
+        "zhCN": "赫尔姆斯深渊"
     },
     {
         "id": 50971,
         "Key": "Death Knight's Mask",
         "enUS": "Death Knight's Mask",
-        "zhTW": "死亡騎士的面具",
+        "zhTW": "死亡骑士的面具",
         "deDE": "Die Maske des Todesritters",
         "esES": "Máscara del Caballero de la Muerte",
         "frFR": "Masque du chevalier de la mort",
@@ -42656,7 +42656,7 @@
         "id": 50973,
         "Key": "Hannibal's Crown",
         "enUS": "Hannibal's Crown",
-        "zhTW": "漢尼拔的王冠",
+        "zhTW": "汉尼拔的王冠",
         "deDE": "Die Krone des Hannibal",
         "esES": "Corona de Aníbal",
         "frFR": "La couronne d'Hannibal",
@@ -42673,7 +42673,7 @@
         "id": 50974,
         "Key": "Wasteland Visage",
         "enUS": "Wasteland Visage",
-        "zhTW": "荒原面甲",
+        "zhTW": "荒原面貌",
         "deDE": "Ödland Visage",
         "esES": "Visaje del páramo",
         "frFR": "Visage de la friche",
@@ -42684,13 +42684,13 @@
         "jaJP": "荒地のヴィサージュ",
         "ptBR": "Aspecto do Terreno Baldio",
         "ruRU": "Визаж пустоши",
-        "zhCN": "荒原面甲"
+        "zhCN": "荒原面貌"
     },
     {
         "id": 50975,
         "Key": "Eagle Eyes",
         "enUS": "Eagle Eyes",
-        "zhTW": "鷹眼",
+        "zhTW": "鹰眼",
         "deDE": "Augen des Adlers",
         "esES": "Ojos de águila",
         "frFR": "Le regard de l'aigle",
@@ -42707,7 +42707,7 @@
         "id": 50976,
         "Key": "Centaur's Sight",
         "enUS": "Centaur's Sight",
-        "zhTW": "半人马的視綫",
+        "zhTW": "半人马的视力",
         "deDE": "Kentaurenblick",
         "esES": "Vista del centauro",
         "frFR": "La vue du centaure",
@@ -42718,13 +42718,13 @@
         "jaJP": "ケンタウルスの視力",
         "ptBR": "Visão do Centauro",
         "ruRU": "Зрение кентавра",
-        "zhCN": "半人马的视线"
+        "zhCN": "半人马的视力"
     },
     {
         "id": 50977,
         "Key": "Yamanda's Token",
         "enUS": "Yamanda's Token",
-        "zhTW": "亞曼達的信物",
+        "zhTW": "山田令牌",
         "deDE": "Yamandas Wertmarke",
         "esES": "Ficha de Yamanda",
         "frFR": "Le jeton de Yamanda",
@@ -42735,13 +42735,13 @@
         "jaJP": "ヤマンダのトークン",
         "ptBR": "Token de Yamanda",
         "ruRU": "Жетон Яманды",
-        "zhCN": "亚曼达的信物"
+        "zhCN": "山田令牌"
     },
     {
         "id": 50978,
         "Key": "Swift Decent",
         "enUS": "Swift Decent",
-        "zhTW": "迅捷得體之盔",
+        "zhTW": "斯威夫特体面",
         "deDE": "Zügig Anständig",
         "esES": "Swift Decent",
         "frFR": "Swift Décent",
@@ -42752,13 +42752,13 @@
         "jaJP": "スウィフト・ディセント",
         "ptBR": "Abater Rapidamente",
         "ruRU": "Свифт Приличный",
-        "zhCN": "迅捷得体之盔"
+        "zhCN": "斯威夫特体面"
     },
     {
         "id": 50979,
         "Key": "Voltar's Feather",
         "enUS": "Voltar's Feather",
-        "zhTW": "沃爾塔之羽",
+        "zhTW": "沃尔塔之羽",
         "deDE": "Die Feder des Voltar",
         "esES": "Pluma de Voltar",
         "frFR": "Plume de Voltar",
@@ -42775,7 +42775,7 @@
         "id": 50980,
         "Key": "Hidden Death",
         "enUS": "Hidden Death",
-        "zhTW": "隱秘死亡",
+        "zhTW": "隐藏的死亡",
         "deDE": "Verborgener Tod",
         "esES": "Muerte oculta",
         "frFR": "La mort cachée",
@@ -42786,13 +42786,13 @@
         "jaJP": "隠された死",
         "ptBR": "Morte Oculta",
         "ruRU": "Скрытая смерть",
-        "zhCN": "隐秘死亡"
+        "zhCN": "隐藏的死亡"
     },
     {
         "id": 50981,
         "Key": "Razorspine",
         "enUS": "Razorspine",
-        "zhTW": "脊柱剃刀",
+        "zhTW": "Razorspine",
         "deDE": "Rasierklingenrücken",
         "esES": "Razorspine",
         "frFR": "Razorspine",
@@ -42803,13 +42803,13 @@
         "jaJP": "レイザースパイン",
         "ptBR": "Navalha Espinhal",
         "ruRU": "Razorspine",
-        "zhCN": "脊柱剃刀"
+        "zhCN": "Razorspine"
     },
     {
         "id": 50982,
         "Key": "Spirit Hawk",
         "enUS": "Spirit Hawk",
-        "zhTW": "靈鷹",
+        "zhTW": "灵鹰",
         "deDE": "Spirit Hawk",
         "esES": "Halcón espiritual",
         "frFR": "Spirit Hawk",
@@ -42826,7 +42826,7 @@
         "id": 50983,
         "Key": "Samantha's Fist",
         "enUS": "Samantha's Fist",
-        "zhTW": "薩曼莎之拳",
+        "zhTW": "萨曼莎的拳头",
         "deDE": "Samanthas Faust",
         "esES": "El puño de Samantha",
         "frFR": "Le poing de Samantha",
@@ -42837,13 +42837,13 @@
         "jaJP": "サマンサの拳",
         "ptBR": "Punho de Samantha",
         "ruRU": "Кулак Саманты",
-        "zhCN": "萨曼莎之拳"
+        "zhCN": "萨曼莎的拳头"
     },
     {
         "id": 50984,
         "Key": "Flaming Fist",
         "enUS": "Flaming Fist",
-        "zhTW": "火焰拳刃",
+        "zhTW": "火焰拳",
         "deDE": "Flammenfaust",
         "esES": "Puño en llamas",
         "frFR": "Poing enflammé",
@@ -42854,13 +42854,13 @@
         "jaJP": "炎の拳",
         "ptBR": "Punho Flamejante",
         "ruRU": "Пламенный кулак",
-        "zhCN": "火焰拳刃"
+        "zhCN": "火焰拳"
     },
     {
         "id": 50985,
         "Key": "Androsphinx",
         "enUS": "Androsphinx",
-        "zhTW": "老斯芬克斯",
+        "zhTW": "Androsphinx",
         "deDE": "Androsphinx",
         "esES": "Androsphinx",
         "frFR": "Androsphinx",
@@ -42871,13 +42871,13 @@
         "jaJP": "アンドロスフィンクス",
         "ptBR": "Esfinge Leão de Asas",
         "ruRU": "Андросфинкс",
-        "zhCN": "老斯芬克斯"
+        "zhCN": "Androsphinx"
     },
     {
         "id": 50986,
         "Key": "Lynx Talon",
         "enUS": "Lynx Talon",
-        "zhTW": "猞猁之爪",
+        "zhTW": "Lynx Talon",
         "deDE": "Luchskralle",
         "esES": "Talón de lince",
         "frFR": "Lynx Talon",
@@ -42888,13 +42888,13 @@
         "jaJP": "リンクス・タロン",
         "ptBR": "Garra de Lynx",
         "ruRU": "Рысь Талон",
-        "zhCN": "猞猁之爪"
+        "zhCN": "Lynx Talon"
     },
     {
         "id": 50987,
         "Key": "Nightmare Razors",
         "enUS": "Nightmare Razors",
-        "zhTW": "噩夢剃刀",
+        "zhTW": "噩梦剃须刀",
         "deDE": "Alptraum Rasiermesser",
         "esES": "Navajas Nightmare",
         "frFR": "Rasoirs cauchemardesques",
@@ -42905,13 +42905,13 @@
         "jaJP": "悪夢のカミソリ",
         "ptBR": "Luva Pesadelo",
         "ruRU": "Кошмарные бритвы",
-        "zhCN": "噩梦剃刀"
+        "zhCN": "噩梦剃须刀"
     },
     {
         "id": 50988,
         "Key": "Martial Law",
         "enUS": "Martial Law",
-        "zhTW": "戰爭法則",
+        "zhTW": "戒严",
         "deDE": "Kriegsrecht",
         "esES": "Ley marcial",
         "frFR": "Loi martiale",
@@ -42922,13 +42922,13 @@
         "jaJP": "戒厳令",
         "ptBR": "Lei Marcial",
         "ruRU": "Военное положение",
-        "zhCN": "战争法则"
+        "zhCN": "戒严"
     },
     {
         "id": 50989,
         "Key": "Storm Demon's Glare",
         "enUS": "Storm Demon's Glare",
-        "zhTW": "風暴惡魔的怒視",
+        "zhTW": "风暴恶魔的眩光",
         "deDE": "Blendung des Sturmdämons",
         "esES": "Resplandor del demonio de la tormenta",
         "frFR": "L'éclat du démon des tempêtes",
@@ -42939,13 +42939,13 @@
         "jaJP": "ストームデーモンの睨み",
         "ptBR": "Demônio Tempestade Brilhoso",
         "ruRU": "Облик демона бури",
-        "zhCN": "风暴恶魔的怒视"
+        "zhCN": "风暴恶魔的眩光"
     },
     {
         "id": 50990,
         "Key": "Sabertooth",
         "enUS": "Sabertooth",
-        "zhTW": "劍齒虎",
+        "zhTW": "剑齿虎",
         "deDE": "Säbelzahn",
         "esES": "Dientes de sable",
         "frFR": "Dents de sabre",
@@ -42962,7 +42962,7 @@
         "id": 50991,
         "Key": "Wight Claw",
         "enUS": "Wight Claw",
-        "zhTW": "幽靈爪",
+        "zhTW": "怀特爪",
         "deDE": "Wight Claw",
         "esES": "Garra de Wight",
         "frFR": "Griffe Wight",
@@ -42973,13 +42973,13 @@
         "jaJP": "ワイト・クロー",
         "ptBR": "Garra da Criatura",
         "ruRU": "Коготь Уайта",
-        "zhCN": "幽灵爪"
+        "zhCN": "怀特爪"
     },
     {
         "id": 50992,
         "Key": "Wakazashi",
         "enUS": "Wakazashi",
-        "zhTW": "若橋",
+        "zhTW": "若桥",
         "deDE": "Wakazashi",
         "esES": "Wakazashi",
         "frFR": "Wakazashi",
@@ -42996,7 +42996,7 @@
         "id": 50993,
         "Key": "Razor Knuckle",
         "enUS": "Razor Knuckle",
-        "zhTW": "剃刀指虎",
+        "zhTW": "剃刀指关节",
         "deDE": "Rasierklinge",
         "esES": "Nudillo de navaja",
         "frFR": "Jarret de rasoir",
@@ -43007,13 +43007,13 @@
         "jaJP": "レイザーナックル",
         "ptBR": "Soqueira de Navalha",
         "ruRU": "Костяшка бритвы",
-        "zhCN": "剃刀指虎"
+        "zhCN": "剃刀指关节"
     },
     {
         "id": 50994,
         "Key": "Chi Strike",
         "enUS": "Chi Strike",
-        "zhTW": "智擊",
+        "zhTW": "智击",
         "deDE": "Chi-Schlag",
         "esES": "Golpe Chi",
         "frFR": "Chi Strike (grève du chi)",
@@ -43030,7 +43030,7 @@
         "id": 50995,
         "Key": "Adamantine Razors",
         "enUS": "Adamantine Razors",
-        "zhTW": "金剛剃刀",
+        "zhTW": "金刚石剃刀",
         "deDE": "Adamantinische Rasiermesser",
         "esES": "Navajas Adamantinas",
         "frFR": "Rasoirs adamantins",
@@ -43041,7 +43041,7 @@
         "jaJP": "アダマンタイン・レイザー",
         "ptBR": "Navalhas de Adamantina",
         "ruRU": "Адамантиновые бритвы",
-        "zhCN": "金刚剃刀"
+        "zhCN": "金刚石剃刀"
     },
     {
         "id": 50996,
@@ -43064,7 +43064,7 @@
         "id": 50997,
         "Key": "Ring of Engagement",
         "enUS": "Ring of Engagement",
-        "zhTW": "訂婚之戒",
+        "zhTW": "订婚戒指",
         "deDE": "Ring der Verlobung",
         "esES": "Anillo de compromiso",
         "frFR": "Anneau de fiançailles",
@@ -43075,13 +43075,13 @@
         "jaJP": "婚約指輪",
         "ptBR": "Anel de Noivado",
         "ruRU": "Обручальное кольцо",
-        "zhCN": "订婚之戒"
+        "zhCN": "订婚戒指"
     },
     {
         "id": 50998,
         "Key": "Plantar Enlightenment",
         "enUS": "Plantar Enlightenment",
-        "zhTW": "原初啓蒙",
+        "zhTW": "足底启蒙",
         "deDE": "Erleuchtung der Fußsohlen",
         "esES": "Iluminación plantar",
         "frFR": "L'éveil plantaire",
@@ -43092,13 +43092,13 @@
         "jaJP": "足底啓蒙",
         "ptBR": "Iluminismo Plantar",
         "ruRU": "Плантарное просветление",
-        "zhCN": "原初启蒙"
+        "zhCN": "足底启蒙"
     },
     {
         "id": 50999,
         "Key": "Vampiric Regeneration",
         "enUS": "Vampiric Regeneration",
-        "zhTW": "吸血鬼的再生",
+        "zhTW": "吸血鬼再生",
         "deDE": "Vampirische Regeneration",
         "esES": "Regeneración vampírica",
         "frFR": "Régénération vampirique",
@@ -43109,13 +43109,13 @@
         "jaJP": "吸血鬼の再生",
         "ptBR": "Regeneração Vampírica",
         "ruRU": "Вампирическая регенерация",
-        "zhCN": "吸血鬼的再生"
+        "zhCN": "吸血鬼再生"
     },
     {
         "id": 51000,
         "Key": "Elven Heartband",
         "enUS": "Elven Heartband",
-        "zhTW": "精靈心带",
+        "zhTW": "精灵心带",
         "deDE": "Elfenherzband",
         "esES": "Cinta de corazón élfica",
         "frFR": "Bandeau Elfique",
@@ -43149,7 +43149,7 @@
         "id": 51002,
         "Key": "Amulet of Warding",
         "enUS": "Amulet of Warding",
-        "zhTW": "守護之護符",
+        "zhTW": "守护护身符",
         "deDE": "Amulett des Schutzes",
         "esES": "Amuleto de la protección",
         "frFR": "Amulette de protection",
@@ -43160,13 +43160,13 @@
         "jaJP": "結界のアミュレット",
         "ptBR": "Amuleto Protetor",
         "ruRU": "Амулет защиты",
-        "zhCN": "守护之护符"
+        "zhCN": "守护护身符"
     },
     {
         "id": 51003,
         "Key": "Adamantine Facet",
         "enUS": "ÿc4Adamantine Facet",
-        "zhTW": "ÿc4金剛刻面",
+        "zhTW": "ÿc4阿达曼汀面",
         "deDE": "ÿc4Adamantine Facet",
         "esES": "ÿc4Faceta Adamantina",
         "frFR": "ÿc4Adamantine Facet",
@@ -43177,13 +43177,13 @@
         "jaJP": "ÿc4アダマンタイン・ファセット",
         "ptBR": "ÿc4Faceta Adamantina",
         "ruRU": "ÿc4Адамантиновая грань",
-        "zhCN": "ÿc4金钢刻面"
+        "zhCN": "ÿc4阿达曼汀面"
     },
     {
         "id": 51004,
         "Key": "Quartz Facet",
         "enUS": "ÿc4Quartz Facet",
-        "zhTW": "ÿc4石英刻面",
+        "zhTW": "ÿc4石英石面",
         "deDE": "ÿc4Quartz Facet",
         "esES": "ÿc4Faceta de cuarzo",
         "frFR": "ÿc4Quartz Facet",
@@ -43194,13 +43194,13 @@
         "jaJP": "ÿc4水晶ファセット",
         "ptBR": "ÿc4Faceta Quartzo",
         "ruRU": "ÿc4 Кварцевая грань",
-        "zhCN": "ÿc4石英刻面"
+        "zhCN": "ÿc4石英石面"
     },
     {
         "id": 51005,
         "Key": "Reign of Deceit",
         "enUS": "Reign of Deceit",
-        "zhTW": "欺詐當政",
+        "zhTW": "欺骗的统治",
         "deDE": "Herrschaft des Betrugs",
         "esES": "El reino del engaño",
         "frFR": "Le règne de la tromperie",
@@ -43211,13 +43211,13 @@
         "jaJP": "欺瞞の支配",
         "ptBR": "Reinado Enganado",
         "ruRU": "Царствование обмана",
-        "zhCN": "欺诈当政"
+        "zhCN": "欺骗的统治"
     },
     {
         "id": 51006,
         "Key": "Aragorn's Scorn",
         "enUS": "Aragorn's Scorn",
-        "zhTW": "阿拉貢的輕蔑",
+        "zhTW": "阿拉贡的蔑视",
         "deDE": "Aragorns Verachtung",
         "esES": "El desprecio de Aragorn",
         "frFR": "Le mépris d'Aragorn",
@@ -43228,13 +43228,13 @@
         "jaJP": "アラゴルンの軽蔑",
         "ptBR": "O desprezo de Aragorn",
         "ruRU": "Презрение Арагорна",
-        "zhCN": "阿拉贡的轻蔑"
+        "zhCN": "阿拉贡的蔑视"
     },
     {
         "id": 51007,
         "Key": "Aragorn's Contempt",
         "enUS": "Aragorn's Contempt",
-        "zhTW": "阿拉貢的蔑視",
+        "zhTW": "阿拉贡的蔑视",
         "deDE": "Aragorns Verachtung",
         "esES": "El desprecio de Aragorn",
         "frFR": "Le mépris d'Aragorn",
@@ -43251,7 +43251,7 @@
         "id": 51008,
         "Key": "Aragorn's Derision",
         "enUS": "Aragorn's Derision",
-        "zhTW": "阿拉貢的嘲笑",
+        "zhTW": "阿拉贡的嘲笑",
         "deDE": "Aragorns Spott",
         "esES": "La burla de Aragorn",
         "frFR": "La dérision d'Aragorn",
@@ -43268,7 +43268,7 @@
         "id": 51009,
         "Key": "Aragorn's Indignation",
         "enUS": "Aragorn's Indignation",
-        "zhTW": "阿拉貢的憤怒",
+        "zhTW": "阿拉贡的愤怒",
         "deDE": "Aragorns Empörung",
         "esES": "La indignación de Aragorn",
         "frFR": "L'indignation d'Aragorn",
@@ -43285,7 +43285,7 @@
         "id": 51010,
         "Key": "Aragorn's Disdain",
         "enUS": "Aragorn's Disdain",
-        "zhTW": "阿拉貢的鄙視",
+        "zhTW": "阿拉贡的蔑视",
         "deDE": "Aragorns Verachtung",
         "esES": "El desdén de Aragorn",
         "frFR": "Le mépris d'Aragorn",
@@ -43296,13 +43296,13 @@
         "jaJP": "アラゴルンの軽蔑",
         "ptBR": "Desdém de Aragorn",
         "ruRU": "Презрение Арагорна",
-        "zhCN": "阿拉贡的鄙视"
+        "zhCN": "阿拉贡的蔑视"
     },
     {
         "id": 51011,
         "Key": "Bogrot's Magic",
         "enUS": "Bogrot's Magic",
-        "zhTW": "博格羅特的魔法",
+        "zhTW": "博格罗特的魔法",
         "deDE": "Die Magie von Bogrot",
         "esES": "Magia de Bogrot",
         "frFR": "La magie de Bogrot",
@@ -43319,7 +43319,7 @@
         "id": 51012,
         "Key": "Winter's Embrace",
         "enUS": "Winter's Embrace",
-        "zhTW": "寒冬之擁",
+        "zhTW": "冬天的怀抱",
         "deDE": "Die Umarmung des Winters",
         "esES": "El abrazo del invierno",
         "frFR": "L'étreinte de l'hiver",
@@ -43330,13 +43330,13 @@
         "jaJP": "冬の抱擁",
         "ptBR": "Abraço Invernal",
         "ruRU": "Объятия зимы",
-        "zhCN": "寒冬之拥"
+        "zhCN": "冬天的怀抱"
     },
     {
         "id": 51013,
         "Key": "Baptism by Fire",
         "enUS": "Baptism by Fire",
-        "zhTW": "烈火洗禮",
+        "zhTW": "火的洗礼",
         "deDE": "Feuertaufe",
         "esES": "Bautismo de fuego",
         "frFR": "Le baptême du feu",
@@ -43347,13 +43347,13 @@
         "jaJP": "火の洗礼",
         "ptBR": "Batismo de Fogo",
         "ruRU": "Крещение огнем",
-        "zhCN": "烈火洗礼"
+        "zhCN": "火的洗礼"
     },
     {
         "id": 51014,
         "Key": "Between Fire and Ice",
         "enUS": "Between Fire and Ice",
-        "zhTW": "冰火交夾",
+        "zhTW": "冰与火之间",
         "deDE": "Zwischen Feuer und Eis",
         "esES": "Entre el fuego y el hielo",
         "frFR": "Entre le feu et la glace",
@@ -43364,13 +43364,13 @@
         "jaJP": "火と氷の間",
         "ptBR": "Entre Fogo e Gelo",
         "ruRU": "Между огнем и льдом",
-        "zhCN": "冰火交夹"
+        "zhCN": "冰与火之间"
     },
     {
         "id": 51015,
         "Key": "Cedric's Jinx",
         "enUS": "Cedric's Jinx",
-        "zhTW": "塞德里克的厄運",
+        "zhTW": "塞德里克的金克斯",
         "deDE": "Cedrics Schreckgespenst",
         "esES": "Gafe de Cedric",
         "frFR": "La guigne de Cédric",
@@ -43381,13 +43381,13 @@
         "jaJP": "セドリックのジンクス",
         "ptBR": "Má Sorte de Cedric",
         "ruRU": "Сглаз Седрика",
-        "zhCN": "塞德里克的厄运"
+        "zhCN": "塞德里克的金克斯"
     },
     {
         "id": 51016,
         "Key": "Call of Gylandra",
         "enUS": "Call of Gylandra",
-        "zhTW": "吉蘭德拉的召喚",
+        "zhTW": "吉兰德拉的召唤",
         "deDE": "Der Ruf von Gylandra",
         "esES": "Llamada de Gylandra",
         "frFR": "L'appel de Gylandra",
@@ -43404,7 +43404,7 @@
         "id": 51017,
         "Key": "Return to Hydrakal",
         "enUS": "Return to Hydrakal",
-        "zhTW": "海德拉卡爾的回歸",
+        "zhTW": "返回海德拉卡尔",
         "deDE": "Rückkehr nach Hydrakal",
         "esES": "Volver a Hydrakal",
         "frFR": "Retour à Hydrakal",
@@ -43415,13 +43415,13 @@
         "jaJP": "ヒドラカルに戻る",
         "ptBR": "Retorne para Hydrakal",
         "ruRU": "Возвращение в Гидракал",
-        "zhCN": "海德拉卡尔的回归"
+        "zhCN": "返回海德拉卡尔"
     },
     {
         "id": 51018,
         "Key": "Neprida's Kiss",
         "enUS": "Neprida's Kiss",
-        "zhTW": "奈普莉達之吻",
+        "zhTW": "奈普莉达之吻",
         "deDE": "Der Kuss der Neprida",
         "esES": "El beso de Neprida",
         "frFR": "Le baiser de Neprida",
@@ -43438,7 +43438,7 @@
         "id": 51019,
         "Key": "Dragon Reborn",
         "enUS": "Dragon Reborn",
-        "zhTW": "龍之重生",
+        "zhTW": "龙之重生",
         "deDE": "Wiedergeborener Drache",
         "esES": "Dragón renacido",
         "frFR": "Le dragon renaît",
@@ -43455,7 +43455,7 @@
         "id": 51020,
         "Key": "Warder's Vest",
         "enUS": "Warder's Vest",
-        "zhTW": "獄吏的背心",
+        "zhTW": "卫兵背心",
         "deDE": "Wächterweste",
         "esES": "Chaleco de guardián",
         "frFR": "Gilet de gardien",
@@ -43466,13 +43466,13 @@
         "jaJP": "ウォーダーズ・ベスト",
         "ptBR": "Colete do Guarda",
         "ruRU": "Жилет стражника",
-        "zhCN": "狱吏的背心"
+        "zhCN": "卫兵背心"
     },
     {
         "id": 51021,
         "Key": "Heron-Branded Blade",
         "enUS": "Heron-Branded Blade",
-        "zhTW": "鷺印刀片",
+        "zhTW": "苍鹭牌刀片",
         "deDE": "Heron-Branding-Klinge",
         "esES": "Cuchilla con marca Heron",
         "frFR": "Lame de marque Heron",
@@ -43483,13 +43483,13 @@
         "jaJP": "ヘロンブレード",
         "ptBR": "Lâmina Marcado com a Garça",
         "ruRU": "Лезвие под маркой Heron",
-        "zhCN": "鹭印刀片"
+        "zhCN": "苍鹭牌刀片"
     },
     {
         "id": 51022,
         "Key": "Ter'Angreal Ring",
         "enUS": "Ter'Angreal Ring",
-        "zhTW": "特·安格爾之戒",
+        "zhTW": "特安格尔戒指",
         "deDE": "Ter'Angreal-Ring",
         "esES": "Anillo Ter'Angreal",
         "frFR": "Anneau Ter'Angreal",
@@ -43500,13 +43500,13 @@
         "jaJP": "テラングル・リング",
         "ptBR": "Anel Ter'Angreal",
         "ruRU": "Кольцо Тер'Ангреала",
-        "zhCN": "特·安格尔之戒"
+        "zhCN": "特安格尔戒指"
     },
     {
         "id": 51023,
         "Key": "Ser'Angreal Necklace",
         "enUS": "Ser'Angreal Necklace",
-        "zhTW": "瑟·安格爾護符",
+        "zhTW": "Ser'Angreal 项链",
         "deDE": "Ser'Angreal Halskette",
         "esES": "Collar Ser'Angreal",
         "frFR": "Collier Ser'Angreal",
@@ -43517,13 +43517,13 @@
         "jaJP": "サングレアル・ネックレス",
         "ptBR": "Colar Ser'Angreal",
         "ruRU": "Ожерелье Ser'Angreal",
-        "zhCN": "瑟·安格尔项链"
+        "zhCN": "Ser'Angreal 项链"
     },
     {
         "id": 51024,
         "Key": "Taint of Saidin",
         "enUS": "Taint of Saidin",
-        "zhTW": "賽丁的污點",
+        "zhTW": "赛丁的污点",
         "deDE": "Der Makel von Saidin",
         "esES": "Mancha de Saidin",
         "frFR": "La souillure de Saidin",
@@ -43540,7 +43540,7 @@
         "id": 51025,
         "Key": "Aviendha's Gift",
         "enUS": "Aviendha's Gift",
-        "zhTW": "阿維恩達的禮物",
+        "zhTW": "阿维恩达的礼物",
         "deDE": "Aviendhas Geschenk",
         "esES": "El regalo de Aviendha",
         "frFR": "Le cadeau d'Aviendha",
@@ -43574,7 +43574,7 @@
         "id": 51027,
         "Key": "Heroes Stand",
         "enUS": "Heroes Stand",
-        "zhTW": "英雄們的高臺",
+        "zhTW": "英雄展台",
         "deDE": "Helden stehen",
         "esES": "Heroes Stand",
         "frFR": "Le stand des héros",
@@ -43585,13 +43585,13 @@
         "jaJP": "ヒーローズスタンド",
         "ptBR": "Heróis Ficam de Pé",
         "ruRU": "Герои стоят",
-        "zhCN": "英雄们的高台"
+        "zhCN": "英雄展台"
     },
     {
         "id": 51028,
         "Key": "Warrior's Heroism",
         "enUS": "Warrior's Heroism",
-        "zhTW": "战士的英勇氣概",
+        "zhTW": "战士的英雄气概",
         "deDE": "Heldentum des Kriegers",
         "esES": "Heroísmo del guerrero",
         "frFR": "L'héroïsme du guerrier",
@@ -43602,13 +43602,13 @@
         "jaJP": "戦士のヒロイズム",
         "ptBR": "Heroísmo do Guerreiro",
         "ruRU": "Героизм воина",
-        "zhCN": "战士的英勇气概"
+        "zhCN": "战士的英雄气概"
     },
     {
         "id": 51029,
         "Key": "Martyr's Principle",
         "enUS": "Martyr's Principle",
-        "zhTW": "烈士的信條",
+        "zhTW": "殉道者原则",
         "deDE": "Märtyrer-Prinzip",
         "esES": "Principio del mártir",
         "frFR": "Le principe du martyr",
@@ -43619,13 +43619,13 @@
         "jaJP": "殉教者の原理",
         "ptBR": "Princípio do Mártir",
         "ruRU": "Принцип мученика",
-        "zhCN": "烈士的信条"
+        "zhCN": "殉道者原则"
     },
     {
         "id": 51030,
         "Key": "Gweibret's Rule",
         "enUS": "Gweibret's Rule",
-        "zhTW": "格韋布雷特的規則",
+        "zhTW": "格韦布雷特规则",
         "deDE": "Gweibrets Regel",
         "esES": "Regla de Gweibret",
         "frFR": "Règle de Gweibret",
@@ -43636,13 +43636,13 @@
         "jaJP": "グウェブレのルール",
         "ptBR": "Regra de Gwei Bredt",
         "ruRU": "Правило Гвейбрета",
-        "zhCN": "格韦布雷特的规则"
+        "zhCN": "格韦布雷特规则"
     },
     {
         "id": 51031,
         "Key": "Judicial Decree",
         "enUS": "Judicial Decree",
-        "zhTW": "司法政令",
+        "zhTW": "司法法令",
         "deDE": "Gerichtliches Dekret",
         "esES": "Judicial Decree",
         "frFR": "Décret judiciaire",
@@ -43653,13 +43653,13 @@
         "jaJP": "司法判決",
         "ptBR": "Decreto Judicial",
         "ruRU": "Судебное постановление",
-        "zhCN": "司法政令"
+        "zhCN": "司法法令"
     },
     {
         "id": 51032,
         "Key": "Regime of Regulation",
         "enUS": "Regime of Regulation",
-        "zhTW": "法規體制",
+        "zhTW": "监管制度",
         "deDE": "Regime der Regulierung",
         "esES": "Régimen de regulación",
         "frFR": "Régime de réglementation",
@@ -43670,13 +43670,13 @@
         "jaJP": "規制体制",
         "ptBR": "Regime de Regulação",
         "ruRU": "Режим регулирования",
-        "zhCN": "法规体制"
+        "zhCN": "监管制度"
     },
     {
         "id": 51033,
         "Key": "King's Prescript",
         "enUS": "King's Prescript",
-        "zhTW": "國王法令",
+        "zhTW": "国王的处方",
         "deDE": "Königliches Präskript",
         "esES": "Prescripción del Rey",
         "frFR": "Prescrit du roi",
@@ -43687,13 +43687,13 @@
         "jaJP": "王の処方箋",
         "ptBR": "Prescrito do Rei",
         "ruRU": "Королевский прескрипт",
-        "zhCN": "国王法令"
+        "zhCN": "国王的处方"
     },
     {
         "id": 51034,
         "Key": "Born Supremacy",
         "enUS": "Born Supremacy",
-        "zhTW": "天生至高",
+        "zhTW": "天生至尊",
         "deDE": "Geborene Vorherrschaft",
         "esES": "Nacido Supremacía",
         "frFR": "Suprématie née",
@@ -43704,13 +43704,13 @@
         "jaJP": "生まれながらの優位性",
         "ptBR": "Supremacia Nascida",
         "ruRU": "Прирожденное превосходство",
-        "zhCN": "天生至高"
+        "zhCN": "天生至尊"
     },
     {
         "id": 51035,
         "Key": "Dominion's Thesis",
         "enUS": "Dominion's Thesis",
-        "zhTW": "統治之論",
+        "zhTW": "多米尼克的论文",
         "deDE": "Die These von Dominion",
         "esES": "Tesis de Dominion",
         "frFR": "Thèse de Dominion",
@@ -43721,13 +43721,13 @@
         "jaJP": "ドミニオンのテーゼ",
         "ptBR": "Tese de Domínio",
         "ruRU": "Тезисы Доминиона",
-        "zhCN": "统治之论"
+        "zhCN": "多米尼克的论文"
     },
     {
         "id": 51036,
         "Key": "Haunted Asylum",
         "enUS": "Haunted Asylum",
-        "zhTW": "靈異病院",
+        "zhTW": "闹鬼的精神病院",
         "deDE": "Spukhaus",
         "esES": "Manicomio embrujado",
         "frFR": "L'asile hanté",
@@ -43738,13 +43738,13 @@
         "jaJP": "幽霊屋敷",
         "ptBR": "Asilo Assombrado",
         "ruRU": "Убежище с привидениями",
-        "zhCN": "灵异病院"
+        "zhCN": "闹鬼的精神病院"
     },
     {
         "id": 51037,
         "Key": "Astral Body",
         "enUS": "Astral Body",
-        "zhTW": "星空之體",
+        "zhTW": "星体",
         "deDE": "Astralkörper",
         "esES": "Cuerpo astral",
         "frFR": "Corps astral",
@@ -43755,13 +43755,13 @@
         "jaJP": "アストラル体",
         "ptBR": "Corpo Astral",
         "ruRU": "Астральное тело",
-        "zhCN": "星空之体"
+        "zhCN": "星体"
     },
     {
         "id": 51038,
         "Key": "Apparition of Malice",
         "enUS": "Apparition of Malice",
-        "zhTW": "鬼魂之怨",
+        "zhTW": "恶意的显现",
         "deDE": "Erscheinung der Bosheit",
         "esES": "Aparición de la malicia",
         "frFR": "Apparition de la malice",
@@ -43772,13 +43772,13 @@
         "jaJP": "悪意の幻影",
         "ptBR": "Aparição de Malícia",
         "ruRU": "Явление зла",
-        "zhCN": "鬼魂之怨"
+        "zhCN": "恶意的显现"
     },
     {
         "id": 51039,
         "Key": "Phantasm of Horror",
         "enUS": "Phantasm of Horror",
-        "zhTW": "恐懼之影",
+        "zhTW": "恐怖幻影",
         "deDE": "Phantasma des Grauens",
         "esES": "Fantasma del horror",
         "frFR": "Phantasme de l'horreur",
@@ -43789,13 +43789,13 @@
         "jaJP": "恐怖のファンタズム",
         "ptBR": "Fantasma do Horror",
         "ruRU": "Призрак ужаса",
-        "zhCN": "恐惧之影"
+        "zhCN": "恐怖幻影"
     },
     {
         "id": 51040,
         "Key": "Haunted Wisdom",
         "enUS": "Haunted Wisdom",
-        "zhTW": "靈異之智",
+        "zhTW": "闹鬼的智慧",
         "deDE": "Gespenstische Weisheit",
         "esES": "Sabiduría embrujada",
         "frFR": "Sagesse hantée",
@@ -43806,13 +43806,13 @@
         "jaJP": "お化けの知恵",
         "ptBR": "Sabedoria Sombria",
         "ruRU": "Мудрость с привидениями",
-        "zhCN": "灵异之智"
+        "zhCN": "闹鬼的智慧"
     },
     {
         "id": 51041,
         "Key": "Revenant's Claw",
         "enUS": "Revenant's Claw",
-        "zhTW": "復生者之爪",
+        "zhTW": "亡灵之爪",
         "deDE": "Klaue des Rächers",
         "esES": "Garra de Revenant",
         "frFR": "La griffe de Revenant",
@@ -43823,13 +43823,13 @@
         "jaJP": "レヴェナントの爪",
         "ptBR": "Garra de Revenant",
         "ruRU": "Коготь ревенанта",
-        "zhCN": "复生者之爪"
+        "zhCN": "亡灵之爪"
     },
     {
         "id": 51042,
         "Key": "Alyssa's Archery",
         "enUS": "Alyssa's Archery",
-        "zhTW": "阿麗莎的箭術",
+        "zhTW": "阿丽莎的射箭",
         "deDE": "Alyssa's Bogenschießen",
         "esES": "Tiro con arco de Alyssa",
         "frFR": "Le tir à l'arc d'Alyssa",
@@ -43840,13 +43840,13 @@
         "jaJP": "アリッサのアーチェリー",
         "ptBR": "Alyssa Tiro ao Alvo",
         "ruRU": "Стрельба из лука Алиссы",
-        "zhCN": "阿丽莎的箭术"
+        "zhCN": "阿丽莎的射箭"
     },
     {
         "id": 51043,
         "Key": "Alyssa's Essence",
         "enUS": "Alyssa's Essence",
-        "zhTW": "阿麗莎的精髓",
+        "zhTW": "阿丽莎的精华",
         "deDE": "Alyssa's Essenz",
         "esES": "Esencia de Alyssa",
         "frFR": "L'essence d'Alyssa",
@@ -43857,13 +43857,13 @@
         "jaJP": "アリッサのエッセンス",
         "ptBR": "Essência de Alyssa",
         "ruRU": "Эссенция Алиссы",
-        "zhCN": "阿丽莎的精髓"
+        "zhCN": "阿丽莎的精华"
     },
     {
         "id": 51044,
         "Key": "Alyssa's Leafblighter",
         "enUS": "Alyssa's Leafblighter",
-        "zhTW": "阿麗莎的枯葉術",
+        "zhTW": "阿丽莎的打叶机",
         "deDE": "Alyssas Laubbläser",
         "esES": "Leafblighter de Alyssa",
         "frFR": "Le tueur de feuilles d'Alyssa",
@@ -43874,13 +43874,13 @@
         "jaJP": "アリッサのリーフブライター",
         "ptBR": "Folha Isqueiro de Alyssa",
         "ruRU": "Листопад Алиссы",
-        "zhCN": "阿丽莎的枯叶术"
+        "zhCN": "阿丽莎的打叶机"
     },
     {
         "id": 51045,
         "Key": "Alyssa's Sandals",
         "enUS": "Alyssa's Sandals",
-        "zhTW": "阿麗莎的涼鞋",
+        "zhTW": "阿丽莎的凉鞋",
         "deDE": "Alyssa's Sandalen",
         "esES": "Sandalias de Alyssa",
         "frFR": "Les sandales d'Alyssa",
@@ -43897,7 +43897,7 @@
         "id": 51046,
         "Key": "Forbidden Lore",
         "enUS": "Forbidden Lore",
-        "zhTW": "禁忌傳説",
+        "zhTW": "禁忌传说",
         "deDE": "Verbotene Überlieferung",
         "esES": "El saber prohibido",
         "frFR": "La lignée interdite",
@@ -43914,7 +43914,7 @@
         "id": 51047,
         "Key": "Unholy Vows",
         "enUS": "Unholy Vows",
-        "zhTW": "邪惡誓言",
+        "zhTW": "不神圣的誓言",
         "deDE": "Unheilige Gelübde",
         "esES": "Votos profanos",
         "frFR": "Vœux impies",
@@ -43925,13 +43925,13 @@
         "jaJP": "聖なる誓い",
         "ptBR": "Votos Profanos",
         "ruRU": "Нечестивые обеты",
-        "zhCN": "邪恶誓言"
+        "zhCN": "不神圣的誓言"
     },
     {
         "id": 51048,
         "Key": "Vampirebone Dagger",
         "enUS": "Vampirebone Dagger",
-        "zhTW": "吸血鬼骸骨匕首",
+        "zhTW": "吸血鬼骨匕首",
         "deDE": "Vampirknochendolch",
         "esES": "Daga de hueso de vampiro",
         "frFR": "Dague en os de vampire",
@@ -43942,13 +43942,13 @@
         "jaJP": "ヴァンパイアボーン・ダガー",
         "ptBR": "Adaga Osso de Vampiro ",
         "ruRU": "Кинжал из вампирской кости",
-        "zhCN": "吸血鬼骸骨匕首"
+        "zhCN": "吸血鬼骨匕首"
     },
     {
         "id": 51049,
         "Key": "Wall of Modius",
         "enUS": "Wall of Modius",
-        "zhTW": "莫迪烏斯之墻",
+        "zhTW": "莫迪乌斯墙",
         "deDE": "Modius-Mauer",
         "esES": "Muro de Modius",
         "frFR": "Mur de Modius",
@@ -43959,13 +43959,13 @@
         "jaJP": "モディウスの壁",
         "ptBR": "Parede de Modius",
         "ruRU": "Стена Модиуса",
-        "zhCN": "莫迪乌斯之墙"
+        "zhCN": "莫迪乌斯墙"
     },
     {
         "id": 51050,
         "Key": "Death's Door",
         "enUS": "Death's Door",
-        "zhTW": "死亡之門",
+        "zhTW": "死亡之门",
         "deDE": "Die Tür des Todes",
         "esES": "La puerta de la muerte",
         "frFR": "La porte de la mort",
@@ -43982,7 +43982,7 @@
         "id": 51051,
         "Key": "Hannibal's Demise",
         "enUS": "Hannibal's Demise",
-        "zhTW": "漢尼拔的消亡",
+        "zhTW": "汉尼拔的灭亡",
         "deDE": "Hannibals Untergang",
         "esES": "El ocaso de Aníbal",
         "frFR": "La fin d'Hannibal",
@@ -43993,13 +43993,13 @@
         "jaJP": "ハンニバルの終焉",
         "ptBR": "Morte de Hannibal",
         "ruRU": "Гибель Ганнибала",
-        "zhCN": "汉尼拔的消亡"
+        "zhCN": "汉尼拔的灭亡"
     },
     {
         "id": 51052,
         "Key": "Hannibal's Shattered Plate",
         "enUS": "Hannibal's Shattered Plate",
-        "zhTW": "漢尼拔的破碎板甲",
+        "zhTW": "汉尼拔的碎盘子",
         "deDE": "Hannibals zerbrochener Teller",
         "esES": "El plato roto de Aníbal",
         "frFR": "L'assiette brisée d'Hannibal",
@@ -44010,13 +44010,13 @@
         "jaJP": "ハンニバルの砕けた皿",
         "ptBR": "Armadura Estilhaçada de Hannibal",
         "ruRU": "Разбитая тарелка Ганнибала",
-        "zhCN": "汉尼拔的破碎板甲"
+        "zhCN": "汉尼拔的碎盘子"
     },
     {
         "id": 51053,
         "Key": "Hannibal's Final Flight",
         "enUS": "Hannibal's Final Flight",
-        "zhTW": "漢尼拔的告別飛行",
+        "zhTW": "汉尼拔的最后一次飞行",
         "deDE": "Hannibals letzter Flug",
         "esES": "El vuelo final de Aníbal",
         "frFR": "Le dernier vol d'Hannibal",
@@ -44027,13 +44027,13 @@
         "jaJP": "ハンニバル最後の飛行",
         "ptBR": "Voo Final de Hannibal",
         "ruRU": "Последний полет Ганнибала",
-        "zhCN": "汉尼拔的告别飞行"
+        "zhCN": "汉尼拔的最后一次飞行"
     },
     {
         "id": 51054,
         "Key": "Hannibal's Blurred Vision",
         "enUS": "Hannibal's Blurred Vision",
-        "zhTW": "漢尼拔的模糊視綫",
+        "zhTW": "汉尼拔模糊的视线",
         "deDE": "Hannibals verschwommene Sicht",
         "esES": "La visión borrosa de Aníbal",
         "frFR": "La vision trouble d'Hannibal",
@@ -44044,13 +44044,13 @@
         "jaJP": "ハンニバルのぼやけたビジョン",
         "ptBR": "Visão Turva de Hannibal",
         "ruRU": "Затуманенное зрение Ганнибала",
-        "zhCN": "汉尼拔的模糊视线"
+        "zhCN": "汉尼拔模糊的视线"
     },
     {
         "id": 51055,
         "Key": "Hannibal's Bending Knee",
         "enUS": "Hannibal's Bending Knee",
-        "zhTW": "漢尼拔的屈膝",
+        "zhTW": "汉尼拔的屈膝",
         "deDE": "Hannibals Kniebeuge",
         "esES": "La rodilla doblada de Aníbal",
         "frFR": "Le genou pliant d'Hannibal",
@@ -44067,7 +44067,7 @@
         "id": 51056,
         "Key": "Wrath of Vengeance",
         "enUS": "Wrath of Vengeance",
-        "zhTW": "復仇怒火",
+        "zhTW": "复仇之怒",
         "deDE": "Zorn der Rache",
         "esES": "Ira de Venganza",
         "frFR": "La colère de la vengeance",
@@ -44078,13 +44078,13 @@
         "jaJP": "復讐の怒り",
         "ptBR": "Ira da Vingança",
         "ruRU": "Гнев возмездия",
-        "zhCN": "复仇怒火"
+        "zhCN": "复仇之怒"
     },
     {
         "id": 51057,
         "Key": "Shroud of Anger",
         "enUS": "Shroud of Anger",
-        "zhTW": "憤怒之壽衣",
+        "zhTW": "愤怒的裹尸布",
         "deDE": "Leichentuch des Zorns",
         "esES": "Sudario de ira",
         "frFR": "Linceul de colère",
@@ -44095,13 +44095,13 @@
         "jaJP": "怒りのシュラウド",
         "ptBR": "Mortalha de Raiva",
         "ruRU": "Саван гнева",
-        "zhCN": "愤怒之寿衣"
+        "zhCN": "愤怒的裹尸布"
     },
     {
         "id": 51058,
         "Key": "Holy Fury",
         "enUS": "Holy Fury",
-        "zhTW": "神聖之狂怒",
+        "zhTW": "神圣的愤怒",
         "deDE": "Heiliger Zorn",
         "esES": "Furia sagrada",
         "frFR": "La sainte fureur",
@@ -44112,13 +44112,13 @@
         "jaJP": "ホーリー・フューリー",
         "ptBR": "Furia Sagrada",
         "ruRU": "Святая ярость",
-        "zhCN": "神圣的狂怒"
+        "zhCN": "神圣的愤怒"
     },
     {
         "id": 51059,
         "Key": "Harvest of Cruelty",
         "enUS": "Harvest of Cruelty",
-        "zhTW": "殘酷之收穫",
+        "zhTW": "残酷的收获",
         "deDE": "Ernte der Grausamkeit",
         "esES": "Cosecha de crueldad",
         "frFR": "La récolte de la cruauté",
@@ -44129,13 +44129,13 @@
         "jaJP": "残酷な収穫",
         "ptBR": "Colheita da Crueldade",
         "ruRU": "Жатва жестокости",
-        "zhCN": "残酷之收获"
+        "zhCN": "残酷的收获"
     },
     {
         "id": 51060,
         "Key": "Guiding Force",
         "enUS": "Guiding Force",
-        "zhTW": "受引之力量",
+        "zhTW": "指导力量",
         "deDE": "Leitende Kraft",
         "esES": "Fuerza orientadora",
         "frFR": "Force motrice",
@@ -44146,13 +44146,13 @@
         "jaJP": "指導力",
         "ptBR": "Força Orientadora",
         "ruRU": "Направляющая сила",
-        "zhCN": "受引之力量"
+        "zhCN": "指导力量"
     },
     {
         "id": 51061,
         "Key": "Embracing Hatred",
         "enUS": "Embracing Hatred",
-        "zhTW": "環抱之仇恨",
+        "zhTW": "拥抱仇恨",
         "deDE": "Umarmung des Hasses",
         "esES": "Abrazar el odio",
         "frFR": "Embrasser la haine",
@@ -44163,13 +44163,13 @@
         "jaJP": "憎しみを受け入れる",
         "ptBR": "Abraçando o Ódio",
         "ruRU": "Воплощение ненависти",
-        "zhCN": "环抱之仇恨"
+        "zhCN": "拥抱仇恨"
     },
     {
         "id": 51062,
         "Key": "Servitude or Rebellion",
         "enUS": "Servitude or Rebellion",
-        "zhTW": "奴役與抗爭",
+        "zhTW": "奴役还是反抗",
         "deDE": "Knechtschaft oder Rebellion",
         "esES": "Servidumbre o rebelión",
         "frFR": "Servitude ou rébellion",
@@ -44180,13 +44180,13 @@
         "jaJP": "隷属か反抗か",
         "ptBR": "Servidão ou Rebelião",
         "ruRU": "Рабство или бунт",
-        "zhCN": "奴役与抗争"
+        "zhCN": "奴役还是反抗"
     },
     {
         "id": 51063,
         "Key": "Slave to Anarchy",
         "enUS": "Slave to Anarchy",
-        "zhTW": "混亂之奴隸",
+        "zhTW": "无政府主义的奴隶",
         "deDE": "Sklave der Anarchie",
         "esES": "Esclavo de la anarquía",
         "frFR": "Esclave de l'anarchie",
@@ -44197,13 +44197,13 @@
         "jaJP": "アナーキーの奴隷",
         "ptBR": "Escravo da Anarquia",
         "ruRU": "Раб анархии",
-        "zhCN": "混乱之奴隶"
+        "zhCN": "无政府主义的奴隶"
     },
     {
         "id": 51064,
         "Key": "Bound by Honor",
         "enUS": "Bound by Honor",
-        "zhTW": "榮譽之束縛",
+        "zhTW": "被荣誉束缚",
         "deDE": "Gebunden durch Ehre",
         "esES": "Obligados por el honor",
         "frFR": "Liés par l'honneur",
@@ -44214,7 +44214,7 @@
         "jaJP": "名誉の絆",
         "ptBR": "Vinculado por Honra",
         "ruRU": "Связанные честью",
-        "zhCN": "被荣之束缚"
+        "zhCN": "被荣誉束缚"
     },
     {
         "id": 51065,
@@ -44237,7 +44237,7 @@
         "id": 51066,
         "Key": "Kaldorn's Majesty",
         "enUS": "Kaldorn's Majesty",
-        "zhTW": "卡爾多恩的威嚴",
+        "zhTW": "卡尔多恩陛下",
         "deDE": "Kaldorns Majestät",
         "esES": "Majestad de Kaldorn",
         "frFR": "Majesté de Kaldorn",
@@ -44248,13 +44248,13 @@
         "jaJP": "カルドーン陛下",
         "ptBR": "Kaldorn Majestade",
         "ruRU": "Величество Калдорн",
-        "zhCN": "卡尔多恩的威严"
+        "zhCN": "卡尔多恩陛下"
     },
     {
         "id": 51067,
         "Key": "Firecam Gilded Plate",
         "enUS": "Firecam Gilded Plate",
-        "zhTW": "法爾凱姆的飾金甲",
+        "zhTW": "Firecam 镀金盘",
         "deDE": "Firecam Vergoldeter Teller",
         "esES": "Firecam Placa dorada",
         "frFR": "Plaque dorée Firecam",
@@ -44265,13 +44265,13 @@
         "jaJP": "ファイヤーカム 金メッキプレート",
         "ptBR": "Placa Dourada Firecam",
         "ruRU": "Позолоченная тарелка Firecam",
-        "zhCN": "法尔凯姆的饰金甲"
+        "zhCN": "Firecam 镀金盘"
     },
     {
         "id": 51068,
         "Key": "Axe of Arvoreen",
         "enUS": "Axe of Arvoreen",
-        "zhTW": "阿爾沃林之斧",
+        "zhTW": "阿尔沃林之斧",
         "deDE": "Die Axt von Arvoreen",
         "esES": "Hacha de Arvoreen",
         "frFR": "Hache d'Arvoreen",
@@ -44288,7 +44288,7 @@
         "id": 51069,
         "Key": "Windspar Mask",
         "enUS": "Windspar Mask",
-        "zhTW": "溫德斯巴的面罩",
+        "zhTW": "Windspar 面罩",
         "deDE": "Windspar Maske",
         "esES": "Máscara Windspar",
         "frFR": "Masque Windspar",
@@ -44299,13 +44299,13 @@
         "jaJP": "ウィンドスパー・マスク",
         "ptBR": "Máscara Windspar",
         "ruRU": "Маска Windspar",
-        "zhCN": "温德斯巴的面罩"
+        "zhCN": "Windspar 面罩"
     },
     {
         "id": 51070,
         "Key": "Waterwyrd's Talon",
         "enUS": "Waterwyrd's Talon",
-        "zhTW": "烏特維爾之爪",
+        "zhTW": "水妖之爪",
         "deDE": "Wassertyrannenklinge",
         "esES": "Garra de Waterwyrd",
         "frFR": "Talon de Waterwyrd",
@@ -44316,13 +44316,13 @@
         "jaJP": "ウォーターワイアーズ・タロン",
         "ptBR": "Garra de Waterwyrd",
         "ruRU": "Талон Водяного Вирда",
-        "zhCN": "乌特维尔之爪"
+        "zhCN": "水妖之爪"
     },
     {
         "id": 51071,
         "Key": "Daystar Wrap",
         "enUS": "Daystar Wrap",
-        "zhTW": "德司達的裹腰",
+        "zhTW": "日星包装",
         "deDE": "Daystar Wrap",
         "esES": "Envoltura Daystar",
         "frFR": "Enveloppe Daystar",
@@ -44333,13 +44333,13 @@
         "jaJP": "デイスター・ラップ",
         "ptBR": "Envoltório Daystar",
         "ruRU": "Обертывание Daystar",
-        "zhCN": "德司达的腰带"
+        "zhCN": "日星包装"
     },
     {
         "id": 51072,
         "Key": "Warlock's Exploration",
         "enUS": "Warlock's Exploration",
-        "zhTW": "術士的探索",
+        "zhTW": "术士的探索",
         "deDE": "Erforschung des Hexenmeisters",
         "esES": "Exploración del brujo",
         "frFR": "Exploration du sorcier",
@@ -44356,7 +44356,7 @@
         "id": 51073,
         "Key": "Incarnadine Elven Plate",
         "enUS": "Incarnadine Elven Plate",
-        "zhTW": "深紅精靈板甲",
+        "zhTW": "因卡纳丁精灵盘",
         "deDE": "Inkarnadiner Elfen-Teller",
         "esES": "Placa élfica encarnadina",
         "frFR": "Plaque elfique d'Incarnadine",
@@ -44367,7 +44367,7 @@
         "jaJP": "インカルナディン・エルヴン・プレート",
         "ptBR": "Armadura Élfica Encarnado",
         "ruRU": "Эльфийская пластина Инкарнадина",
-        "zhCN": "深红精灵板甲"
+        "zhCN": "因卡纳丁精灵盘"
     },
     {
         "id": 51074,
@@ -44390,7 +44390,7 @@
         "id": 51075,
         "Key": "Lilarcor Cap",
         "enUS": "Lilarcor Cap",
-        "zhTW": "小黃帽",
+        "zhTW": "Lilarcor 帽",
         "deDE": "Lilarcor-Mütze",
         "esES": "Gorra Lilarcor",
         "frFR": "Casquette Lilarcor",
@@ -44401,13 +44401,13 @@
         "jaJP": "リラールキャップ",
         "ptBR": "Boné Lilarcor",
         "ruRU": "Шапка Lilarcor",
-        "zhCN": "小黄帽"
+        "zhCN": "Lilarcor 帽"
     },
     {
         "id": 51076,
         "Key": "Teleomortis' Gloves",
         "enUS": "Teleomortis' Gloves",
-        "zhTW": "終焉手套",
+        "zhTW": "Teleomortis 的手套",
         "deDE": "Teleomortis' Handschuhe",
         "esES": "Guantes de Teleomortis",
         "frFR": "Gants de Teleomortis",
@@ -44418,13 +44418,13 @@
         "jaJP": "テレオモルティスのグローブ",
         "ptBR": "Luvas Teleomortis",
         "ruRU": "Перчатки Телеомортиса",
-        "zhCN": "终焉手套"
+        "zhCN": "Teleomortis 的手套"
     },
     {
         "id": 51077,
         "Key": "Citadel Belt",
         "enUS": "Citadel Belt",
-        "zhTW": "堡壘腰带",
+        "zhTW": "城堡腰带",
         "deDE": "Zitadellengürtel",
         "esES": "Cinturón Ciudadela",
         "frFR": "Ceinture Citadel",
@@ -44435,13 +44435,13 @@
         "jaJP": "シタデルベルト",
         "ptBR": "Cinto Citadel",
         "ruRU": "Пояс \"Цитадель",
-        "zhCN": "堡垒腰带"
+        "zhCN": "城堡腰带"
     },
     {
         "id": 51078,
         "Key": "Amaunator's Peace",
         "enUS": "Amaunator's Peace",
-        "zhTW": "阿曼納塔的和平",
+        "zhTW": "阿毛纳托的和平",
         "deDE": "Amaunator's Frieden",
         "esES": "Paz de Amaunator",
         "frFR": "La paix d'Amaunator",
@@ -44452,13 +44452,13 @@
         "jaJP": "アマウネーターの平和",
         "ptBR": "Paz de Amaunator",
         "ruRU": "Мир Амаунатора",
-        "zhCN": "阿曼纳塔的和平"
+        "zhCN": "阿毛纳托的和平"
     },
     {
         "id": 51079,
         "Key": "Holy Shroud of Amaunator",
         "enUS": "Holy Shroud of Amaunator",
-        "zhTW": "阿曼納塔的聖潔壽衣",
+        "zhTW": "阿莫纳托的神圣裹尸布",
         "deDE": "Heiliges Leichentuch des Amaunators",
         "esES": "Sábana Santa de Amaunator",
         "frFR": "Saint Suaire d'Amaunator",
@@ -44469,13 +44469,13 @@
         "jaJP": "アマウネーターの聖なるシュラウド",
         "ptBR": "Santo Sudário de Amaunator",
         "ruRU": "Священная плащаница Амаунатора",
-        "zhCN": "阿曼纳塔的圣洁寿衣"
+        "zhCN": "阿莫纳托的神圣裹尸布"
     },
     {
         "id": 51080,
         "Key": "Holy Cleaver of Amaunator",
         "enUS": "Holy Cleaver of Amaunator",
-        "zhTW": "阿曼納塔的聖潔之劍",
+        "zhTW": "阿莫纳托的圣洁之剑",
         "deDE": "Heiliges Hackbeil des Amaunators",
         "esES": "Cuchilla sagrada de Amaunator",
         "frFR": "Le couperet sacré d'Amaunator",
@@ -44486,13 +44486,13 @@
         "jaJP": "アマウネーターの聖なる薙刀",
         "ptBR": "Santo Cutelo de Amaunator",
         "ruRU": "Священный кливер Амаунатора",
-        "zhCN": "阿曼纳塔的圣洁之剑"
+        "zhCN": "阿莫纳托的圣洁之剑"
     },
     {
         "id": 51081,
         "Key": "Holy Buckler of Amaunator",
         "enUS": "Holy Buckler of Amaunator",
-        "zhTW": "阿曼納塔的聖潔之盾",
+        "zhTW": "阿莫纳托的圣扣",
         "deDE": "Heiliger Buckler des Amaunators",
         "esES": "Broquel sagrado de Amaunator",
         "frFR": "Bouclier sacré d'Amaunator",
@@ -44503,13 +44503,13 @@
         "jaJP": "アマウナトルの聖なるバックラー",
         "ptBR": "Santo Broquel de Amaunator",
         "ruRU": "Священный ковш Амаунатора",
-        "zhCN": "阿曼纳塔的圣洁之盾"
+        "zhCN": "阿莫纳托的圣扣"
     },
     {
         "id": 51082,
         "Key": "Holy Ring of Amaunator",
         "enUS": "Holy Ring of Amaunator",
-        "zhTW": "阿曼納塔的聖潔之戒",
+        "zhTW": "阿莫纳托圣戒",
         "deDE": "Heiliger Ring des Amaunators",
         "esES": "Anillo Sagrado de Amaunator",
         "frFR": "Anneau sacré d'Amaunator",
@@ -44520,13 +44520,13 @@
         "jaJP": "アマウネーターの聖なる指輪",
         "ptBR": "Anel Sagrado de Amaunator",
         "ruRU": "Священное кольцо Амаунатора",
-        "zhCN": "阿曼纳塔的圣洁之戒"
+        "zhCN": "阿莫纳托圣戒"
     },
     {
         "id": 51083,
         "Key": "Holy Boots of Amaunator",
         "enUS": "Holy Boots of Amaunator",
-        "zhTW": "阿曼納塔的聖潔之靴",
+        "zhTW": "阿莫纳托的圣靴",
         "deDE": "Heilige Stiefel des Amaunators",
         "esES": "Botas sagradas de Amaunator",
         "frFR": "Bottes sacrées d'Amaunator",
@@ -44537,13 +44537,13 @@
         "jaJP": "アマウネーターのホーリーブーツ",
         "ptBR": "Botas Sagradas de Amaunator",
         "ruRU": "Священные сапоги Амаунатора",
-        "zhCN": "阿曼纳塔的圣洁之靴"
+        "zhCN": "阿莫纳托的圣靴"
     },
     {
         "id": 51084,
         "Key": "Holy Sash of Amaunator",
         "enUS": "Holy Sash of Amaunator",
-        "zhTW": "阿曼納塔的聖潔腰帶",
+        "zhTW": "阿莫纳托的神圣腰带",
         "deDE": "Heilige Schärpe des Amaunators",
         "esES": "Faja sagrada de Amaunator",
         "frFR": "Ceinture sacrée d'Amaunator",
@@ -44554,13 +44554,13 @@
         "jaJP": "アマウナトルの聖なる帯",
         "ptBR": "Faixa Sagrada de Amaunator",
         "ruRU": "Священный пояс Амаунатора",
-        "zhCN": "阿曼纳塔的圣洁腰带"
+        "zhCN": "阿莫纳托的神圣腰带"
     },
     {
         "id": 51085,
         "Key": "Tika's Request",
         "enUS": "Tika's Request",
-        "zhTW": "蒂卡的請求",
+        "zhTW": "蒂卡的请求",
         "deDE": "Tika's Anfrage",
         "esES": "Petición de Tika",
         "frFR": "Demande de Tika",
@@ -44577,7 +44577,7 @@
         "id": 51086,
         "Key": "Frostwyrm Hide",
         "enUS": "Frostwyrm Hide",
-        "zhTW": "冰霜巨龍之隱",
+        "zhTW": "霜雪隐藏",
         "deDE": "Frostwyrm Versteck",
         "esES": "Piel Frostwyrm",
         "frFR": "Cache Frostwyrm",
@@ -44588,13 +44588,13 @@
         "jaJP": "フロストウィルムハイド",
         "ptBR": "Dragão de Gelo Escondido",
         "ruRU": "Шкура Фроствирма",
-        "zhCN": "冰霜巨龙之隐"
+        "zhCN": "霜雪隐藏"
     },
     {
         "id": 51087,
         "Key": "Hallowed Redeemer",
         "enUS": "Hallowed Redeemer",
-        "zhTW": "神聖救世主",
+        "zhTW": "神圣的救赎主",
         "deDE": "Geheiligter Erlöser",
         "esES": "Santificado Redentor",
         "frFR": "Rédempteur consacré",
@@ -44605,13 +44605,13 @@
         "jaJP": "聖なる贖い主",
         "ptBR": "Redentor Sagrado",
         "ruRU": "Святой Искупитель",
-        "zhCN": "神圣救世主"
+        "zhCN": "神圣的救赎主"
     },
     {
         "id": 51088,
         "Key": "Draconian Mask",
         "enUS": "Draconian Mask",
-        "zhTW": "龍人面具",
+        "zhTW": "龙人面具",
         "deDE": "Drakonische Maske",
         "esES": "Máscara draconiana",
         "frFR": "Masque draconien",
@@ -44628,7 +44628,7 @@
         "id": 51089,
         "Key": "Girdle of Kitthix",
         "enUS": "Girdle of Kitthix",
-        "zhTW": "基特西斯腰帶",
+        "zhTW": "基特西斯腰带",
         "deDE": "Hüftgürtel von Kitthix",
         "esES": "Faja de Kitthix",
         "frFR": "Ceinture de Kitthix",
@@ -44645,7 +44645,7 @@
         "id": 51090,
         "Key": "Gauntlets of Quietus",
         "enUS": "Gauntlets of Quietus",
-        "zhTW": "寂滅護手",
+        "zhTW": "安静之铠",
         "deDE": "Fehdehandschuhe des Quietus",
         "esES": "Guanteletes de Quietus",
         "frFR": "Gantelets de Quietus",
@@ -44656,13 +44656,13 @@
         "jaJP": "ガントレット・オブ・クワイタス",
         "ptBR": "Manoplas de Quietus",
         "ruRU": "Перчатки Квиетуса",
-        "zhCN": "寂灭护手"
+        "zhCN": "安静之铠"
     },
     {
         "id": 51091,
         "Key": "Corthala Family Heirlooms",
         "enUS": "Corthala Family Heirlooms",
-        "zhTW": "科薩拉家族的傳家寶",
+        "zhTW": "科萨拉家族的传家宝",
         "deDE": "Erbstücke der Familie Corthala",
         "esES": "Herencias de la familia Corthala",
         "frFR": "Héritages de la famille Corthala",
@@ -44679,7 +44679,7 @@
         "id": 51092,
         "Key": "Sir Tylan's Sylvan Mail",
         "enUS": "Sir Tylan's Sylvan Mail",
-        "zhTW": "泰蘭爵士的森林之甲",
+        "zhTW": "泰兰爵士的希尔凡邮件",
         "deDE": "Sir Tylans Sylvanische Post",
         "esES": "Correo Silvano de Sir Tylan",
         "frFR": "Le courrier sylvestre de Sir Tylan",
@@ -44690,13 +44690,13 @@
         "jaJP": "サー・タイランのシルヴァン・メール",
         "ptBR": "Correio Silvestre de Sir Tylan",
         "ruRU": "Сильванская почта сэра Тилана",
-        "zhCN": "泰兰爵士的森林之甲"
+        "zhCN": "泰兰爵士的希尔凡邮件"
     },
     {
         "id": 51093,
         "Key": "Prince Karnd's Abomination",
         "enUS": "Prince Karnd's Abomination",
-        "zhTW": "卡恩德王子的憎惡",
+        "zhTW": "卡恩德王子的憎恶",
         "deDE": "Prinz Karnds Abscheulichkeit",
         "esES": "Abominación del Príncipe Karnd",
         "frFR": "L'abomination du prince Karnd",
@@ -44713,7 +44713,7 @@
         "id": 51094,
         "Key": "Yavin's Infernal Visage",
         "enUS": "Yavin's Infernal Visage",
-        "zhTW": "雅文的地獄面容",
+        "zhTW": "雅文的无间面容",
         "deDE": "Yavins höllische Visage",
         "esES": "Visaje infernal de Yavin",
         "frFR": "Visage infernal de Yavin",
@@ -44724,13 +44724,13 @@
         "jaJP": "ヤヴィンの地獄の面影",
         "ptBR": "Visage Infernal de Yavin",
         "ruRU": "Инфернальное видение Явина",
-        "zhCN": "雅文的地狱面容"
+        "zhCN": "雅文的无间面容"
     },
     {
         "id": 51095,
         "Key": "Prince Gwar's Bracers",
         "enUS": "Prince Gwar's Bracers",
-        "zhTW": "格瓦王子的護腕",
+        "zhTW": "格瓦王子的臂铠",
         "deDE": "Prinz Gwars Armschienen",
         "esES": "Brazales del Príncipe Gwar",
         "frFR": "Les bracelets du prince Gwar",
@@ -44741,13 +44741,13 @@
         "jaJP": "プリンス・グワーのブレイサー",
         "ptBR": "Braçadeiras do Príncipe Gwar",
         "ruRU": "Браслеты принца Гвара",
-        "zhCN": "格瓦王子的护腕"
+        "zhCN": "格瓦王子的臂铠"
     },
     {
         "id": 51096,
         "Key": "Lady Daan's Celeritous Jambeau",
         "enUS": "Lady Daan's Celeritous Jambeau",
-        "zhTW": "達安夫人的慶典脛甲（Lady Daan's Celeritous Jambeau)",
+        "zhTW": "达安夫人的赛勒瑞斯-贾博（Lady Daan's Celeritous Jambeau",
         "deDE": "Lady Daan's Schnelllebige Marmelade",
         "esES": "Jambeau Celeritous de Lady Daan",
         "frFR": "Lady Daan's Celeritous Jambeau",
@@ -44758,13 +44758,13 @@
         "jaJP": "レディ・ダアンのセレリトゥス・ジャンボー",
         "ptBR": "Jambeau Célebre da Dama Daan",
         "ruRU": "Леди Даан'с Селеритис Джамбо",
-        "zhCN": "达安夫人的庆典胫甲（Lady Daan's Celeritous Jambeau)"
+        "zhCN": "达安夫人的赛勒瑞斯-贾博（Lady Daan's Celeritous Jambeau"
     },
     {
         "id": 51097,
         "Key": "Knight's Gallantry",
         "enUS": "Knight's Gallantry",
-        "zhTW": "騎士的英勇",
+        "zhTW": "骑士的英勇",
         "deDE": "Ritterliche Tapferkeit",
         "esES": "Gallardía de caballero",
         "frFR": "Galanterie du chevalier",
@@ -44781,7 +44781,7 @@
         "id": 51098,
         "Key": "Mail of Courageousness",
         "enUS": "Mail of Courageousness",
-        "zhTW": "無畏之甲",
+        "zhTW": "勇气邮件",
         "deDE": "Post der Tapferkeit",
         "esES": "Correo del Valor",
         "frFR": "Courrier du courage",
@@ -44792,13 +44792,13 @@
         "jaJP": "勇気メール",
         "ptBR": "Correio de Coragem",
         "ruRU": "Почта храбрости",
-        "zhCN": "无畏之甲"
+        "zhCN": "勇气邮件"
     },
     {
         "id": 51099,
         "Key": "Baton of Intrepidity",
         "enUS": "Baton of Intrepidity",
-        "zhTW": "膽氣之棍",
+        "zhTW": "无畏接力棒",
         "deDE": "Baton der Unerschrockenheit",
         "esES": "Bastón de la Intrepidez",
         "frFR": "Bâton de l'intrépidité",
@@ -44809,13 +44809,13 @@
         "jaJP": "不屈のバトン",
         "ptBR": "Bastão da Intrepidez",
         "ruRU": "Батон неустрашимости",
-        "zhCN": "胆气之棍"
+        "zhCN": "无畏接力棒"
     },
     {
         "id": 51100,
         "Key": "Wall of Bravery",
         "enUS": "Wall of Bravery",
-        "zhTW": "勇氣之墻",
+        "zhTW": "勇敢墙",
         "deDE": "Mauer der Tapferkeit",
         "esES": "Muro de la valentía",
         "frFR": "Mur de la bravoure",
@@ -44826,13 +44826,13 @@
         "jaJP": "勇気の壁",
         "ptBR": "Parede da Bravura",
         "ruRU": "Стена храбрости",
-        "zhCN": "勇气之墙"
+        "zhCN": "勇敢墙"
     },
     {
         "id": 51101,
         "Key": "Helm of Chivalry",
         "enUS": "Helm of Chivalry",
-        "zhTW": "俠義之盔",
+        "zhTW": "侠义之盔",
         "deDE": "Helm der Ritterlichkeit",
         "esES": "Yelmo de caballería",
         "frFR": "Casque de chevalerie",
@@ -44849,7 +44849,7 @@
         "id": 51102,
         "Key": "Belt of Temerity",
         "enUS": "Belt of Temerity",
-        "zhTW": "蠻勇之帶",
+        "zhTW": "节制腰带",
         "deDE": "Gürtel der Gelassenheit",
         "esES": "Cinturón de Temeridad",
         "frFR": "Ceinture de Temerity",
@@ -44860,13 +44860,13 @@
         "jaJP": "テマリティのベルト",
         "ptBR": "Cinto da Temeridade",
         "ruRU": "Пояс храбрости",
-        "zhCN": "蛮勇之带"
+        "zhCN": "节制腰带"
     },
     {
         "id": 51103,
         "Key": "Lord Sith's Province",
         "enUS": "Lord Sith's Province",
-        "zhTW": "西斯王的行省",
+        "zhTW": "西斯王省",
         "deDE": "Die Provinz von Lord Sith",
         "esES": "Provincia de Lord Sith",
         "frFR": "Province du Seigneur Sith",
@@ -44877,13 +44877,13 @@
         "jaJP": "シス卿の州",
         "ptBR": "Província de Lord Sith",
         "ruRU": "Провинция лорда Ситха",
-        "zhCN": "西斯王的行省"
+        "zhCN": "西斯王省"
     },
     {
         "id": 51104,
         "Key": "Ebony Plate of Evil",
         "enUS": "Ebony Plate of Evil",
-        "zhTW": "邪惡之烏木板甲",
+        "zhTW": "邪恶乌木盘",
         "deDE": "Ebenholzplatte des Bösen",
         "esES": "Placa de ébano del mal",
         "frFR": "Plaque d'ébène du mal",
@@ -44894,13 +44894,13 @@
         "jaJP": "悪の黒檀プレート",
         "ptBR": "Armadura Ébano do Mal ",
         "ruRU": "Эбеновая пластина зла",
-        "zhCN": "邪恶之乌木板甲"
+        "zhCN": "邪恶乌木盘"
     },
     {
         "id": 51105,
         "Key": "Deflector of Light",
         "enUS": "Deflector of Light",
-        "zhTW": "光明之偏轉護盾",
+        "zhTW": "光之偏转器",
         "deDE": "Deflektor des Lichts",
         "esES": "Deflector de luz",
         "frFR": "Déflecteur de lumière",
@@ -44911,13 +44911,13 @@
         "jaJP": "ディフレクター・オブ・ライト",
         "ptBR": "Defletor de Luz",
         "ruRU": "Отражатель света",
-        "zhCN": "光明之偏转护盾"
+        "zhCN": "光之偏转器"
     },
     {
         "id": 51106,
         "Key": "Dark Cataclysm",
         "enUS": "Dark Cataclysm",
-        "zhTW": "黑暗之災變冠冕",
+        "zhTW": "黑暗大灾变",
         "deDE": "Dunkler Kataklysmus",
         "esES": "Cataclismo oscuro",
         "frFR": "Dark Cataclysm",
@@ -44928,13 +44928,13 @@
         "jaJP": "ダーク・カタクリズム",
         "ptBR": "Cataclismo Tenebroso",
         "ruRU": "Темный катаклизм",
-        "zhCN": "黑暗之灾变冠冕"
+        "zhCN": "黑暗大灾变"
     },
     {
         "id": 51107,
         "Key": "Malignant Rod",
         "enUS": "Malignant Rod",
-        "zhTW": "惡毒之短杖",
+        "zhTW": "恶性棒",
         "deDE": "Malignant Rod",
         "esES": "Vara maligna",
         "frFR": "Malignant Rod",
@@ -44945,13 +44945,13 @@
         "jaJP": "悪性棒",
         "ptBR": "Bastão Maligno",
         "ruRU": "Злокачественный стержень",
-        "zhCN": "恶毒之短杖"
+        "zhCN": "恶性棒"
     },
     {
         "id": 51108,
         "Key": "Kai Lord's Valiance",
         "enUS": "Kai Lord's Valiance",
-        "zhTW": "君主凱的英勇",
+        "zhTW": "凯主的英勇",
         "deDE": "Die Tapferkeit des Kai Lords",
         "esES": "El valor de Kai Lord",
         "frFR": "La bravoure du seigneur Kai",
@@ -44962,13 +44962,13 @@
         "jaJP": "甲斐ロードの勇姿",
         "ptBR": "Variância de Kai Lord",
         "ruRU": "Доблесть Кая Лорда",
-        "zhCN": "君主凯的英勇"
+        "zhCN": "凯主的英勇"
     },
     {
         "id": 51109,
         "Key": "Helshazag",
         "enUS": "Helshazag",
-        "zhTW": "赫爾沙扎",
+        "zhTW": "Helshazag",
         "deDE": "Helshazag",
         "esES": "Helshazag",
         "frFR": "Helshazag",
@@ -44979,13 +44979,13 @@
         "jaJP": "ヘルシャザグ",
         "ptBR": "Shazag Infernal ",
         "ruRU": "Хельсхазаг",
-        "zhCN": "赫尔沙扎"
+        "zhCN": "Helshazag"
     },
     {
         "id": 51110,
         "Key": "Summerswerd",
         "enUS": "Summerswerd",
-        "zhTW": "夏日之刃",
+        "zhTW": "夏日之窗",
         "deDE": "Summerswerd",
         "esES": "Summerswerd",
         "frFR": "Summerswerd",
@@ -44996,13 +44996,13 @@
         "jaJP": "サマースワード",
         "ptBR": "Verões Estranhos",
         "ruRU": "Саммерсверд",
-        "zhCN": "夏日之刃"
+        "zhCN": "夏日之窗"
     },
     {
         "id": 51111,
         "Key": "Helghast Waistband",
         "enUS": "Helghast Waistband",
-        "zhTW": "赫爾加斯特腰帶",
+        "zhTW": "赫尔加斯特腰带",
         "deDE": "Helghast Waistband",
         "esES": "Cintura Helghast",
         "frFR": "Bandeau Helghast",
@@ -45019,7 +45019,7 @@
         "id": 51112,
         "Key": "Hallowed Greaves",
         "enUS": "Hallowed Greaves",
-        "zhTW": "神聖護脛",
+        "zhTW": "神圣的格里夫斯",
         "deDE": "Geheiligte Gürtel",
         "esES": "Grebas consagradas",
         "frFR": "Greaves sanctifiés",
@@ -45030,13 +45030,13 @@
         "jaJP": "神聖な薙刀",
         "ptBR": "Caneleira Sagrados",
         "ruRU": "Освященные гривы",
-        "zhCN": "神圣护胫"
+        "zhCN": "神圣的格里夫斯"
     },
     {
         "id": 51113,
         "Key": "Sunspear Deflector",
         "enUS": "Sunspear Deflector",
-        "zhTW": "光之矛的偏轉護盾",
+        "zhTW": "太阳矛偏转器",
         "deDE": "Sonnenspeer Deflektor",
         "esES": "Deflector Sunspear",
         "frFR": "Déflecteur Sunspear",
@@ -45047,13 +45047,13 @@
         "jaJP": "サンスピア・ディフレクター",
         "ptBR": "Defletor de Lança Solar",
         "ruRU": "Отражатель солнечного копья",
-        "zhCN": "光之矛的偏转护盾"
+        "zhCN": "太阳矛偏转器"
     },
     {
         "id": 51114,
         "Key": "Path of Bravery",
         "enUS": "Path of Bravery",
-        "zhTW": "無畏之路",
+        "zhTW": "勇敢之路",
         "deDE": "Pfad der Tapferkeit",
         "esES": "El camino de la valentía",
         "frFR": "La voie de la bravoure",
@@ -45064,13 +45064,13 @@
         "jaJP": "勇気の道",
         "ptBR": "Caminho da Bravura",
         "ruRU": "Путь храбрости",
-        "zhCN": "无畏之路"
+        "zhCN": "勇敢之路"
     },
     {
         "id": 51115,
         "Key": "Imperial Plate",
         "enUS": "Imperial Plate",
-        "zhTW": "帝國重甲",
+        "zhTW": "帝王板",
         "deDE": "Kaiserliche Platte",
         "esES": "Placa imperial",
         "frFR": "Plaque impériale",
@@ -45081,13 +45081,13 @@
         "jaJP": "インペリアルプレート",
         "ptBR": "Armadura Imperial",
         "ruRU": "Императорская плита",
-        "zhCN": "帝国重甲"
+        "zhCN": "帝王板"
     },
     {
         "id": 51116,
         "Key": "Imperial Helm",
         "enUS": "Imperial Helm",
-        "zhTW": "帝國头盔",
+        "zhTW": "帝国头盔",
         "deDE": "Kaiserlicher Helm",
         "esES": "Imperial Helm",
         "frFR": "Casque impérial",
@@ -45104,7 +45104,7 @@
         "id": 51117,
         "Key": "Imperial Girdle",
         "enUS": "Imperial Girdle",
-        "zhTW": "帝國腰帶",
+        "zhTW": "御用腰带",
         "deDE": "Kaiserlicher Hüftgürtel",
         "esES": "Faja imperial",
         "frFR": "Gaine impériale",
@@ -45115,13 +45115,13 @@
         "jaJP": "インペリアル・ガードル",
         "ptBR": "Cinturão Imperial",
         "ruRU": "Императорский пояс",
-        "zhCN": "帝国腰带"
+        "zhCN": "御用腰带"
     },
     {
         "id": 51118,
         "Key": "Imperial Greaves",
         "enUS": "Imperial Greaves",
-        "zhTW": "帝國護脛",
+        "zhTW": "帝国格里夫斯",
         "deDE": "Kaiserliche Grieben",
         "esES": "Chicharrones imperiales",
         "frFR": "Imperial Greaves",
@@ -45132,13 +45132,13 @@
         "jaJP": "インペリアル・グリーヴス",
         "ptBR": "Caneleira Imperiais",
         "ruRU": "Имперский Гривз",
-        "zhCN": "帝国护胫"
+        "zhCN": "帝国格里夫斯"
     },
     {
         "id": 51119,
         "Key": "Imperial Gauntlets",
         "enUS": "Imperial Gauntlets",
-        "zhTW": "帝國臂鎧",
+        "zhTW": "帝国臂铠",
         "deDE": "Kaiserliche Fehdehandschuhe",
         "esES": "Guanteletes imperiales",
         "frFR": "Gantelets impériaux",
@@ -45155,7 +45155,7 @@
         "id": 51120,
         "Key": "Imperial Scepter",
         "enUS": "Imperial Scepter",
-        "zhTW": "帝國權杖",
+        "zhTW": "帝国权杖",
         "deDE": "Kaiserliches Zepter",
         "esES": "Cetro imperial",
         "frFR": "Sceptre impérial",
@@ -45172,7 +45172,7 @@
         "id": 51121,
         "Key": "Terror of the Deep",
         "enUS": "Terror of the Deep",
-        "zhTW": "深海之恐怖",
+        "zhTW": "深海恐怖",
         "deDE": "Der Schrecken der Tiefe",
         "esES": "Terror de las profundidades",
         "frFR": "La terreur des profondeurs",
@@ -45183,13 +45183,13 @@
         "jaJP": "深海の恐怖",
         "ptBR": "Terror das Profundezas",
         "ruRU": "Ужас глубин",
-        "zhCN": "深海之恐怖"
+        "zhCN": "深海恐怖"
     },
     {
         "id": 51122,
         "Key": "Great White Terror",
         "enUS": "Great White Terror",
-        "zhTW": "慘白恐怖",
+        "zhTW": "白色恐怖",
         "deDE": "Großer weißer Terror",
         "esES": "Gran terror blanco",
         "frFR": "Terreur blanche",
@@ -45200,13 +45200,13 @@
         "jaJP": "グレート・ホワイト・テラー",
         "ptBR": "Grande Terror Branco",
         "ruRU": "Большой белый ужас",
-        "zhCN": "惨白恐怖"
+        "zhCN": "白色恐怖"
     },
     {
         "id": 51123,
         "Key": "Feeding Frenzy",
         "enUS": "Feeding Frenzy",
-        "zhTW": "飼育狂怒",
+        "zhTW": "喂食狂潮",
         "deDE": "Fressrausch",
         "esES": "Frenesí de alimentación",
         "frFR": "La frénésie alimentaire",
@@ -45217,13 +45217,13 @@
         "jaJP": "フィーディングフレンジー",
         "ptBR": "Frenesi de Alimentação",
         "ruRU": "Кормовое безумие",
-        "zhCN": "饲育狂怒"
+        "zhCN": "喂食狂潮"
     },
     {
         "id": 51124,
         "Key": "Mako's Quickness",
         "enUS": "Mako's Quickness",
-        "zhTW": "真子的迅捷",
+        "zhTW": "真子的速度",
         "deDE": "Makos Schnelligkeit",
         "esES": "La rapidez de Mako",
         "frFR": "La rapidité de Mako",
@@ -45234,13 +45234,13 @@
         "jaJP": "マコのクイックネス",
         "ptBR": "Rapidez de Mako",
         "ruRU": "Быстрота Мако",
-        "zhCN": "真子的迅捷"
+        "zhCN": "真子的速度"
     },
     {
         "id": 51125,
         "Key": "Hammerhead's Persistence",
         "enUS": "Hammerhead's Persistence",
-        "zhTW": "錘头的堅持",
+        "zhTW": "锤头的坚持",
         "deDE": "Die Beharrlichkeit des Hammerhais",
         "esES": "Persistencia de Hammerhead",
         "frFR": "La persévérance de Hammerhead",
@@ -45257,7 +45257,7 @@
         "id": 51126,
         "Key": "Celestial Hierarchy",
         "enUS": "Celestial Hierarchy",
-        "zhTW": "天堂體系",
+        "zhTW": "天体等级",
         "deDE": "Die himmlische Hierarchie",
         "esES": "Jerarquía celeste",
         "frFR": "Hiérarchie céleste",
@@ -45268,7 +45268,7 @@
         "jaJP": "天界のヒエラルキー",
         "ptBR": "Hierarquia Celestial",
         "ruRU": "Небесная иерархия",
-        "zhCN": "天堂体系"
+        "zhCN": "天体等级"
     },
     {
         "id": 51127,
@@ -45291,7 +45291,7 @@
         "id": 51128,
         "Key": "Principality",
         "enUS": "Principality",
-        "zhTW": "權天使",
+        "zhTW": "公国",
         "deDE": "Fürstentum",
         "esES": "Principado",
         "frFR": "Principauté",
@@ -45302,13 +45302,13 @@
         "jaJP": "公国",
         "ptBR": "Principado",
         "ruRU": "Княжество",
-        "zhCN": "权天使"
+        "zhCN": "公国"
     },
     {
         "id": 51129,
         "Key": "Virtue",
         "enUS": "Virtue",
-        "zhTW": "德天使",
+        "zhTW": "美德",
         "deDE": "Virtue",
         "esES": "Virtud",
         "frFR": "Virtue",
@@ -45319,13 +45319,13 @@
         "jaJP": "美徳",
         "ptBR": "Virtude",
         "ruRU": "Добродетель",
-        "zhCN": "德天使"
+        "zhCN": "美德"
     },
     {
         "id": 51130,
         "Key": "Dominion",
         "enUS": "Dominion",
-        "zhTW": "主天使",
+        "zhTW": "多米尼克",
         "deDE": "Herrschaft",
         "esES": "Dominion",
         "frFR": "Dominion",
@@ -45336,13 +45336,13 @@
         "jaJP": "ドミニオン",
         "ptBR": "Domínio",
         "ruRU": "Доминион",
-        "zhCN": "主天使"
+        "zhCN": "多米尼克"
     },
     {
         "id": 51131,
         "Key": "Cherubim",
         "enUS": "Cherubim",
-        "zhTW": "智天使",
+        "zhTW": "基路伯",
         "deDE": "Cherubim",
         "esES": "Querubines",
         "frFR": "Chérubins",
@@ -45353,13 +45353,13 @@
         "jaJP": "ケルビム",
         "ptBR": "Querubim",
         "ruRU": "Херувимы",
-        "zhCN": "智天使"
+        "zhCN": "基路伯"
     },
     {
         "id": 51132,
         "Key": "Seraphim",
         "enUS": "Seraphim",
-        "zhTW": "六翼天使",
+        "zhTW": "塞拉芬",
         "deDE": "Seraphim",
         "esES": "Serafín",
         "frFR": "Séraphin",
@@ -45370,13 +45370,13 @@
         "jaJP": "セラフィム",
         "ptBR": "Serafim",
         "ruRU": "Серафим",
-        "zhCN": "六翼天使"
+        "zhCN": "塞拉芬"
     },
     {
         "id": 51133,
         "Key": "Lords of Hell",
         "enUS": "Lords of Hell",
-        "zhTW": "地獄之主",
+        "zhTW": "地狱领主",
         "deDE": "Die Herren der Hölle",
         "esES": "Señores del Infierno",
         "frFR": "Les seigneurs de l'enfer",
@@ -45387,13 +45387,13 @@
         "jaJP": "地獄の領主たち",
         "ptBR": "Senhores do Inferno",
         "ruRU": "Повелители ада",
-        "zhCN": "地狱之主"
+        "zhCN": "地狱领主"
     },
     {
         "id": 51134,
         "Key": "Mephisto's Misty Aura",
         "enUS": "Mephisto's Misty Aura",
-        "zhTW": "墨菲斯托的迷霧光環",
+        "zhTW": "墨菲斯托的迷雾光环",
         "deDE": "Mephistos neblige Aura",
         "esES": "Aura brumosa de Mephisto",
         "frFR": "Aura brumeuse de Méphisto",
@@ -45410,7 +45410,7 @@
         "id": 51135,
         "Key": "Diablo's Soulstone Ring",
         "enUS": "Diablo's Soulstone Ring",
-        "zhTW": "迪亞波羅的灵魂石之戒",
+        "zhTW": "暗黑破坏神灵魂石戒指",
         "deDE": "Diablos Seelenstein-Ring",
         "esES": "Anillo de piedra del alma de Diablo",
         "frFR": "Anneau de pierre d'âme de Diablo",
@@ -45421,13 +45421,13 @@
         "jaJP": "ディアブロのソウルストーン・リング",
         "ptBR": "Anel Pedra da Alma de Diablo",
         "ruRU": "Кольцо с камнем души Диабло",
-        "zhCN": "迪亚波罗灵魂石之戒"
+        "zhCN": "暗黑破坏神灵魂石戒指"
     },
     {
         "id": 51136,
         "Key": "Baal's Cryptic Amulet",
         "enUS": "Baal's Cryptic Amulet",
-        "zhTW": "巴爾的神秘護身符",
+        "zhTW": "巴尔的神秘护身符",
         "deDE": "Das kryptische Amulett des Baal",
         "esES": "Amuleto críptico de Baal",
         "frFR": "Amulette cryptique de Baal",
@@ -45444,7 +45444,7 @@
         "id": 51137,
         "Key": "Heaven's Lances",
         "enUS": "Heaven's Lances",
-        "zhTW": "天堂之槍",
+        "zhTW": "天堂之枪",
         "deDE": "Die Lanzen des Himmels",
         "esES": "Lanzas del cielo",
         "frFR": "Les lances du ciel",
@@ -45461,7 +45461,7 @@
         "id": 51138,
         "Key": "Corruption Coils",
         "enUS": "Corruption Coils",
-        "zhTW": "腐化纏繞",
+        "zhTW": "腐败线圈",
         "deDE": "Korruptionsspulen",
         "esES": "Bobinas de corrupción",
         "frFR": "Bobines de corruption",
@@ -45472,13 +45472,13 @@
         "jaJP": "汚職コイル",
         "ptBR": "Bobinas de Corrupção",
         "ruRU": "Коррупционные катушки",
-        "zhCN": "腐化缠绕"
+        "zhCN": "腐败线圈"
     },
     {
         "id": 51139,
         "Key": "Demonic Chuckle",
         "enUS": "Demonic Chuckle",
-        "zhTW": "惡魔的嗤笑",
+        "zhTW": "恶魔的嗤笑",
         "deDE": "Dämonisches Glucksen",
         "esES": "Risita demoníaca",
         "frFR": "Rire démoniaque",
@@ -45495,7 +45495,7 @@
         "id": 51140,
         "Key": "Evil Humor",
         "enUS": "Evil Humor",
-        "zhTW": "邪惡的幽默",
+        "zhTW": "邪恶幽默",
         "deDE": "Böser Humor",
         "esES": "Humor maligno",
         "frFR": "Humour diabolique",
@@ -45506,13 +45506,13 @@
         "jaJP": "邪悪なユーモア",
         "ptBR": "Mau Humor",
         "ruRU": "Злой юмор",
-        "zhCN": "邪恶的幽默"
+        "zhCN": "邪恶幽默"
     },
     {
         "id": 51141,
         "Key": "Temptation's Death",
         "enUS": "Temptation's Death",
-        "zhTW": "誘惑的死亡",
+        "zhTW": "诱惑之死",
         "deDE": "Der Tod der Versuchung",
         "esES": "La muerte de la tentación",
         "frFR": "La mort de la tentation",
@@ -45523,13 +45523,13 @@
         "jaJP": "誘惑の死",
         "ptBR": "Morte da Tentação",
         "ruRU": "Смерть искушения",
-        "zhCN": "诱惑的死亡"
+        "zhCN": "诱惑之死"
     },
     {
         "id": 51142,
         "Key": "Midnight Calling",
         "enUS": "Midnight Calling",
-        "zhTW": "午夜召喚",
+        "zhTW": "午夜召唤",
         "deDE": "Mitternachtsrufe",
         "esES": "Llamada de medianoche",
         "frFR": "L'appel de minuit",
@@ -45546,7 +45546,7 @@
         "id": 51143,
         "Key": "Jakira's Strike",
         "enUS": "Jakira's Strike",
-        "zhTW": "雅基拉的襲擊",
+        "zhTW": "雅基拉的罢工",
         "deDE": "Jakiras Streik",
         "esES": "Huelga de Jakira",
         "frFR": "La grève de Jakira",
@@ -45557,13 +45557,13 @@
         "jaJP": "ジャキーラの一撃",
         "ptBR": "Golpe de Jakira",
         "ruRU": "Удар Джакиры",
-        "zhCN": "雅基拉的袭击"
+        "zhCN": "雅基拉的罢工"
     },
     {
         "id": 51144,
         "Key": "Jakira's Braces",
         "enUS": "Jakira's Braces",
-        "zhTW": "雅基拉的手套",
+        "zhTW": "雅基拉的牙套",
         "deDE": "Jakiras Zahnspange",
         "esES": "Tirantes de Jakira",
         "frFR": "L'appareil dentaire de Jakira",
@@ -45574,13 +45574,13 @@
         "jaJP": "ジャキーラの歯列矯正",
         "ptBR": "Suspensórios de Jakira",
         "ruRU": "Брекеты Джакиры",
-        "zhCN": "雅基拉的手套"
+        "zhCN": "雅基拉的牙套"
     },
     {
         "id": 51145,
         "Key": "Jakira's Hood",
         "enUS": "Jakira's Hood",
-        "zhTW": "雅基拉的頭巾",
+        "zhTW": "雅基拉的头巾",
         "deDE": "Jakiras Kapuze",
         "esES": "Capucha de Jakira",
         "frFR": "Le capuchon de Jakira",
@@ -45597,7 +45597,7 @@
         "id": 51146,
         "Key": "Jakira's Leather Jerkin",
         "enUS": "Jakira's Leather Jerkin",
-        "zhTW": "雅基拉的皮甲",
+        "zhTW": "雅基拉的皮套",
         "deDE": "Jakiras Lederwams",
         "esES": "Jerkin de cuero de Jakira",
         "frFR": "Jerkin en cuir de Jakira",
@@ -45608,13 +45608,13 @@
         "jaJP": "ジャキラのレザージャーキン",
         "ptBR": "Justilho de Couro de Jakira",
         "ruRU": "Кожаный камзол Джакиры",
-        "zhCN": "雅基拉的皮甲"
+        "zhCN": "雅基拉的皮套"
     },
     {
         "id": 51147,
         "Key": "Nature's Grove",
         "enUS": "Nature's Grove",
-        "zhTW": "自然叢林",
+        "zhTW": "自然丛林园",
         "deDE": "Der Hain der Natur",
         "esES": "Arboleda natural",
         "frFR": "Le bosquet de la nature",
@@ -45625,13 +45625,13 @@
         "jaJP": "ネイチャーズ・グローブ",
         "ptBR": "Bosque da Natureza",
         "ruRU": "Природная роща",
-        "zhCN": "自然丛林"
+        "zhCN": "自然丛林园"
     },
     {
         "id": 51148,
         "Key": "Peace Ring",
         "enUS": "Peace Ring",
-        "zhTW": "平和之戒指",
+        "zhTW": "和平戒指",
         "deDE": "Friedensring",
         "esES": "Anillo de la Paz",
         "frFR": "Anneau de la paix",
@@ -45642,13 +45642,13 @@
         "jaJP": "ピースリング",
         "ptBR": "Anel da Paz",
         "ruRU": "Кольцо мира",
-        "zhCN": "平和之戒指"
+        "zhCN": "和平戒指"
     },
     {
         "id": 51149,
         "Key": "Balance of Power",
         "enUS": "Balance of Power",
-        "zhTW": "力量的平衡",
+        "zhTW": "权力制衡",
         "deDE": "Gleichgewicht der Kräfte",
         "esES": "Equilibrio de poder",
         "frFR": "L'équilibre des pouvoirs",
@@ -45659,13 +45659,13 @@
         "jaJP": "パワーバランス",
         "ptBR": "Equilíbrio de Poder",
         "ruRU": "Баланс сил",
-        "zhCN": "力量的平衡"
+        "zhCN": "权力制衡"
     },
     {
         "id": 51150,
         "Key": "Calming Embrace",
         "enUS": "Calming Embrace",
-        "zhTW": "平静的擁抱",
+        "zhTW": "平静的怀抱",
         "deDE": "Beruhigende Umarmung",
         "esES": "Abrazo tranquilizador",
         "frFR": "Étreinte apaisante",
@@ -45676,13 +45676,13 @@
         "jaJP": "カーミング・エンブレイス",
         "ptBR": "Abraço Calmante",
         "ruRU": "Успокаивающие объятия",
-        "zhCN": "平静的拥抱"
+        "zhCN": "平静的怀抱"
     },
     {
         "id": 51151,
         "Key": "Animal Kinship",
         "enUS": "Animal Kinship",
-        "zhTW": "動物的親和",
+        "zhTW": "动物亲缘关系",
         "deDE": "Tierische Verwandtschaft",
         "esES": "Parentesco animal",
         "frFR": "La parenté animale",
@@ -45693,7 +45693,7 @@
         "jaJP": "動物の親族関係",
         "ptBR": "Parentesco Animal",
         "ruRU": "Родство животных",
-        "zhCN": "动物的亲和"
+        "zhCN": "动物亲缘关系"
     },
     {
         "id": 51152,
@@ -45716,7 +45716,7 @@
         "id": 51153,
         "Key": "Grimlock's Skull",
         "enUS": "Grimlock's Skull",
-        "zhTW": "格里姆洛克的頭骨",
+        "zhTW": "格里姆洛克的头骨",
         "deDE": "Grimlocks Schädel",
         "esES": "Cráneo de Grimlock",
         "frFR": "Crâne de Grimlock",
@@ -45784,7 +45784,7 @@
         "id": 51157,
         "Key": "Corgina's Element",
         "enUS": "Corgina's Element",
-        "zhTW": "科爾吉娜的元素",
+        "zhTW": "科尔吉娜元素",
         "deDE": "Corginas Element",
         "esES": "Elemento de Corgina",
         "frFR": "L'élément de Corgina",
@@ -45795,13 +45795,13 @@
         "jaJP": "コルギナのエレメント",
         "ptBR": "Elemento de Corgina",
         "ruRU": "Элемент Коргины",
-        "zhCN": "科尔吉娜的元素"
+        "zhCN": "科尔吉娜元素"
     },
     {
         "id": 51158,
         "Key": "Corgina's Orb",
         "enUS": "Corgina's Orb",
-        "zhTW": "科爾吉娜的法球",
+        "zhTW": "科尔吉娜的球体",
         "deDE": "Der Reichsapfel von Corgina",
         "esES": "Orbe de Corgina",
         "frFR": "L'orbe de Corgina",
@@ -45812,13 +45812,13 @@
         "jaJP": "コルギナのオーブ",
         "ptBR": "Orbe de Corgina",
         "ruRU": "Сфера Коргины",
-        "zhCN": "科尔吉娜的法球"
+        "zhCN": "科尔吉娜的球体"
     },
     {
         "id": 51159,
         "Key": "Corgina's Plate",
         "enUS": "Corgina's Plate",
-        "zhTW": "科爾吉娜的板甲",
+        "zhTW": "科尔吉娜的盘子",
         "deDE": "Corginas Teller",
         "esES": "Plato de Corgina",
         "frFR": "Assiette de Corgina",
@@ -45829,13 +45829,13 @@
         "jaJP": "コルジーナの皿",
         "ptBR": "Armadura de Corgina",
         "ruRU": "Тарелка Коргины",
-        "zhCN": "科尔吉娜的板甲"
+        "zhCN": "科尔吉娜的盘子"
     },
     {
         "id": 51160,
         "Key": "Corgina's Ward",
         "enUS": "Corgina's Ward",
-        "zhTW": "科爾吉娜的防衛",
+        "zhTW": "科尔吉娜病房",
         "deDE": "Corginas Station",
         "esES": "Pabellón de Corgina",
         "frFR": "Quartier de Corgina",
@@ -45846,13 +45846,13 @@
         "jaJP": "コルジーナ区",
         "ptBR": "Custódia de Corgina",
         "ruRU": "Палата Коргины",
-        "zhCN": "科尔吉娜的防卫"
+        "zhCN": "科尔吉娜病房"
     },
     {
         "id": 51161,
         "Key": "Corgina's Slippers",
         "enUS": "Corgina's Slippers",
-        "zhTW": "科爾吉娜的拖鞋",
+        "zhTW": "科尔吉娜的拖鞋",
         "deDE": "Corginas Hausschuhe",
         "esES": "Zapatillas de Corgina",
         "frFR": "Les pantoufles de Corgina",
@@ -45869,7 +45869,7 @@
         "id": 51162,
         "Key": "Sheena's Grace",
         "enUS": "Sheena's Grace",
-        "zhTW": "希娜的優雅",
+        "zhTW": "希娜的恩典",
         "deDE": "Sheenas Anmut",
         "esES": "La gracia de Sheena",
         "frFR": "La grâce de Sheena",
@@ -45880,7 +45880,7 @@
         "jaJP": "シーナの恩寵",
         "ptBR": "Graça de Sheena",
         "ruRU": "Милость Шины",
-        "zhCN": "希娜的优雅"
+        "zhCN": "希娜的恩典"
     },
     {
         "id": 51163,
@@ -45903,7 +45903,7 @@
         "id": 51164,
         "Key": "Sheena's Choker",
         "enUS": "Sheena's Choker",
-        "zhTW": "希娜的項鏈",
+        "zhTW": "希娜的项链",
         "deDE": "Sheenas Halsband",
         "esES": "Gargantilla de Sheena",
         "frFR": "Le tour de cou de Sheena",
@@ -45920,7 +45920,7 @@
         "id": 51165,
         "Key": "Sheena's Elven Mail",
         "enUS": "Sheena's Elven Mail",
-        "zhTW": "希娜的精靈甲",
+        "zhTW": "希娜的精灵邮件",
         "deDE": "Sheenas Elfenpost",
         "esES": "Correo élfico de Sheena",
         "frFR": "Le courrier elfique de Sheena",
@@ -45931,13 +45931,13 @@
         "jaJP": "シーナのエルフ・メール",
         "ptBR": "Correio Élfico de Sheena",
         "ruRU": "Эльфийская почта Шины",
-        "zhCN": "希娜的精灵甲"
+        "zhCN": "希娜的精灵邮件"
     },
     {
         "id": 51166,
         "Key": "Sheena's Band",
         "enUS": "Sheena's Band",
-        "zhTW": "希娜的彩帶",
+        "zhTW": "希娜乐队",
         "deDE": "Sheenas Band",
         "esES": "La banda de Sheena",
         "frFR": "Le groupe de Sheena",
@@ -45948,13 +45948,13 @@
         "jaJP": "シーナ・バンド",
         "ptBR": "Banda de Sheena",
         "ruRU": "Группа Шины",
-        "zhCN": "希娜的彩带"
+        "zhCN": "希娜乐队"
     },
     {
         "id": 51167,
         "Key": "Talonrage's Fury",
         "enUS": "Talonrage's Fury",
-        "zhTW": "塔倫拉格之怒",
+        "zhTW": "塔伦拉格之怒",
         "deDE": "Talonrages Wut",
         "esES": "La furia de Talonrage",
         "frFR": "La fureur de Talonrage",
@@ -45971,7 +45971,7 @@
         "id": 51168,
         "Key": "Berserker's Howl",
         "enUS": "Berserker's Howl",
-        "zhTW": "狂戰士的呼嘯",
+        "zhTW": "狂战士的嚎叫",
         "deDE": "Heulen des Berserkers",
         "esES": "Aullido de Berserker",
         "frFR": "Hurlement de Berserker",
@@ -45982,13 +45982,13 @@
         "jaJP": "バーサーカーの遠吠え",
         "ptBR": "Uivo do Berserker",
         "ruRU": "Вой берсерка",
-        "zhCN": "狂战士的呼啸"
+        "zhCN": "狂战士的嚎叫"
     },
     {
         "id": 51169,
         "Key": "Chaos Heart",
         "enUS": "Chaos Heart",
-        "zhTW": "渾沌之心",
+        "zhTW": "混沌之心",
         "deDE": "Chaos Herz",
         "esES": "Corazón del caos",
         "frFR": "Le cœur du chaos",
@@ -46005,7 +46005,7 @@
         "id": 51170,
         "Key": "Warlord's Pike",
         "enUS": "Warlord's Pike",
-        "zhTW": "戰神長槍",
+        "zhTW": "战神长矛",
         "deDE": "Hecht des Kriegsherrn",
         "esES": "Pica del caudillo",
         "frFR": "Pique du seigneur de la guerre",
@@ -46016,13 +46016,13 @@
         "jaJP": "ウォーロード・パイク",
         "ptBR": "Lança do Senhor da Guerra ",
         "ruRU": "Пика военачальника",
-        "zhCN": "战神长枪"
+        "zhCN": "战神长矛"
     },
     {
         "id": 51171,
         "Key": "Shattering Fist",
         "enUS": "Shattering Fist",
-        "zhTW": "粉碎拳套",
+        "zhTW": "粉碎拳",
         "deDE": "Zerschmetternde Faust",
         "esES": "Puño demoledor",
         "frFR": "Poing brisant",
@@ -46033,13 +46033,13 @@
         "jaJP": "粉砕拳",
         "ptBR": "Punho Quebrando",
         "ruRU": "Сокрушительный кулак",
-        "zhCN": "粉碎拳套"
+        "zhCN": "粉碎拳"
     },
     {
         "id": 51172,
         "Key": "Greyhawk's Mantle",
         "enUS": "Greyhawk's Mantle",
-        "zhTW": "灰鷹的衣鉢",
+        "zhTW": "灰鹰的衣钵",
         "deDE": "Der Mantel von Greyhawk",
         "esES": "Manto de Greyhawk",
         "frFR": "Le manteau de Greyhawk",
@@ -46056,7 +46056,7 @@
         "id": 51173,
         "Key": "Greyhawk's Wing",
         "enUS": "Greyhawk's Wing",
-        "zhTW": "灰鷹之翼",
+        "zhTW": "灰鹰之翼",
         "deDE": "Greyhawks Flügel",
         "esES": "Ala de Greyhawk",
         "frFR": "L'aile de Greyhawk",
@@ -46073,7 +46073,7 @@
         "id": 51174,
         "Key": "Greyhawk's Icebrand",
         "enUS": "Greyhawk's Icebrand",
-        "zhTW": "灰鷹的寒冰烙印",
+        "zhTW": "灰鹰的冰标",
         "deDE": "Greyhawks Eisbrand",
         "esES": "Greyhawk's Icebrand",
         "frFR": "L'Icebrand de Greyhawk",
@@ -46084,13 +46084,13 @@
         "jaJP": "グレイホークのアイスブランド",
         "ptBR": "Marca Gelada do Falcão Cinzento",
         "ruRU": "Айсбранд из Грейхоука",
-        "zhCN": "灰鹰的寒冰烙印"
+        "zhCN": "灰鹰的冰标"
     },
     {
         "id": 51175,
         "Key": "Greyhawk's Deflector",
         "enUS": "Greyhawk's Deflector",
-        "zhTW": "灰鷹的偏轉護盾",
+        "zhTW": "灰鹰的偏转器",
         "deDE": "Greyhawks Deflektor",
         "esES": "Deflector de Greyhawk",
         "frFR": "Le déflecteur de Greyhawk",
@@ -46101,13 +46101,13 @@
         "jaJP": "グレイホークのディフレクター",
         "ptBR": "Falcão Cinzento Defletor",
         "ruRU": "Отражатель Грейхока",
-        "zhCN": "灰鹰的偏转护盾"
+        "zhCN": "灰鹰的偏转器"
     },
     {
         "id": 51176,
         "Key": "Greyhawk's Viser",
         "enUS": "Greyhawk's Viser",
-        "zhTW": "灰鷹的面甲",
+        "zhTW": "灰鹰的维瑟",
         "deDE": "Grauhawks Visier",
         "esES": "Visera de Greyhawk",
         "frFR": "Le Viser de Greyhawk",
@@ -46118,13 +46118,13 @@
         "jaJP": "グレイホークのバイザー",
         "ptBR": "Visão do Falcão Cinzento",
         "ruRU": "Визер Грейхока",
-        "zhCN": "灰鹰的面甲"
+        "zhCN": "灰鹰的 Viser"
     },
     {
         "id": 51177,
         "Key": "Silent Runnings",
         "enUS": "Silent Runnings",
-        "zhTW": "無聲狂奔",
+        "zhTW": "无声的奔跑",
         "deDE": "Silent Runnings",
         "esES": "Corridas silenciosas",
         "frFR": "Les coulisses du silence",
@@ -46135,13 +46135,13 @@
         "jaJP": "サイレント・ランニング",
         "ptBR": "Corrida Silenciada",
         "ruRU": "Безмолвные бега",
-        "zhCN": "无声狂奔"
+        "zhCN": "无声的奔跑"
     },
     {
         "id": 51178,
         "Key": "Dragon's Flank",
         "enUS": "Dragon's Flank",
-        "zhTW": "巨龍側翼",
+        "zhTW": "龙之侧翼",
         "deDE": "Die Drachenflanke",
         "esES": "Flanco de Dragón",
         "frFR": "Le flanc du dragon",
@@ -46152,13 +46152,13 @@
         "jaJP": "ドラゴンズ・フランクス",
         "ptBR": "Flancos de Dragão",
         "ruRU": "Фланг дракона",
-        "zhCN": "巨龙侧翼"
+        "zhCN": "龙之侧翼"
     },
     {
         "id": 51179,
         "Key": "Ferrit's Paw",
         "enUS": "Ferrit's Paw",
-        "zhTW": "費利特之爪",
+        "zhTW": "费里特的爪子",
         "deDE": "Ferrits Pfote",
         "esES": "La pata de Ferrit",
         "frFR": "La patte de Ferrit",
@@ -46169,13 +46169,13 @@
         "jaJP": "フェリットの足",
         "ptBR": "Pata de Ferrit",
         "ruRU": "Лапа Феррита",
-        "zhCN": "费利特之爪"
+        "zhCN": "费里特的爪子"
     },
     {
         "id": 51180,
         "Key": "Turtle's Shell",
         "enUS": "Turtle's Shell",
-        "zhTW": "龜殼",
+        "zhTW": "龟壳",
         "deDE": "Schildkrötenpanzer",
         "esES": "Caparazón de tortuga",
         "frFR": "Écaille de tortue",
@@ -46192,7 +46192,7 @@
         "id": 51181,
         "Key": "Wolf Pelt",
         "enUS": "Wolf Pelt",
-        "zhTW": "野狼獸皮",
+        "zhTW": "狼皮",
         "deDE": "Wolfspelz",
         "esES": "Piel de lobo",
         "frFR": "Peau de loup",
@@ -46203,13 +46203,13 @@
         "jaJP": "ウルフ・フェルト",
         "ptBR": "Couro de Lobo",
         "ruRU": "Волчья шкура",
-        "zhCN": "野狼兽皮"
+        "zhCN": "狼皮"
     },
     {
         "id": 51182,
         "Key": "Beast Collar",
         "enUS": "Beast Collar",
-        "zhTW": "猛獸項圈",
+        "zhTW": "野兽项圈",
         "deDE": "Biest-Halsband",
         "esES": "Collar Bestia",
         "frFR": "Collier de bête",
@@ -46220,13 +46220,13 @@
         "jaJP": "ビースト・カラー",
         "ptBR": "Coleira de Fera",
         "ruRU": "Звериный ошейник",
-        "zhCN": "猛兽项圈"
+        "zhCN": "野兽项圈"
     },
     {
         "id": 51183,
         "Key": "Snowmane's Jewelry",
         "enUS": "Snowmane's Jewelry",
-        "zhTW": "斯羅曼尼的首飾盒",
+        "zhTW": "雪人珠宝",
         "deDE": "Snowmane's Schmuck",
         "esES": "Joyería Snowmane",
         "frFR": "Les bijoux de Snowmane",
@@ -46237,13 +46237,13 @@
         "jaJP": "スノーマンズ・ジュエリー",
         "ptBR": "Joias de Boneco de Neve",
         "ruRU": "Украшения Сноумена",
-        "zhCN": "斯罗曼尼的首饰盒"
+        "zhCN": "雪人珠宝"
     },
     {
         "id": 51184,
         "Key": "Jeweled Circlet",
         "enUS": "Jeweled Circlet",
-        "zhTW": "珠玉頭環",
+        "zhTW": "宝石圆环",
         "deDE": "Juwelenring",
         "esES": "Collar enjoyado",
         "frFR": "Circulez avec des bijoux",
@@ -46254,13 +46254,13 @@
         "jaJP": "ジュエルド・サークレット",
         "ptBR": "Tiara de Joias",
         "ruRU": "Циркуль с драгоценными камнями",
-        "zhCN": "珠玉头环"
+        "zhCN": "宝石圆环"
     },
     {
         "id": 51185,
         "Key": "Jeweled Belt",
         "enUS": "Jeweled Belt",
-        "zhTW": "寶石腰帶",
+        "zhTW": "珠宝腰带",
         "deDE": "Gürtel mit Juwelen",
         "esES": "Cinturón joya",
         "frFR": "Ceinture ornée de bijoux",
@@ -46271,13 +46271,13 @@
         "jaJP": "宝石付きベルト",
         "ptBR": "Cinto de Joias",
         "ruRU": "Пояс с драгоценными камнями",
-        "zhCN": "宝石腰带"
+        "zhCN": "珠宝腰带"
     },
     {
         "id": 51186,
         "Key": "Ruby Ring",
         "enUS": "Ruby Ring",
-        "zhTW": "紅寶指環",
+        "zhTW": "红宝石戒指",
         "deDE": "Rubin-Ring",
         "esES": "Anillo de rubí",
         "frFR": "Anneau de rubis",
@@ -46288,13 +46288,13 @@
         "jaJP": "ルビーの指輪",
         "ptBR": "Anel de Rubi",
         "ruRU": "Кольцо с рубином",
-        "zhCN": "红宝指环"
+        "zhCN": "红宝石戒指"
     },
     {
         "id": 51187,
         "Key": "Diamond Necklace",
         "enUS": "Diamond Necklace",
-        "zhTW": "鑽石項鏈",
+        "zhTW": "钻石项链",
         "deDE": "Diamant-Halskette",
         "esES": "Collar de diamantes",
         "frFR": "Collier de diamants",
@@ -46311,7 +46311,7 @@
         "id": 51188,
         "Key": "Four Seasons",
         "enUS": "Four Seasons",
-        "zhTW": "四季",
+        "zhTW": "四季酒店",
         "deDE": "Vier Jahreszeiten",
         "esES": "Cuatro estaciones",
         "frFR": "Quatre saisons",
@@ -46322,13 +46322,13 @@
         "jaJP": "四季",
         "ptBR": "Quatro Estações",
         "ruRU": "Четыре сезона",
-        "zhCN": "四季"
+        "zhCN": "四季酒店"
     },
     {
         "id": 51189,
         "Key": "Winter's Heart",
         "enUS": "Winter's Heart",
-        "zhTW": "凜冬之心",
+        "zhTW": "冬日之心",
         "deDE": "Das Herz des Winters",
         "esES": "Corazón de invierno",
         "frFR": "Le cœur de l'hiver",
@@ -46339,13 +46339,13 @@
         "jaJP": "冬の心",
         "ptBR": "Coração Invernal",
         "ruRU": "Сердце зимы",
-        "zhCN": "凜冬之心"
+        "zhCN": "冬日之心"
     },
     {
         "id": 51190,
         "Key": "Spring Dawning",
         "enUS": "Spring Dawning",
-        "zhTW": "早春破曉",
+        "zhTW": "春晓",
         "deDE": "Frühlingserwachen",
         "esES": "Amanecer de primavera",
         "frFR": "L'aube du printemps",
@@ -46356,13 +46356,13 @@
         "jaJP": "春の夜明け",
         "ptBR": "Amanhecer da Primavera",
         "ruRU": "Весенний рассвет",
-        "zhCN": "早春破晓"
+        "zhCN": "春晓"
     },
     {
         "id": 51191,
         "Key": "Summer Flame",
         "enUS": "Summer Flame",
-        "zhTW": "盛夏之焰",
+        "zhTW": "夏日火焰",
         "deDE": "Summer Flame",
         "esES": "Llama de verano",
         "frFR": "Flamme d'été",
@@ -46373,13 +46373,13 @@
         "jaJP": "夏の炎",
         "ptBR": "Queimar do Verão",
         "ruRU": "Летнее пламя",
-        "zhCN": "盛夏之焰"
+        "zhCN": "夏日火焰"
     },
     {
         "id": 51192,
         "Key": "Autumn's Decay",
         "enUS": "Autumn's Decay",
-        "zhTW": "晚秋之朽",
+        "zhTW": "秋天的衰败",
         "deDE": "Herbstverfall",
         "esES": "Decadencia otoñal",
         "frFR": "La décadence de l'automne",
@@ -46390,13 +46390,13 @@
         "jaJP": "秋の衰退",
         "ptBR": "Decadência do Outono",
         "ruRU": "Осенний упадок",
-        "zhCN": "晚秋之朽"
+        "zhCN": "秋天的衰败"
     },
     {
         "id": 51193,
         "Key": "Forgotten Treasures",
         "enUS": "Forgotten Treasures",
-        "zhTW": "被遺忘的寶藏",
+        "zhTW": "被遗忘的宝藏",
         "deDE": "Vergessene Schätze",
         "esES": "Tesoros olvidados",
         "frFR": "Trésors oubliés",
@@ -46413,7 +46413,7 @@
         "id": 51194,
         "Key": "Fernandez' Plate",
         "enUS": "Fernandez' Plate",
-        "zhTW": "費爾南德斯的板甲",
+        "zhTW": "费尔南德斯餐盘",
         "deDE": "Fernandez' Plate",
         "esES": "Plato de Fernández",
         "frFR": "Plaque Fernandez",
@@ -46424,7 +46424,7 @@
         "jaJP": "フェルナンデスのプレート",
         "ptBR": "Armadura de Fernandez",
         "ruRU": "Тарелка Фернандеса",
-        "zhCN": "费尔南德斯的板甲"
+        "zhCN": "费尔南德斯餐盘"
     },
     {
         "id": 51195,
@@ -46447,7 +46447,7 @@
         "id": 51196,
         "Key": "Luther's Cord",
         "enUS": "Luther's Cord",
-        "zhTW": "盧瑟的腰繩",
+        "zhTW": "路德的绳索",
         "deDE": "Luthers Kordel",
         "esES": "Cordón de Lutero",
         "frFR": "La corde de Luther",
@@ -46458,13 +46458,13 @@
         "jaJP": "ルターの紐",
         "ptBR": "Cordão de Lutero",
         "ruRU": "Шнур Лютера",
-        "zhCN": "卢瑟的束带"
+        "zhCN": "路德的绳索"
     },
     {
         "id": 51197,
         "Key": "Janis' Gloves",
         "enUS": "Janis' Gloves",
-        "zhTW": "傑尼斯的手套",
+        "zhTW": "杰尼斯的手套",
         "deDE": "Janis' Handschuhe",
         "esES": "Guantes de Janis",
         "frFR": "Gants de Janis",
@@ -46481,7 +46481,7 @@
         "id": 51198,
         "Key": "Xavier's Greaves",
         "enUS": "Xavier's Greaves",
-        "zhTW": "謝維爾的護脛",
+        "zhTW": "泽维尔的格列夫",
         "deDE": "Xaviers Beinschienen",
         "esES": "Grebas de Xavier",
         "frFR": "Xavier's Greaves",
@@ -46492,13 +46492,13 @@
         "jaJP": "ザビエル・グリーブス",
         "ptBR": "Caneleira de Xavier",
         "ruRU": "Гривы Ксавьера",
-        "zhCN": "谢维尔的护胫"
+        "zhCN": "泽维尔的格列夫"
     },
     {
         "id": 51199,
         "Key": "Quincy's Shield",
         "enUS": "Quincy's Shield",
-        "zhTW": "昆西的刺盾",
+        "zhTW": "昆西之盾",
         "deDE": "Quincy-Schild",
         "esES": "Escudo de Quincy",
         "frFR": "Bouclier de Quincy",
@@ -46509,13 +46509,13 @@
         "jaJP": "クインシーの盾",
         "ptBR": "Escudo de Quincy",
         "ruRU": "Щит Квинси",
-        "zhCN": "昆西的刺盾"
+        "zhCN": "昆西之盾"
     },
     {
         "id": 51200,
         "Key": "Insight of Brother Laz",
         "enUS": "Insight of Brother Laz",
-        "zhTW": "拉兹兄弟的洞察",
+        "zhTW": "拉兹兄弟的洞察力",
         "deDE": "Einsicht von Bruder Laz",
         "esES": "Visión del Hermano Laz",
         "frFR": "Aperçu de Frère Laz",
@@ -46526,7 +46526,7 @@
         "jaJP": "ブラザー・ラズの洞察",
         "ptBR": "Visão do Irmão Laz",
         "ruRU": "Озарение брата Лаза",
-        "zhCN": "拉兹兄弟的洞察"
+        "zhCN": "拉兹兄弟的洞察力"
     },
     {
         "id": 51201,
@@ -46549,7 +46549,7 @@
         "id": 51202,
         "Key": "Prayer of Brother Laz",
         "enUS": "Prayer of Brother Laz",
-        "zhTW": "拉兹兄弟的禱告",
+        "zhTW": "拉兹弟兄的祷告",
         "deDE": "Gebet von Bruder Laz",
         "esES": "Oración del Hermano Laz",
         "frFR": "Prière de Frère Laz",
@@ -46560,13 +46560,13 @@
         "jaJP": "ブラザー・ラズの祈り",
         "ptBR": "Poder do Irmão Laz",
         "ruRU": "Молитва брата Лаза",
-        "zhCN": "拉兹兄弟的祷告"
+        "zhCN": "拉兹弟兄的祷告"
     },
     {
         "id": 51203,
         "Key": "Brother Laz' Holy Symbol",
         "enUS": "Brother Laz' Holy Symbol",
-        "zhTW": "拉兹兄弟的聖物",
+        "zhTW": "拉兹修士的圣物",
         "deDE": "Bruder Laz' Heiliges Symbol",
         "esES": "Símbolo sagrado del Hermano Laz",
         "frFR": "Le symbole sacré de Frère Laz",
@@ -46577,13 +46577,13 @@
         "jaJP": "ブラザー・ラズの聖なるシンボル",
         "ptBR": "Símbolo Sagrado do Irmão Laz",
         "ruRU": "Священный символ брата Лаза",
-        "zhCN": "拉兹兄弟的圣物"
+        "zhCN": "拉兹修士的圣物"
     },
     {
         "id": 51204,
         "Key": "Wrath of Brother Laz",
         "enUS": "Wrath of Brother Laz",
-        "zhTW": "拉兹兄弟的怒火",
+        "zhTW": "拉兹兄弟之怒",
         "deDE": "Der Zorn von Bruder Laz",
         "esES": "La ira del hermano Laz",
         "frFR": "La colère de Frère Laz",
@@ -46594,13 +46594,13 @@
         "jaJP": "ブラザー・ラズの怒り",
         "ptBR": "Ira do Irmão Laz",
         "ruRU": "Гнев брата Лаза",
-        "zhCN": "拉兹兄弟的怒火"
+        "zhCN": "拉兹兄弟之怒"
     },
     {
         "id": 51205,
         "Key": "Brother Laz' Faith",
         "enUS": "Brother Laz' Faith",
-        "zhTW": "拉兹兄弟的信仰",
+        "zhTW": "拉兹修士的信仰",
         "deDE": "Bruder Laz' Glaube",
         "esES": "La fe del hermano Laz",
         "frFR": "La foi de frère Laz",
@@ -46611,13 +46611,13 @@
         "jaJP": "ブラザー・ラズの信仰",
         "ptBR": "Irmão Laz 'Faith",
         "ruRU": "Вера брата Лаза",
-        "zhCN": "拉兹兄弟的信仰"
+        "zhCN": "拉兹修士的信仰"
     },
     {
         "id": 51206,
         "Key": "Hades' Underworld",
         "enUS": "Hades' Underworld",
-        "zhTW": "黑帝斯的地下世界",
+        "zhTW": "哈迪斯的地下世界",
         "deDE": "Hades' Unterwelt",
         "esES": "Inframundo de Hades",
         "frFR": "Le monde souterrain d'Hadès",
@@ -46628,13 +46628,13 @@
         "jaJP": "黄泉の冥府",
         "ptBR": "Submundo de Hades",
         "ruRU": "Подземный мир Аида",
-        "zhCN": "冥王的地下世界"
+        "zhCN": "哈迪斯的地下世界"
     },
     {
         "id": 51207,
         "Key": "Afterlife",
         "enUS": "Afterlife",
-        "zhTW": "轉生",
+        "zhTW": "来世",
         "deDE": "Leben nach dem Tod",
         "esES": "Vida después de la muerte",
         "frFR": "La vie après la mort",
@@ -46645,13 +46645,13 @@
         "jaJP": "死後の世界",
         "ptBR": "Vida Após a Morte",
         "ruRU": "Загробная жизнь",
-        "zhCN": "转生"
+        "zhCN": "来世"
     },
     {
         "id": 51208,
         "Key": "Dracolich",
         "enUS": "Dracolich",
-        "zhTW": "龍巫妖",
+        "zhTW": "Dracolich",
         "deDE": "Dracolich",
         "esES": "Dracolich",
         "frFR": "Dracolich",
@@ -46662,13 +46662,13 @@
         "jaJP": "ドラコリッチ",
         "ptBR": "Dragão Zumbi Lich",
         "ruRU": "Драколич",
-        "zhCN": "龙巫妖"
+        "zhCN": "Dracolich"
     },
     {
         "id": 51209,
         "Key": "Vampire's Crusade",
         "enUS": "Vampire's Crusade",
-        "zhTW": "吸血鬼的聖教軍",
+        "zhTW": "吸血鬼的十字军东征",
         "deDE": "Der Kreuzzug der Vampire",
         "esES": "La Cruzada de los Vampiros",
         "frFR": "Croisade des vampires",
@@ -46679,13 +46679,13 @@
         "jaJP": "ヴァンパイアの聖戦",
         "ptBR": "Cruzada de Vampiros",
         "ruRU": "Крестовый поход вампира",
-        "zhCN": "吸血鬼的十字军"
+        "zhCN": "吸血鬼的十字军东征"
     },
     {
         "id": 51210,
         "Key": "The River Stix",
         "enUS": "The River Stix",
-        "zhTW": "斯蒂克斯之河",
+        "zhTW": "斯蒂克斯河",
         "deDE": "Der Fluss Stix",
         "esES": "El río Stix",
         "frFR": "Les Stix de la rivière",
@@ -46696,13 +46696,13 @@
         "jaJP": "リバー・スティックス",
         "ptBR": "O Rio Styx",
         "ruRU": "Река Стикс",
-        "zhCN": "斯蒂克斯之河"
+        "zhCN": "斯蒂克斯河"
     },
     {
         "id": 51211,
         "Key": "Lord Hades' Throne",
         "enUS": "Lord Hades' Throne",
-        "zhTW": "黑帝斯王座",
+        "zhTW": "哈迪斯王座",
         "deDE": "Der Thron des Herrn Hades",
         "esES": "Trono de Lord Hades",
         "frFR": "Le trône du seigneur Hadès",
@@ -46713,13 +46713,13 @@
         "jaJP": "ロード・ハデスの玉座",
         "ptBR": "Trono do Lorde Hades",
         "ruRU": "Трон владыки Аида",
-        "zhCN": "冥王王座"
+        "zhCN": "哈迪斯王座"
     },
     {
         "id": 51212,
         "Key": "Darque's Cabal",
         "enUS": "Darque's Cabal",
-        "zhTW": "達爾凱的陰謀",
+        "zhTW": "达尔克阴谋集团",
         "deDE": "Darque-Kabale",
         "esES": "La Cábala de Darque",
         "frFR": "Cabale de Darque",
@@ -46730,13 +46730,13 @@
         "jaJP": "ダルクの陰謀",
         "ptBR": "Cabala de Darque",
         "ruRU": "Общество Дарка",
-        "zhCN": "达尔凯的阴谋"
+        "zhCN": "达尔克阴谋集团"
     },
     {
         "id": 51213,
         "Key": "Secret Society",
         "enUS": "Secret Society",
-        "zhTW": "祕社",
+        "zhTW": "秘社",
         "deDE": "Geheimgesellschaft",
         "esES": "Sociedad secreta",
         "frFR": "Société secrète",
@@ -46753,7 +46753,7 @@
         "id": 51214,
         "Key": "Fallen Angels",
         "enUS": "Fallen Angels",
-        "zhTW": "墮落天使",
+        "zhTW": "堕落天使",
         "deDE": "Fallen Angels",
         "esES": "Ángeles caídos",
         "frFR": "Fallen Angels",
@@ -46770,7 +46770,7 @@
         "id": 51215,
         "Key": "Savant Fury",
         "enUS": "Savant Fury",
-        "zhTW": "學者之怒",
+        "zhTW": "Savant Fury",
         "deDE": "Savant Fury",
         "esES": "Furia Savant",
         "frFR": "Savant Fury",
@@ -46781,13 +46781,13 @@
         "jaJP": "サヴァン・フューリー",
         "ptBR": "Sábio Furioso",
         "ruRU": "Ярость Саванта",
-        "zhCN": "学者之怒"
+        "zhCN": "Savant Fury"
     },
     {
         "id": 51216,
         "Key": "Dawn's Blessing",
         "enUS": "Dawn's Blessing",
-        "zhTW": "黎明祝福",
+        "zhTW": "黎明的祝福",
         "deDE": "Der Segen der Morgenröte",
         "esES": "Bendición del Amanecer",
         "frFR": "La bénédiction de l'aube",
@@ -46798,13 +46798,13 @@
         "jaJP": "夜明けの祝福",
         "ptBR": "Bênção do Amanhecer",
         "ruRU": "Благословение рассвета",
-        "zhCN": "黎明祝福"
+        "zhCN": "黎明的祝福"
     },
     {
         "id": 51217,
         "Key": "Red Havoc's Challenge",
         "enUS": "Red Havoc's Challenge",
-        "zhTW": "赤劫之挑戰",
+        "zhTW": "红色浩劫的挑战",
         "deDE": "Red Havocs Herausforderung",
         "esES": "Desafío de Red Havoc",
         "frFR": "Le défi de Red Havoc",
@@ -46815,13 +46815,13 @@
         "jaJP": "レッド・ハボックの挑戦",
         "ptBR": "Desafio Destruidor Vermelho",
         "ruRU": "Вызов Красного Хавока",
-        "zhCN": "赤劫之挑战"
+        "zhCN": "红色浩劫的挑战"
     },
     {
         "id": 51218,
         "Key": "Cry of the Wolf",
         "enUS": "Cry of the Wolf",
-        "zhTW": "惡狼之嚎",
+        "zhTW": "狼来了",
         "deDE": "Der Schrei des Wolfes",
         "esES": "Grito de lobo",
         "frFR": "Le cri du loup",
@@ -46832,13 +46832,13 @@
         "jaJP": "クライ・オブ・ザ・ウルフ",
         "ptBR": "Grito do Lobo",
         "ruRU": "Крик волка",
-        "zhCN": "恶狼之嚎"
+        "zhCN": "狼来了"
     },
     {
         "id": 51219,
         "Key": "Full Moon Frenzy",
         "enUS": "Full Moon Frenzy",
-        "zhTW": "滿月狂潮",
+        "zhTW": "满月狂潮",
         "deDE": "Vollmond-Raserei",
         "esES": "Frenesí de luna llena",
         "frFR": "La frénésie de la pleine lune",
@@ -46855,7 +46855,7 @@
         "id": 51220,
         "Key": "Torment of Innocence",
         "enUS": "Torment of Innocence",
-        "zhTW": "無辜之折磨",
+        "zhTW": "纯真的折磨",
         "deDE": "Die Qual der Unschuld",
         "esES": "Tormento de inocencia",
         "frFR": "Le tourment de l'innocence",
@@ -46866,13 +46866,13 @@
         "jaJP": "イノセンスの苦悩",
         "ptBR": "Tormento da Inocência",
         "ruRU": "Муки невинности",
-        "zhCN": "无辜之折磨"
+        "zhCN": "纯真的折磨"
     },
     {
         "id": 51221,
         "Key": "Drawing Out the Beast",
         "enUS": "Drawing Out the Beast",
-        "zhTW": "獸引腰帶",
+        "zhTW": "引出野兽",
         "deDE": "Die Bestie hervorlocken",
         "esES": "Sacar a la bestia",
         "frFR": "Faire sortir la bête",
@@ -46883,13 +46883,13 @@
         "jaJP": "野獣を引き出す",
         "ptBR": "Tirando a Besta",
         "ruRU": "Вытаскивание зверя",
-        "zhCN": "兽引腰带"
+        "zhCN": "引出野兽"
     },
     {
         "id": 51222,
         "Key": "Mishy's Avatar",
         "enUS": "Mishy's Avatar",
-        "zhTW": "米希的化身",
+        "zhTW": "米希的头像",
         "deDE": "Mishys Avatar",
         "esES": "Avatar de Mishy",
         "frFR": "Avatar de Mishy",
@@ -46900,13 +46900,13 @@
         "jaJP": "ミッシーのアバター",
         "ptBR": "Avatar de Mishy",
         "ruRU": "Аватар Миши",
-        "zhCN": "米希的化身"
+        "zhCN": "米希的头像"
     },
     {
         "id": 51223,
         "Key": "Elven Grace",
         "enUS": "Elven Grace",
-        "zhTW": "精靈之優雅",
+        "zhTW": "精灵恩典",
         "deDE": "Elfenhafte Anmut",
         "esES": "Gracia élfica",
         "frFR": "Grâce elfique",
@@ -46917,13 +46917,13 @@
         "jaJP": "エルヴン・グレイス",
         "ptBR": "Graça Élfico",
         "ruRU": "Эльфийская грация",
-        "zhCN": "精灵之优雅"
+        "zhCN": "精灵恩典"
     },
     {
         "id": 51224,
         "Key": "Woodland Protector",
         "enUS": "Woodland Protector",
-        "zhTW": "林地守護者",
+        "zhTW": "林地保护者",
         "deDE": "Woodland Protector",
         "esES": "Protector del bosque",
         "frFR": "Protecteur des bois",
@@ -46934,13 +46934,13 @@
         "jaJP": "ウッドランド・プロテクター",
         "ptBR": "Protetor de Terreno Madeirado",
         "ruRU": "Защитник леса",
-        "zhCN": "林地守护者"
+        "zhCN": "林地保护者"
     },
     {
         "id": 51225,
         "Key": "Silent Whisper",
         "enUS": "Silent Whisper",
-        "zhTW": "無聲低語",
+        "zhTW": "无声低语",
         "deDE": "Leises Flüstern",
         "esES": "Susurro silencioso",
         "frFR": "Chuchotement silencieux",
@@ -46957,7 +46957,7 @@
         "id": 51226,
         "Key": "Warder's Bond",
         "enUS": "Warder's Bond",
-        "zhTW": "獄吏的鐐銬",
+        "zhTW": "看守债券",
         "deDE": "Bürgschaft eines Wärters",
         "esES": "Vínculo del guardián",
         "frFR": "Obligation du gardien",
@@ -46968,7 +46968,7 @@
         "jaJP": "ウォーダーの絆",
         "ptBR": "Vínculo do Guardião",
         "ruRU": "Узы стражника",
-        "zhCN": "狱吏的镣铐"
+        "zhCN": "看守债券"
     },
     {
         "id": 51227,
@@ -46991,7 +46991,7 @@
         "id": 51228,
         "Key": "Trent's Caster",
         "enUS": "Trent's Caster",
-        "zhTW": "特倫特的強弓",
+        "zhTW": "特伦特脚轮",
         "deDE": "Trent's Streuer",
         "esES": "Caster de Trent",
         "frFR": "Caster de Trent",
@@ -47002,13 +47002,13 @@
         "jaJP": "トレントのキャスター",
         "ptBR": "Arremessador Trento",
         "ruRU": "Кастер Трента",
-        "zhCN": "特伦特的强弓"
+        "zhCN": "特伦特脚轮"
     },
     {
         "id": 51229,
         "Key": "Joel's Sanctuary",
         "enUS": "Joel's Sanctuary",
-        "zhTW": "喬爾的聖堂",
+        "zhTW": "乔尔的圣所",
         "deDE": "Joel's Heiligtum",
         "esES": "Santuario de Joel",
         "frFR": "Le sanctuaire de Joel",
@@ -47019,13 +47019,13 @@
         "jaJP": "ジョエルの聖域",
         "ptBR": "Santuário de Joel",
         "ruRU": "Убежище Джоэла",
-        "zhCN": "乔尔的圣堂"
+        "zhCN": "乔尔的圣所"
     },
     {
         "id": 51230,
         "Key": "Eye of the Trent",
         "enUS": "Eye of the Trent",
-        "zhTW": "特倫特之眼",
+        "zhTW": "特伦特之眼",
         "deDE": "Das Auge des Trent",
         "esES": "El ojo de Trento",
         "frFR": "L'œil du Trent",
@@ -47042,7 +47042,7 @@
         "id": 51231,
         "Key": "Power of Fire",
         "enUS": "Power of Fire",
-        "zhTW": "烈火之力",
+        "zhTW": "火的力量",
         "deDE": "Die Macht des Feuers",
         "esES": "El poder del fuego",
         "frFR": "Le pouvoir du feu",
@@ -47053,13 +47053,13 @@
         "jaJP": "火の力",
         "ptBR": "Poder do Fogo",
         "ruRU": "Сила огня",
-        "zhCN": "烈火之力"
+        "zhCN": "火的力量"
     },
     {
         "id": 51232,
         "Key": "Power of Ice",
         "enUS": "Power of Ice",
-        "zhTW": "寒冰之力",
+        "zhTW": "冰的力量",
         "deDE": "Die Macht des Eises",
         "esES": "El poder del hielo",
         "frFR": "Le pouvoir de la glace",
@@ -47070,13 +47070,13 @@
         "jaJP": "氷の力",
         "ptBR": "Poder do Gelo",
         "ruRU": "Сила льда",
-        "zhCN": "寒冰之力"
+        "zhCN": "冰的力量"
     },
     {
         "id": 51233,
         "Key": "Power of Lightning",
         "enUS": "Power of Lightning",
-        "zhTW": "閃電之力",
+        "zhTW": "闪电的力量",
         "deDE": "Macht der Blitze",
         "esES": "El poder del rayo",
         "frFR": "Le pouvoir de la foudre",
@@ -47087,13 +47087,13 @@
         "jaJP": "稲妻の力",
         "ptBR": "Poder do Relâmpago",
         "ruRU": "Сила молнии",
-        "zhCN": "闪电之力"
+        "zhCN": "闪电的力量"
     },
     {
         "id": 51234,
         "Key": "JBouley's Scion",
         "enUS": "JBouley's Scion",
-        "zhTW": "傑布雷的子嗣",
+        "zhTW": "JBouley's Scion",
         "deDE": "JBouleys Nachkomme",
         "esES": "Scion de JBouley",
         "frFR": "La Scion de JBouley",
@@ -47104,13 +47104,13 @@
         "jaJP": "JBouleyのサイオン",
         "ptBR": "Enxerto JBouley",
         "ruRU": "JBouley's Scion",
-        "zhCN": "杰布雷的子嗣"
+        "zhCN": "JBouley's Scion"
     },
     {
         "id": 51235,
         "Key": "Shadow Ninja",
         "enUS": "Shadow Ninja",
-        "zhTW": "暗影忍者",
+        "zhTW": "影子忍者",
         "deDE": "Schatten-Ninja",
         "esES": "Ninja en la sombra",
         "frFR": "Ninja de l'ombre",
@@ -47121,13 +47121,13 @@
         "jaJP": "シャドウ・ニンジャ",
         "ptBR": "Ninja Fantasma",
         "ruRU": "Теневой ниндзя",
-        "zhCN": "暗影忍者"
+        "zhCN": "影子忍者"
     },
     {
         "id": 51236,
         "Key": "Night's Caress",
         "enUS": "Night's Caress",
-        "zhTW": "暮風酥撫",
+        "zhTW": "夜晚的爱抚",
         "deDE": "Die Liebkosung der Nacht",
         "esES": "Caricia nocturna",
         "frFR": "La caresse de la nuit",
@@ -47138,7 +47138,7 @@
         "jaJP": "夜の愛撫",
         "ptBR": "Carícia da Noite",
         "ruRU": "Ночная ласка",
-        "zhCN": "暮风酥抚"
+        "zhCN": "夜晚的爱抚"
     },
     {
         "id": 51237,
@@ -47161,7 +47161,7 @@
         "id": 51238,
         "Key": "Fade to Black",
         "enUS": "Fade to Black",
-        "zhTW": "隱於墨黑",
+        "zhTW": "褪去黑色",
         "deDE": "Fade to Black",
         "esES": "Fundido a negro",
         "frFR": "Fondu au noir",
@@ -47172,13 +47172,13 @@
         "jaJP": "フェード・トゥ・ブラック",
         "ptBR": "Escurecer",
         "ruRU": "Оттенок черного",
-        "zhCN": "隐于墨黑"
+        "zhCN": "褪去黑色"
     },
     {
         "id": 51239,
         "Key": "Forsaken Divinity",
         "enUS": "Forsaken Divinity",
-        "zhTW": "被遺忘的神性",
+        "zhTW": "被遗忘的神性",
         "deDE": "Verlassene Göttlichkeit",
         "esES": "Divinidad Abandonada",
         "frFR": "Divinité abandonnée",
@@ -47195,7 +47195,7 @@
         "id": 51240,
         "Key": "Fall From Grace",
         "enUS": "Fall From Grace",
-        "zhTW": "失卻天恩",
+        "zhTW": "从优雅中坠落",
         "deDE": "Gnadenloser Fall",
         "esES": "Caída en desgracia",
         "frFR": "La chute de la grâce",
@@ -47206,13 +47206,13 @@
         "jaJP": "恩寵からの転落",
         "ptBR": "Cair da Graça",
         "ruRU": "Падение из благодати",
-        "zhCN": "失却天恩"
+        "zhCN": "从优雅中坠落"
     },
     {
         "id": 51241,
         "Key": "Tyrial's Grief",
         "enUS": "Tyrial's Grief",
-        "zhTW": "泰瑞爾的悲傷",
+        "zhTW": "泰里尔的悲伤",
         "deDE": "Tyrias Trauer",
         "esES": "El dolor de Tyrial",
         "frFR": "Le deuil de Tyrial",
@@ -47223,13 +47223,13 @@
         "jaJP": "ティリアルの悲しみ",
         "ptBR": "Dor de Tyrial",
         "ruRU": "Горе Тириала",
-        "zhCN": "泰瑞尔的悲伤"
+        "zhCN": "泰里尔的悲伤"
     },
     {
         "id": 51242,
         "Key": "Redemption Denied",
         "enUS": "Redemption Denied",
-        "zhTW": "天贖不允",
+        "zhTW": "拒绝救赎",
         "deDE": "Erlösung verweigert",
         "esES": "Redención denegada",
         "frFR": "Rachat refusé",
@@ -47240,13 +47240,13 @@
         "jaJP": "拒否された救済",
         "ptBR": "Resgate Negado",
         "ruRU": "Искупление отклонено",
-        "zhCN": "天赎不允"
+        "zhCN": "拒绝救赎"
     },
     {
         "id": 51243,
         "Key": "Hell's Embrace",
         "enUS": "Hell's Embrace",
-        "zhTW": "地獄的擁抱",
+        "zhTW": "地狱的拥抱",
         "deDE": "Die Umarmung der Hölle",
         "esES": "El abrazo del infierno",
         "frFR": "L'étreinte de l'enfer",
@@ -47263,7 +47263,7 @@
         "id": 51244,
         "Key": "Volf's Undead Legion",
         "enUS": "Volf's Undead Legion",
-        "zhTW": "沃爾夫的亡靈軍團",
+        "zhTW": "沃尔夫的亡灵军团",
         "deDE": "Volfs Untote Legion",
         "esES": "Legión de muertos vivientes de Volf",
         "frFR": "La légion des morts-vivants de Volf",
@@ -47280,7 +47280,7 @@
         "id": 51245,
         "Key": "Spectral Knight's Unholy Shield",
         "enUS": "Spectral Knight's Unholy Shield",
-        "zhTW": "幽靈騎士的邪惡之盾",
+        "zhTW": "幽灵骑士的邪恶之盾",
         "deDE": "Der unheilige Schild des Spektralritters",
         "esES": "Escudo impío del Caballero Espectral",
         "frFR": "Bouclier impie du chevalier spectral",
@@ -47297,7 +47297,7 @@
         "id": 51246,
         "Key": "Death Knight's Demon Blade",
         "enUS": "Death Knight's Demon Blade",
-        "zhTW": "死亡騎士的惡魔之刃",
+        "zhTW": "死亡骑士的恶魔之刃",
         "deDE": "Die Dämonenklinge des Todesritters",
         "esES": "Hoja demoníaca del Caballero de la Muerte",
         "frFR": "Lame démoniaque du chevalier de la mort",
@@ -47314,7 +47314,7 @@
         "id": 51247,
         "Key": "Lich's Cranium",
         "enUS": "Lich's Cranium",
-        "zhTW": "巫妖的邪惡顱骨",
+        "zhTW": "利奇的头盖骨",
         "deDE": "Lichs Schädel",
         "esES": "Cráneo del Lich",
         "frFR": "Crâne de liche",
@@ -47325,13 +47325,13 @@
         "jaJP": "リヒトの頭蓋",
         "ptBR": "Crânio de Lich",
         "ruRU": "Череп лича",
-        "zhCN": "巫妖的邪恶颅骨"
+        "zhCN": "利奇的头盖骨"
     },
     {
         "id": 51248,
         "Key": "Skeleton Warrior's Corpse Plate",
         "enUS": "Skeleton Warrior's Corpse Plate",
-        "zhTW": "骷髏戰士的尸骨板甲",
+        "zhTW": "骷髅战士的尸骨板",
         "deDE": "Leichenplatte des Skelettkriegers",
         "esES": "Placa de cadáver de guerrero esqueleto",
         "frFR": "Plaque du cadavre du guerrier squelette",
@@ -47342,13 +47342,13 @@
         "jaJP": "スケルトン戦士の死体プレート",
         "ptBR": "Armadura do Esqueleto Guerreiro Cadáver",
         "ruRU": "Пластина трупа скелета-воина",
-        "zhCN": "骷髅战士的尸骨板甲"
+        "zhCN": "骷髅战士的尸骨板"
     },
     {
         "id": 51249,
         "Key": "Legacy of Vashna",
         "enUS": "Legacy of Vashna",
-        "zhTW": "瓦什納的遺產",
+        "zhTW": "瓦什纳的遗产",
         "deDE": "Das Vermächtnis von Vashna",
         "esES": "Legado de Vashna",
         "frFR": "L'héritage de Vashna",
@@ -47365,7 +47365,7 @@
         "id": 51250,
         "Key": "Dagger of Vashna",
         "enUS": "Dagger of Vashna",
-        "zhTW": "瓦什納的匕首",
+        "zhTW": "瓦什纳匕首",
         "deDE": "Dolch von Vashna",
         "esES": "Daga de Vashna",
         "frFR": "Dague de Vashna",
@@ -47376,13 +47376,13 @@
         "jaJP": "ヴァシュナの短剣",
         "ptBR": "Punhal de Vashna",
         "ruRU": "Кинжал Вашны",
-        "zhCN": "瓦什纳的匕首"
+        "zhCN": "瓦什纳匕首"
     },
     {
         "id": 51251,
         "Key": "Mask of Vashna",
         "enUS": "Mask of Vashna",
-        "zhTW": "瓦什納的的面具",
+        "zhTW": "瓦什纳面具",
         "deDE": "Maske von Vashna",
         "esES": "Máscara de Vashna",
         "frFR": "Masque de Vashna",
@@ -47393,13 +47393,13 @@
         "jaJP": "ヴァシュナの仮面",
         "ptBR": "Máscara de Vashna",
         "ruRU": "Маска Вашны",
-        "zhCN": "瓦什纳的面具"
+        "zhCN": "瓦什纳面具"
     },
     {
         "id": 51252,
         "Key": "Robes of Vashna",
         "enUS": "Robes of Vashna",
-        "zhTW": "瓦什納的長袍",
+        "zhTW": "瓦什纳长袍",
         "deDE": "Gewänder von Vashna",
         "esES": "Túnicas de Vashna",
         "frFR": "Robes de Vashna",
@@ -47410,13 +47410,13 @@
         "jaJP": "ヴァシュナのローブ",
         "ptBR": "Manto de Vashna",
         "ruRU": "Одеяния Вашны",
-        "zhCN": "瓦什纳的长袍"
+        "zhCN": "瓦什纳长袍"
     },
     {
         "id": 51253,
         "Key": "Salander's Tirade",
         "enUS": "Salander's Tirade",
-        "zhTW": "薩蘭德的咆哮",
+        "zhTW": "萨兰德的咆哮",
         "deDE": "Salanders Tirade",
         "esES": "La diatriba de Salander",
         "frFR": "La tirade de Salander",
@@ -47433,7 +47433,7 @@
         "id": 51254,
         "Key": "Lancer's Reach",
         "enUS": "Lancer's Reach",
-        "zhTW": "藍瑟之域",
+        "zhTW": "蓝瑟之域",
         "deDE": "Lancer's Reach",
         "esES": "Alcance del Lancer",
         "frFR": "Lancer's Reach",
@@ -47450,7 +47450,7 @@
         "id": 51255,
         "Key": "Salander's Mail",
         "enUS": "Salander's Mail",
-        "zhTW": "薩蘭德之甲",
+        "zhTW": "萨兰德的邮件",
         "deDE": "Salanders Post",
         "esES": "Correo de Salander",
         "frFR": "Le courrier de Salander",
@@ -47461,13 +47461,13 @@
         "jaJP": "サランダーのメール",
         "ptBR": "Correio Salamandra",
         "ruRU": "Почта Саландер",
-        "zhCN": "萨兰德之甲"
+        "zhCN": "萨兰德的邮件"
     },
     {
         "id": 51256,
         "Key": "Salander's Visor",
         "enUS": "Salander's Visor",
-        "zhTW": "薩蘭德的護面",
+        "zhTW": "萨兰德的面罩",
         "deDE": "Salanders Visier",
         "esES": "Visera de Salander",
         "frFR": "Visière de Salander",
@@ -47478,13 +47478,13 @@
         "jaJP": "サランダーのバイザー",
         "ptBR": "Visão Salamandra",
         "ruRU": "Козырек Саландер",
-        "zhCN": "萨兰德的面甲"
+        "zhCN": "萨兰德的面罩"
     },
     {
         "id": 51257,
         "Key": "Jerik's Dragon Armor",
         "enUS": "Jerik's Dragon Armor",
-        "zhTW": "傑里克的巨龍防具",
+        "zhTW": "杰里克的龙铠",
         "deDE": "Jeriks Drachen-Rüstung",
         "esES": "Armadura de dragón de Jerik",
         "frFR": "Armure du dragon de Jerik",
@@ -47495,13 +47495,13 @@
         "jaJP": "ジェリクのドラゴンアーマー",
         "ptBR": "Armadura Dragão de Jerik",
         "ruRU": "Доспехи дракона Джерика",
-        "zhCN": "杰里克的巨龙防具"
+        "zhCN": "杰里克的龙铠"
     },
     {
         "id": 51258,
         "Key": "Red Dragon Scale Mail",
         "enUS": "Red Dragon Scale Mail",
-        "zhTW": "赤龍鱗甲",
+        "zhTW": "红龙鳞甲",
         "deDE": "Red Dragon Scale Mail",
         "esES": "Correo de escamas de dragón rojo",
         "frFR": "Red Dragon Scale Mail",
@@ -47512,13 +47512,13 @@
         "jaJP": "レッド・ドラゴン・スケール・メール",
         "ptBR": "Escama do Dragão Vermelho Correio",
         "ruRU": "Почта чешуи красного дракона",
-        "zhCN": "赤龙鳞甲"
+        "zhCN": "红龙鳞甲"
     },
     {
         "id": 51259,
         "Key": "Black Dragon Hide Shield",
         "enUS": "Black Dragon Hide Shield",
-        "zhTW": "黑龍隱盾",
+        "zhTW": "黑龙皮盾",
         "deDE": "Schild aus schwarzer Drachenhaut",
         "esES": "Escudo de piel de dragón negro",
         "frFR": "Bouclier en peau de dragon noir",
@@ -47529,13 +47529,13 @@
         "jaJP": "ブラック・ドラゴン・ハイド・シールド",
         "ptBR": "Escudo Oculto do Dragão Preto",
         "ruRU": "Щит из шкуры черного дракона",
-        "zhCN": "黑龙隐盾"
+        "zhCN": "黑龙皮盾"
     },
     {
         "id": 51260,
         "Key": "Green Dragon Mask",
         "enUS": "Green Dragon Mask",
-        "zhTW": "青龍面具",
+        "zhTW": "青龙面具",
         "deDE": "Grüne Drachenmaske",
         "esES": "Máscara del Dragón Verde",
         "frFR": "Masque du dragon vert",
@@ -47552,7 +47552,7 @@
         "id": 51261,
         "Key": "Onyx's Primal Rage",
         "enUS": "Onyx's Primal Rage",
-        "zhTW": "黑瑪瑙的原始狂暴",
+        "zhTW": "玛瑙的原始狂暴",
         "deDE": "Onyx' ursprüngliche Wut",
         "esES": "Furia primigenia de Onyx",
         "frFR": "La rage primitive d'Onyx",
@@ -47563,13 +47563,13 @@
         "jaJP": "オニキスのプライマルレイジ",
         "ptBR": "Fúria Primitiva Onyx",
         "ruRU": "Первобытная ярость Оникса",
-        "zhCN": "黑玛瑙的原始狂暴"
+        "zhCN": "玛瑙的原始狂暴"
     },
     {
         "id": 51262,
         "Key": "Onyx's Fallen Star",
         "enUS": "Onyx's Fallen Star",
-        "zhTW": "黑瑪瑙的隕星",
+        "zhTW": "玛瑙陨星",
         "deDE": "Onyx's Fallen Star",
         "esES": "Estrella caída de Onyx",
         "frFR": "L'étoile filante d'Onyx",
@@ -47580,13 +47580,13 @@
         "jaJP": "オニキスの堕ちた星",
         "ptBR": "Estrela Caída Onyx",
         "ruRU": "Падшая звезда Оникса",
-        "zhCN": "黑玛瑙的陨星"
+        "zhCN": "玛瑙陨星"
     },
     {
         "id": 51263,
         "Key": "Onyx's Solar Flair",
         "enUS": "Onyx's Solar Flair",
-        "zhTW": "黑玛瑙的太陽耀斑",
+        "zhTW": "玛瑙的太阳能光彩",
         "deDE": "Onyx' solares Flair",
         "esES": "El toque solar de Onyx",
         "frFR": "Le flair solaire d'Onyx",
@@ -47597,13 +47597,13 @@
         "jaJP": "オニキスのソーラー・フレア",
         "ptBR": "Faro Solar Onyx",
         "ruRU": "Солнечное чутье Оникса",
-        "zhCN": "黑玛瑙的太阳耀斑"
+        "zhCN": "玛瑙的太阳能光彩"
     },
     {
         "id": 51264,
         "Key": "Onyx's Super Nova",
         "enUS": "Onyx's Super Nova",
-        "zhTW": "黑瑪瑙的超新星",
+        "zhTW": "黑玛瑙的超级新星",
         "deDE": "Onyx's Super Nova",
         "esES": "Super Nova de Onyx",
         "frFR": "La Super Nova d'Onyx",
@@ -47614,13 +47614,13 @@
         "jaJP": "オニキスのスーパーノヴァ",
         "ptBR": "Explosão Estelar Onyx",
         "ruRU": "Супер Нова Оникса",
-        "zhCN": "黑玛瑙的超新星"
+        "zhCN": "黑玛瑙的超级新星"
     },
     {
         "id": 51265,
         "Key": "Onyx's Meteor Shower",
         "enUS": "Onyx's Meteor Shower",
-        "zhTW": "黑瑪瑙的流星雨",
+        "zhTW": "玛瑙流星雨",
         "deDE": "Meteoritenschauer von Onyx",
         "esES": "Lluvia de meteoritos de Onyx",
         "frFR": "La pluie de météores d'Onyx",
@@ -47631,13 +47631,13 @@
         "jaJP": "オニキスの流星群",
         "ptBR": "Chuva de Meteoros Onyx",
         "ruRU": "Метеорный поток Оникса",
-        "zhCN": "黑玛瑙的流星雨"
+        "zhCN": "玛瑙流星雨"
     },
     {
         "id": 51266,
         "Key": "Onyx's Celestial Rage",
         "enUS": "Onyx's Celestial Rage",
-        "zhTW": "黑瑪瑙的天體狂暴",
+        "zhTW": "玛瑙的天怒",
         "deDE": "Onyx' himmlischer Zorn",
         "esES": "Furia Celestial de Onyx",
         "frFR": "La rage céleste d'Onyx",
@@ -47648,13 +47648,13 @@
         "jaJP": "オニキスのセレスティアル・レイジ",
         "ptBR": "Fúria Celestial Onyx",
         "ruRU": "Небесная ярость Оникса",
-        "zhCN": "黑玛瑙的天体狂暴"
+        "zhCN": "玛瑙的天怒"
     },
     {
         "id": 51267,
         "Key": "Brother Laz' Calling",
         "enUS": "Brother Laz' Calling",
-        "zhTW": "拉兹兄弟的呼喚",
+        "zhTW": "拉兹兄弟的召唤",
         "deDE": "Bruder Laz' Berufung",
         "esES": "La llamada del Hermano Laz",
         "frFR": "L'appel de Frère Laz",
@@ -47665,13 +47665,13 @@
         "jaJP": "ブラザー・ラズの呼びかけ",
         "ptBR": "Irmão Laz Chamando",
         "ruRU": "Призвание брата Лаза",
-        "zhCN": "拉兹兄弟的呼唤"
+        "zhCN": "拉兹兄弟的召唤"
     },
     {
         "id": 51268,
         "Key": "Teachings of Brother Laz",
         "enUS": "Teachings of Brother Laz",
-        "zhTW": "拉兹兄弟的教诲",
+        "zhTW": "拉兹教友的教诲",
         "deDE": "Die Lehren von Bruder Laz",
         "esES": "Enseñanzas del Hermano Laz",
         "frFR": "Enseignements de Frère Laz",
@@ -47682,13 +47682,13 @@
         "jaJP": "ブラザー・ラズの教え",
         "ptBR": "Ensinamentos do Irmão Laz",
         "ruRU": "Учения брата Лаза",
-        "zhCN": "拉兹兄弟的教诲"
+        "zhCN": "拉兹教友的教诲"
     },
     {
         "id": 51269,
         "Key": "Holy Aura",
         "enUS": "Holy Aura",
-        "zhTW": "神聖光環",
+        "zhTW": "神圣光环",
         "deDE": "Heilige Aura",
         "esES": "Aura sagrada",
         "frFR": "Aura sacrée",
@@ -47705,7 +47705,7 @@
         "id": 51270,
         "Key": "Retribution",
         "enUS": "Retribution",
-        "zhTW": "報應",
+        "zhTW": "报应",
         "deDE": "Vergeltung",
         "esES": "Retribution",
         "frFR": "La rétribution",
@@ -47722,7 +47722,7 @@
         "id": 51271,
         "Key": "Glory of Salvation",
         "enUS": "Glory of Salvation",
-        "zhTW": "救贖的榮耀",
+        "zhTW": "救赎的荣耀",
         "deDE": "Die Herrlichkeit der Erlösung",
         "esES": "Gloria de la Salvación",
         "frFR": "La gloire du salut",
@@ -47739,7 +47739,7 @@
         "id": 51272,
         "Key": "Angel's Touch",
         "enUS": "Angel's Touch",
-        "zhTW": "天使之觸",
+        "zhTW": "天使之触",
         "deDE": "Engelsgleiche Berührung",
         "esES": "El toque del ángel",
         "frFR": "Le toucher de l'ange",
@@ -47756,7 +47756,7 @@
         "id": 51273,
         "Key": "The Mysterious Spin",
         "enUS": "The Mysterious Spin",
-        "zhTW": "神秘螺旋",
+        "zhTW": "神秘的旋转",
         "deDE": "Die geheimnisvolle Drehung",
         "esES": "El giro misterioso",
         "frFR": "La mystérieuse pirouette",
@@ -47767,13 +47767,13 @@
         "jaJP": "謎のスピン",
         "ptBR": "Giro Misterioso ",
         "ruRU": "Таинственный спин",
-        "zhCN": "神秘螺旋"
+        "zhCN": "神秘的旋转"
     },
     {
         "id": 51274,
         "Key": "Spin's Enigma",
         "enUS": "Spin's Enigma",
-        "zhTW": "螺旋之謎",
+        "zhTW": "旋转之谜",
         "deDE": "Das Rätsel des Spin",
         "esES": "El enigma de Spin",
         "frFR": "L'énigme de Spin",
@@ -47784,13 +47784,13 @@
         "jaJP": "スピンの謎",
         "ptBR": "Giro Enigmatico",
         "ruRU": "Загадка Спина",
-        "zhCN": "螺旋之谜"
+        "zhCN": "旋转之谜"
     },
     {
         "id": 51275,
         "Key": "Spin's Paradox",
         "enUS": "Spin's Paradox",
-        "zhTW": "螺旋悖論",
+        "zhTW": "自旋悖论",
         "deDE": "Das Paradoxon des Spin",
         "esES": "La paradoja del trompo",
         "frFR": "Le paradoxe de Spin",
@@ -47801,13 +47801,13 @@
         "jaJP": "スピンのパラドックス",
         "ptBR": "Giro Paradoxo",
         "ruRU": "Парадокс Спина",
-        "zhCN": "螺旋悖论"
+        "zhCN": "自旋悖论"
     },
     {
         "id": 51276,
         "Key": "Spin's Mystery",
         "enUS": "Spin's Mystery",
-        "zhTW": "螺旋之秘",
+        "zhTW": "旋转之谜",
         "deDE": "Das Geheimnis von Spin",
         "esES": "El misterio de Spin",
         "frFR": "Le mystère de Spin",
@@ -47818,13 +47818,13 @@
         "jaJP": "スピンの謎",
         "ptBR": "Giro Misterioso",
         "ruRU": "Тайна Спина",
-        "zhCN": "螺旋之秘"
+        "zhCN": "旋转之谜"
     },
     {
         "id": 51277,
         "Key": "Spin's Conundrum",
         "enUS": "Spin's Conundrum",
-        "zhTW": "螺旋難題",
+        "zhTW": "旋转的难题",
         "deDE": "Das Rätsel des Spin",
         "esES": "El enigma de Spin",
         "frFR": "L'énigme de Spin",
@@ -47835,13 +47835,13 @@
         "jaJP": "スピンの難問",
         "ptBR": "Dilema do Giro",
         "ruRU": "Загадка Спина",
-        "zhCN": "螺旋难题"
+        "zhCN": "旋转的难题"
     },
     {
         "id": 51278,
         "Key": "Spin's Perplexing Puzzle",
         "enUS": "Spin's Perplexing Puzzle",
-        "zhTW": "螺旋謎題",
+        "zhTW": "旋转的谜题",
         "deDE": "Das verwirrende Rätsel des Spin",
         "esES": "El desconcertante rompecabezas de Spin",
         "frFR": "Le casse-tête de Spin",
@@ -47852,13 +47852,13 @@
         "jaJP": "スピンの不可解なパズル",
         "ptBR": "Giro Quebra-Cabeça",
         "ruRU": "Загадка Спина",
-        "zhCN": "螺旋谜题"
+        "zhCN": "旋转的谜题"
     },
     {
         "id": 51279,
         "Key": "Darkmage's Astral Projection",
         "enUS": "Darkmage's Astral Projection",
-        "zhTW": "黑暗法師的星界投影",
+        "zhTW": "黑暗法师的星界投影",
         "deDE": "Astralprojektion des Dunkelmagiers",
         "esES": "Proyección astral del Darkmage",
         "frFR": "La projection astrale du Darkmage",
@@ -47875,7 +47875,7 @@
         "id": 51280,
         "Key": "Darkmage's Falling Star",
         "enUS": "Darkmage's Falling Star",
-        "zhTW": "黑暗法師的隕星",
+        "zhTW": "黑暗法师的陨星",
         "deDE": "Der fallende Stern des Dunkelmagiers",
         "esES": "Estrella fugaz del Darkmage",
         "frFR": "L'étoile filante de Darkmage",
@@ -47892,7 +47892,7 @@
         "id": 51281,
         "Key": "Darkmage's Solar Flair",
         "enUS": "Darkmage's Solar Flair",
-        "zhTW": "黑暗法師的太陽耀斑",
+        "zhTW": "黑暗法师的太阳能天赋",
         "deDE": "Sonnenflair des Dunkelmagiers",
         "esES": "Destello solar del Darkmage",
         "frFR": "Le flair solaire de Darkmage",
@@ -47903,13 +47903,13 @@
         "jaJP": "ダークメイジのソーラーフレア",
         "ptBR": "Sombrio",
         "ruRU": "Солнечное чутье темного мага",
-        "zhCN": "黑暗法师的太阳耀斑"
+        "zhCN": "黑暗法师的太阳能天赋"
     },
     {
         "id": 51282,
         "Key": "Darkmage's Super Nova",
         "enUS": "Darkmage's Super Nova",
-        "zhTW": "黑暗法師的超新星",
+        "zhTW": "黑暗法师的超级新星",
         "deDE": "Super Nova des Dunkelmagiers",
         "esES": "Super Nova del Darkmage",
         "frFR": "Super Nova de Darkmage",
@@ -47920,13 +47920,13 @@
         "jaJP": "ダークメイジのスーパーノヴァ",
         "ptBR": "Escuridão",
         "ruRU": "Супернова Даркмага",
-        "zhCN": "黑暗法师的超新星"
+        "zhCN": "黑暗法师的超级新星"
     },
     {
         "id": 51283,
         "Key": "Darkmage's Meteor Shower",
         "enUS": "Darkmage's Meteor Shower",
-        "zhTW": "黑暗法師的流星雨",
+        "zhTW": "黑暗法师的流星雨",
         "deDE": "Der Meteoritenschauer des Dunkelmagiers",
         "esES": "Lluvia de meteoritos del Darkmage",
         "frFR": "La pluie de météores de Darkmage",
@@ -47943,7 +47943,7 @@
         "id": 51284,
         "Key": "Darkmage's Celestial Fury",
         "enUS": "Darkmage's Celestial Fury",
-        "zhTW": "黑暗法師的天體狂暴",
+        "zhTW": "黑暗法师的天怒",
         "deDE": "Himmlischer Zorn des Dunkelmagiers",
         "esES": "Furia celestial del Darkmage",
         "frFR": "La fureur céleste du Darkmage",
@@ -47954,13 +47954,13 @@
         "jaJP": "ダークメイジの天空の怒り",
         "ptBR": "Tenebroso",
         "ruRU": "Небесная ярость темного мага",
-        "zhCN": "黑暗法师的天体狂暴"
+        "zhCN": "黑暗法师的天怒"
     },
     {
         "id": 51285,
         "Key": "Phrozen Heart's Mysticism",
         "enUS": "Phrozen Heart's Mysticism",
-        "zhTW": "冰封之心的神秘主義",
+        "zhTW": "冰封之心的神秘主义",
         "deDE": "Die Mystik des gefrorenen Herzens",
         "esES": "Misticismo de Phrozen Heart",
         "frFR": "Le mysticisme du cœur gelé",
@@ -47977,7 +47977,7 @@
         "id": 51286,
         "Key": "Cryptic Claws",
         "enUS": "Cryptic Claws",
-        "zhTW": "絕秘之爪",
+        "zhTW": "隐爪",
         "deDE": "Kryptische Krallen",
         "esES": "Garras crípticas",
         "frFR": "Griffes cryptiques",
@@ -47988,13 +47988,13 @@
         "jaJP": "クリプティック・クロー",
         "ptBR": "Garras Crípticas",
         "ruRU": "Криптические когти",
-        "zhCN": "秘文之爪"
+        "zhCN": "隐爪"
     },
     {
         "id": 51287,
         "Key": "Way of the Shadow",
         "enUS": "Way of the Shadow",
-        "zhTW": "陰影之道",
+        "zhTW": "阴影之道",
         "deDE": "Weg des Schattens",
         "esES": "El camino de la sombra",
         "frFR": "La voie de l'ombre",
@@ -48011,7 +48011,7 @@
         "id": 51288,
         "Key": "Dawns Mist",
         "enUS": "Dawns Mist",
-        "zhTW": "黎明迷霧",
+        "zhTW": "黎明之雾",
         "deDE": "Dämmerung Nebel",
         "esES": "Niebla del amanecer",
         "frFR": "Brume de l'aube",
@@ -48022,13 +48022,13 @@
         "jaJP": "夜明けの霧",
         "ptBR": "Névoa do Amanhecer",
         "ruRU": "Рассветный туман",
-        "zhCN": "黎明迷雾"
+        "zhCN": "黎明之雾"
     },
     {
         "id": 51289,
         "Key": "Featherfoot",
         "enUS": "Featherfoot",
-        "zhTW": "足下生羽",
+        "zhTW": "羽毛脚",
         "deDE": "Federfuß",
         "esES": "Pies de pluma",
         "frFR": "Pied de plume",
@@ -48039,13 +48039,13 @@
         "jaJP": "フェザーフット",
         "ptBR": "Pé de Pena",
         "ruRU": "Featherfoot",
-        "zhCN": "足下生羽"
+        "zhCN": "羽毛脚"
     },
     {
         "id": 51290,
         "Key": "Winter's Discord",
         "enUS": "Winter's Discord",
-        "zhTW": "冬日的紛爭",
+        "zhTW": "冬天的不和谐",
         "deDE": "Zwietracht des Winters",
         "esES": "Discordia de invierno",
         "frFR": "La discorde de l'hiver",
@@ -48056,13 +48056,13 @@
         "jaJP": "冬の不協和音",
         "ptBR": "Discórdia de Inverno",
         "ruRU": "Зимний раздор",
-        "zhCN": "冬日的纷争"
+        "zhCN": "冬天的不和谐"
     },
     {
         "id": 51291,
         "Key": "Chaos Energy",
         "enUS": "Chaos Energy",
-        "zhTW": "渾沌能量",
+        "zhTW": "混沌能源",
         "deDE": "Chaos Energy",
         "esES": "Energía del caos",
         "frFR": "Chaos Energy",
@@ -48073,13 +48073,13 @@
         "jaJP": "カオス・エネルギー",
         "ptBR": "Energia do Caos",
         "ruRU": "Энергия хаоса",
-        "zhCN": "混沌能量"
+        "zhCN": "混沌能源"
     },
     {
         "id": 51292,
         "Key": "Soulstone of Power",
         "enUS": "Soulstone of Power",
-        "zhTW": "力之靈魂石",
+        "zhTW": "力量灵魂石",
         "deDE": "Seelenstein der Macht",
         "esES": "Piedra del alma del poder",
         "frFR": "Pierre d'âme du pouvoir",
@@ -48090,13 +48090,13 @@
         "jaJP": "力のソウルストーン",
         "ptBR": "Pedra da Alma do Poder",
         "ruRU": "Камень силы души",
-        "zhCN": "力之灵魂石"
+        "zhCN": "力量灵魂石"
     },
     {
         "id": 51293,
         "Key": "Guiding Focus",
         "enUS": "Guiding Focus",
-        "zhTW": "引導焦點",
+        "zhTW": "指导重点",
         "deDE": "Leitmotiv",
         "esES": "Enfoque orientador",
         "frFR": "Orientations",
@@ -48107,13 +48107,13 @@
         "jaJP": "ガイド・フォーカス",
         "ptBR": "Foco Orientador",
         "ruRU": "Направляющий фокус",
-        "zhCN": "引导焦点"
+        "zhCN": "指导重点"
     },
     {
         "id": 51294,
         "Key": "Chaotic Shield",
         "enUS": "Chaotic Shield",
-        "zhTW": "渾沌護盾",
+        "zhTW": "混沌护盾",
         "deDE": "Chaotischer Schild",
         "esES": "Escudo Caótico",
         "frFR": "Bouclier chaotique",
@@ -48130,7 +48130,7 @@
         "id": 51295,
         "Key": "Treads of Energy",
         "enUS": "Treads of Energy",
-        "zhTW": "能量踐踏",
+        "zhTW": "能量踏板",
         "deDE": "Laufflächen der Energie",
         "esES": "Pisadas de energía",
         "frFR": "Les marches de l'énergie",
@@ -48141,13 +48141,13 @@
         "jaJP": "エネルギーのトレッド",
         "ptBR": "Fios de Energia",
         "ruRU": "Протекторы энергии",
-        "zhCN": "能量践踏"
+        "zhCN": "能量踏板"
     },
     {
         "id": 51296,
         "Key": "Band of Mysticism",
         "enUS": "Band of Mysticism",
-        "zhTW": "神秘頻帶",
+        "zhTW": "神秘乐队",
         "deDE": "Band der Mystik",
         "esES": "Banda del Misticismo",
         "frFR": "Bande de mysticisme",
@@ -48158,13 +48158,13 @@
         "jaJP": "神秘主義のバンド",
         "ptBR": "Banda de Misticismo",
         "ruRU": "Группа мистицизма",
-        "zhCN": "神秘频带"
+        "zhCN": "神秘乐队"
     },
     {
         "id": 51297,
         "Key": "Aiel Shieldmaiden",
         "enUS": "Aiel Shieldmaiden",
-        "zhTW": "艾爾女戰士",
+        "zhTW": "艾尔盾女",
         "deDE": "Aiel-Schildmaid",
         "esES": "Doncella Escudo Aiel",
         "frFR": "La demoiselle de bouclier d'Aiel",
@@ -48175,13 +48175,13 @@
         "jaJP": "アイエル・シールドメイデン",
         "ptBR": "Escudo da Donzela Aiel",
         "ruRU": "Дева щита Аиэля",
-        "zhCN": "艾尔女战士"
+        "zhCN": "艾尔盾女"
     },
     {
         "id": 51298,
         "Key": "Chiad's Lances",
         "enUS": "Chiad's Lances",
-        "zhTW": "奇亞德的長槍",
+        "zhTW": "恰德长矛",
         "deDE": "Lanzen von Chiad",
         "esES": "Lanzas de Chiad",
         "frFR": "Lances de Chiad",
@@ -48192,13 +48192,13 @@
         "jaJP": "チアドの槍",
         "ptBR": "Lanças de Chiad",
         "ruRU": "Копья Чиада",
-        "zhCN": "奇亚德的长枪"
+        "zhCN": "恰德长矛"
     },
     {
         "id": 51299,
         "Key": "Chiad's Wall",
         "enUS": "Chiad's Wall",
-        "zhTW": "奇亞達之墻",
+        "zhTW": "Chiad 的墙",
         "deDE": "Chiad's Wand",
         "esES": "Muro de Chiad",
         "frFR": "Mur de Chiad",
@@ -48209,13 +48209,13 @@
         "jaJP": "チアドの壁",
         "ptBR": "Muro de Chiad",
         "ruRU": "Стена Чиада",
-        "zhCN": "奇亚达之墙"
+        "zhCN": "Chiad 的墙"
     },
     {
         "id": 51300,
         "Key": "Chiad's Heartbane",
         "enUS": "Chiad's Heartbane",
-        "zhTW": "奇亞德的心脏",
+        "zhTW": "基亚德的心脏",
         "deDE": "Chiad's Heartbane",
         "esES": "Corazonada de Chiad",
         "frFR": "L'aile du cœur de Chiad",
@@ -48226,13 +48226,13 @@
         "jaJP": "チアドのハートベイン",
         "ptBR": "Maldição do Coração de Chiad",
         "ruRU": "Сердцеед Кьяда",
-        "zhCN": "奇亚德的心脏"
+        "zhCN": "基亚德的心脏"
     },
     {
         "id": 51301,
         "Key": "Chiad's Halo",
         "enUS": "Chiad's Halo",
-        "zhTW": "奇亞德的光晕",
+        "zhTW": "奇亚德的光环",
         "deDE": "Chiads Halo",
         "esES": "Halo de Chiad",
         "frFR": "Halo de Chiad",
@@ -48243,13 +48243,13 @@
         "jaJP": "チアドの後光",
         "ptBR": "Auréola de Chiad",
         "ruRU": "Ореол Чада",
-        "zhCN": "奇亚德的光晕"
+        "zhCN": "奇亚德的光环"
     },
     {
         "id": 51302,
         "Key": "Chiad's Valor",
         "enUS": "Chiad's Valor",
-        "zhTW": "奇亞德的勇气",
+        "zhTW": "基亚德的勇气",
         "deDE": "Chiads Tapferkeit",
         "esES": "Valor de Chiad",
         "frFR": "La valeur de Chiad",
@@ -48260,13 +48260,13 @@
         "jaJP": "チアドの勇姿",
         "ptBR": "Valentia de Chiad",
         "ruRU": "Доблесть Чиада",
-        "zhCN": "奇亚德的勇气"
+        "zhCN": "基亚德的勇气"
     },
     {
         "id": 51303,
         "Key": "Myhrginoc's Warbreeder",
         "enUS": "Myhrginoc's Warbreeder",
-        "zhTW": "米爾金諾的戰爭販子",
+        "zhTW": "米尔金诺克的战争饲养员",
         "deDE": "Myhrginocs Kriegszüchter",
         "esES": "Warbreeder de Myhrginoc",
         "frFR": "Le Warbreeder de Myhrginoc",
@@ -48277,13 +48277,13 @@
         "jaJP": "ミールギノックのウォーブリーダー",
         "ptBR": "Criador de Guerra de Myhrginoc",
         "ruRU": "Военачальник Миргинок",
-        "zhCN": "米尔金诺的战争贩子"
+        "zhCN": "米尔金诺克的战争饲养员"
     },
     {
         "id": 51304,
         "Key": "Myhrginoc's Headhunter",
         "enUS": "Myhrginoc's Headhunter",
-        "zhTW": "米爾金諾的獵頭者",
+        "zhTW": "米尔金诺克的猎头人",
         "deDE": "Myhrginocs Kopfjäger",
         "esES": "Cazatalentos de Myhrginoc",
         "frFR": "Le chasseur de têtes de Myhrginoc",
@@ -48294,13 +48294,13 @@
         "jaJP": "ミールギノックのヘッドハンター",
         "ptBR": "Caçador de Cabeças de Myhrginoc",
         "ruRU": "Охотник за головами Миргинока",
-        "zhCN": "米尔金诺的猎头者"
+        "zhCN": "米尔金诺克的猎头人"
     },
     {
         "id": 51305,
         "Key": "Myhrginoc's Black Rain",
         "enUS": "Myhrginoc's Black Rain",
-        "zhTW": "米爾金諾的黑雨",
+        "zhTW": "迈尔吉诺克的黑雨",
         "deDE": "Myhrginocs Schwarzer Regen",
         "esES": "Lluvia negra de Myhrginoc",
         "frFR": "La pluie noire de Myhrginoc",
@@ -48311,13 +48311,13 @@
         "jaJP": "ミールギノックの黒い雨",
         "ptBR": "Chuva Negra de Myhrginoc",
         "ruRU": "Черный дождь Миргинока",
-        "zhCN": "米尔金诺的黑雨"
+        "zhCN": "迈尔吉诺克的黑雨"
     },
     {
         "id": 51306,
         "Key": "Myhrginoc's Crimson Crusader",
         "enUS": "Myhrginoc's Crimson Crusader",
-        "zhTW": "米爾金諾的緋紅聖教军",
+        "zhTW": "米尔金诺克的深红十字军",
         "deDE": "Myhrginocs Karmesin-Kreuzritter",
         "esES": "Cruzado Carmesí de Myhrginoc",
         "frFR": "Le Crimson Crusader de Myhrginoc",
@@ -48328,13 +48328,13 @@
         "jaJP": "ミールギノックのクリムゾン・クルセイダー",
         "ptBR": "Cruzado Carmesim de Myhrginoc",
         "ruRU": "Багровый крестоносец Миргинока",
-        "zhCN": "米尔金诺的绯红十字军"
+        "zhCN": "米尔金诺克的深红十字军"
     },
     {
         "id": 51307,
         "Key": "Myhrginoc's Deathmonger",
         "enUS": "Myhrginoc's Deathmonger",
-        "zhTW": "米爾金諾的死亡商販",
+        "zhTW": "米尔金诺克的死亡商贩",
         "deDE": "Myhrginocs Totengräber",
         "esES": "Deathmonger de Myhrginoc",
         "frFR": "Le marchand de mort de Myhrginoc",
@@ -48345,13 +48345,13 @@
         "jaJP": "ミールギノックの死の商人",
         "ptBR": "Traficante da morte de Myhrginoc",
         "ruRU": "Смертоносец Миргинока",
-        "zhCN": "米尔金诺的死亡商贩"
+        "zhCN": "米尔金诺克的死亡商贩"
     },
     {
         "id": 51308,
         "Key": "Nefarious Ways",
         "enUS": "Nefarious Ways",
-        "zhTW": "邪惡之路",
+        "zhTW": "邪恶的方式",
         "deDE": "Schändliche Wege",
         "esES": "Maneras nefastas",
         "frFR": "Moyens détournés",
@@ -48362,13 +48362,13 @@
         "jaJP": "極悪非道な方法",
         "ptBR": "Caminhos Nefastos",
         "ruRU": "Гнусные способы",
-        "zhCN": "邪恶之路"
+        "zhCN": "邪恶的方式"
     },
     {
         "id": 51309,
         "Key": "Sin and Greed",
         "enUS": "Sin and Greed",
-        "zhTW": "罪與貪",
+        "zhTW": "罪恶与贪婪",
         "deDE": "Sünde und Gier",
         "esES": "Pecado y avaricia",
         "frFR": "Péché et cupidité",
@@ -48379,13 +48379,13 @@
         "jaJP": "罪と欲",
         "ptBR": "Pecado e Ganância",
         "ruRU": "Грех и жадность",
-        "zhCN": "罪与贪"
+        "zhCN": "罪恶与贪婪"
     },
     {
         "id": 51310,
         "Key": "wicked Impulse",
         "enUS": "Wicked Impulse",
-        "zhTW": "邪惡衝動",
+        "zhTW": "邪恶的冲动",
         "deDE": "Wicked Impulse",
         "esES": "Impulso perverso",
         "frFR": "Wicked Impulse",
@@ -48396,13 +48396,13 @@
         "jaJP": "邪悪な衝動",
         "ptBR": "Impulso Perverso",
         "ruRU": "Порочный импульс",
-        "zhCN": "邪恶冲动"
+        "zhCN": "邪恶的冲动"
     },
     {
         "id": 51311,
         "Key": "Evil Reputation",
         "enUS": "Evil Reputation",
-        "zhTW": "惡名在外",
+        "zhTW": "邪恶声誉",
         "deDE": "Böser Ruf",
         "esES": "Mala reputación",
         "frFR": "Mauvaise réputation",
@@ -48413,13 +48413,13 @@
         "jaJP": "悪の評判",
         "ptBR": "Má Reputação",
         "ruRU": "Злая репутация",
-        "zhCN": "恶名在外"
+        "zhCN": "邪恶声誉"
     },
     {
         "id": 51312,
         "Key": "Noxious Whispers",
         "enUS": "Noxious Whispers",
-        "zhTW": "惡毒低語",
+        "zhTW": "恶毒的低语",
         "deDE": "Schädliches Flüstern",
         "esES": "Susurros nocivos",
         "frFR": "Chuchotements nocifs",
@@ -48430,13 +48430,13 @@
         "jaJP": "有害なささやき",
         "ptBR": "Sussurros Nocivos",
         "ruRU": "Вредный шепот",
-        "zhCN": "恶毒低语"
+        "zhCN": "恶毒的低语"
     },
     {
         "id": 51313,
         "Key": "Kraj's Memorial",
         "enUS": "Kraj's Memorial",
-        "zhTW": "克拉伊的紀念館",
+        "zhTW": "克拉伊纪念馆",
         "deDE": "Krajs Gedenkstätte",
         "esES": "Memorial de Kraj",
         "frFR": "Mémorial de Kraj",
@@ -48447,13 +48447,13 @@
         "jaJP": "クラジ追悼",
         "ptBR": "Memorial de Kraj",
         "ruRU": "Мемориал Крайя",
-        "zhCN": "克拉伊的纪念馆"
+        "zhCN": "克拉伊纪念馆"
     },
     {
         "id": 51314,
         "Key": "Eternal Sleep",
         "enUS": "Eternal Sleep",
-        "zhTW": "永恒安眠",
+        "zhTW": "永恒的睡眠",
         "deDE": "Ewiger Schlaf",
         "esES": "Sueño eterno",
         "frFR": "Sommeil éternel",
@@ -48464,13 +48464,13 @@
         "jaJP": "永遠の眠り",
         "ptBR": "Sono Eterno",
         "ruRU": "Вечный сон",
-        "zhCN": "永恒安眠"
+        "zhCN": "永恒的睡眠"
     },
     {
         "id": 51315,
         "Key": "Calming Peace",
         "enUS": "Calming Peace",
-        "zhTW": "平靜寧和",
+        "zhTW": "平静安宁",
         "deDE": "Beruhigende Ruhe",
         "esES": "Paz tranquilizadora",
         "frFR": "Calmer la paix",
@@ -48481,13 +48481,13 @@
         "jaJP": "穏やかな平和",
         "ptBR": "Paz Calmante",
         "ruRU": "Успокаивающий мир",
-        "zhCN": "平静宁和"
+        "zhCN": "平静安宁"
     },
     {
         "id": 51316,
         "Key": "Silk Shroud",
         "enUS": "Silk Shroud",
-        "zhTW": "絲綢壽衣",
+        "zhTW": "丝绸裹尸布",
         "deDE": "Seidenes Leichentuch",
         "esES": "Mortaja de seda",
         "frFR": "Linceul de soie",
@@ -48498,13 +48498,13 @@
         "jaJP": "シルク・シュラウド",
         "ptBR": "Mortalha de Seda",
         "ruRU": "Шелковый саван",
-        "zhCN": "丝绸寿衣"
+        "zhCN": "丝绸裹尸布"
     },
     {
         "id": 51317,
         "Key": "Temple Guardian",
         "enUS": "Temple Guardian",
-        "zhTW": "神廟守衛",
+        "zhTW": "寺庙守护者",
         "deDE": "Wächter des Tempels",
         "esES": "Guardián del Templo",
         "frFR": "Gardien du temple",
@@ -48515,13 +48515,13 @@
         "jaJP": "テンプルガーディアン",
         "ptBR": "Guardião do Templo",
         "ruRU": "Хранитель храма",
-        "zhCN": "神庙守卫"
+        "zhCN": "寺庙守护者"
     },
     {
         "id": 51318,
         "Key": "The Darkest Weaves",
         "enUS": "The Darkest Weaves",
-        "zhTW": "至暗編制",
+        "zhTW": "最黑暗的编织",
         "deDE": "Die dunkelsten Gewebe",
         "esES": "Los tejidos más oscuros",
         "frFR": "Les trames les plus sombres",
@@ -48532,13 +48532,13 @@
         "jaJP": "闇の織物",
         "ptBR": "As Extensões Mais Escuras",
         "ruRU": "Самые темные переплетения",
-        "zhCN": "至暗编织"
+        "zhCN": "最黑暗的编织"
     },
     {
         "id": 51319,
         "Key": "Sundered Heart",
         "enUS": "Sundered Heart",
-        "zhTW": "碎裂之心",
+        "zhTW": "Sundered Heart",
         "deDE": "Versunkenes Herz",
         "esES": "Corazón ensombrecido",
         "frFR": "Le cœur ensoleillé",
@@ -48549,13 +48549,13 @@
         "jaJP": "サンダーハート",
         "ptBR": "Coração Dividido",
         "ruRU": "Закаленное сердце",
-        "zhCN": "碎裂之心"
+        "zhCN": "Sundered Heart"
     },
     {
         "id": 51320,
         "Key": "Soulreaver",
         "enUS": "Soulreaver",
-        "zhTW": "掠魂者",
+        "zhTW": "Soulreaver",
         "deDE": "Seelenräuber",
         "esES": "Soulreaver",
         "frFR": "Soulreaver",
@@ -48566,13 +48566,13 @@
         "jaJP": "ソウルリーバー",
         "ptBR": "Ladrão de Alma",
         "ruRU": "Soulreaver",
-        "zhCN": "掠魂者"
+        "zhCN": "Soulreaver"
     },
     {
         "id": 51321,
         "Key": "Throws of Hatred",
         "enUS": "Throws of Hatred",
-        "zhTW": "憎恨投擲",
+        "zhTW": "仇恨的投掷",
         "deDE": "Würfe des Hasses",
         "esES": "Lanzamientos de odio",
         "frFR": "Les jets de haine",
@@ -48583,13 +48583,13 @@
         "jaJP": "憎しみの投擲",
         "ptBR": "Jogadas de Ódio",
         "ruRU": "Броски ненависти",
-        "zhCN": "憎恨投掷"
+        "zhCN": "仇恨的投掷"
     },
     {
         "id": 51322,
         "Key": "Blood Raven's Despair",
         "enUS": "Blood Raven's Despair",
-        "zhTW": "血鴉的絕望",
+        "zhTW": "血鸦的绝望",
         "deDE": "Die Verzweiflung des Blutraben",
         "esES": "La desesperación del cuervo de sangre",
         "frFR": "Le désespoir du corbeau de sang",
@@ -48606,7 +48606,7 @@
         "id": 51323,
         "Key": "Blood Raven's Pain",
         "enUS": "Blood Raven's Pain",
-        "zhTW": "血鴉的痛苦",
+        "zhTW": "血鸦之痛",
         "deDE": "Der Schmerz des Blutraben",
         "esES": "Dolor del Cuervo de Sangre",
         "frFR": "La douleur du corbeau de sang",
@@ -48617,13 +48617,13 @@
         "jaJP": "ブラッド・レイブンズ・ペイン",
         "ptBR": "Dor do Corvo Sangrento",
         "ruRU": "Боль Кровавого Ворона",
-        "zhCN": "血鸦的痛苦"
+        "zhCN": "血鸦之痛"
     },
     {
         "id": 51324,
         "Key": "Blood Raven's Curse",
         "enUS": "Blood Raven's Curse",
-        "zhTW": "血鴉的诅咒",
+        "zhTW": "血鸦的诅咒",
         "deDE": "Der Fluch des Blutraben",
         "esES": "La maldición del cuervo de sangre",
         "frFR": "La malédiction du corbeau de sang",
@@ -48640,7 +48640,7 @@
         "id": 51325,
         "Key": "Blood Raven's Redemption",
         "enUS": "Blood Raven's Redemption",
-        "zhTW": "血鴉的救赎",
+        "zhTW": "血鸦的救赎",
         "deDE": "Die Erlösung des Blutraben",
         "esES": "Redención del Cuervo de Sangre",
         "frFR": "La rédemption du corbeau de sang",
@@ -48657,7 +48657,7 @@
         "id": 51326,
         "Key": "Narrow Path Between Light and Darkness",
         "enUS": "Narrow Path Between Light and Darkness",
-        "zhTW": "光黯狹隙",
+        "zhTW": "光明与黑暗之间的窄路",
         "deDE": "Der schmale Pfad zwischen Licht und Dunkelheit",
         "esES": "El estrecho camino entre la luz y la oscuridad",
         "frFR": "Un chemin étroit entre la lumière et les ténèbres",
@@ -48668,13 +48668,13 @@
         "jaJP": "光と闇の間の狭い道",
         "ptBR": "Caminho Estreito Entre Luz e Trevas",
         "ruRU": "Узкий путь между светом и тьмой",
-        "zhCN": "光暗狭隙"
+        "zhCN": "光明与黑暗之间的窄路"
     },
     {
         "id": 51327,
         "Key": "Char's Grimace of Death",
         "enUS": "Char's Grimace of Death",
-        "zhTW": "查爾的死亡鬼臉",
+        "zhTW": "查尔的死亡表情",
         "deDE": "Chars Fratze des Todes",
         "esES": "La mueca de la muerte de Char",
         "frFR": "La grimace de la mort de Char",
@@ -48685,13 +48685,13 @@
         "jaJP": "シャアの死のグリマス",
         "ptBR": "Careta da Morte de Char",
         "ruRU": "Гримаса смерти Чара",
-        "zhCN": "查尔的死亡鬼脸"
+        "zhCN": "查尔的死亡表情"
     },
     {
         "id": 51328,
         "Key": "Char's Annulus of Obscurity",
         "enUS": "Char's Annulus of Obscurity",
-        "zhTW": "查爾的晦澀空環",
+        "zhTW": "查尔的模糊环",
         "deDE": "Char's Annulus of Obscurity",
         "esES": "Anillo de oscuridad de Char",
         "frFR": "L'anneau d'obscurité de Char",
@@ -48702,13 +48702,13 @@
         "jaJP": "シャアの無名の環",
         "ptBR": "Anel de Obscuridade de Char",
         "ruRU": "Аннулус неизвестности Чара",
-        "zhCN": "查尔的晦涩空环"
+        "zhCN": "查尔的模糊环"
     },
     {
         "id": 51329,
         "Key": "Char's Blessed Reflection",
         "enUS": "Char's Blessed Reflection",
-        "zhTW": "查爾的幸運反射",
+        "zhTW": "夏尔的幸福反思",
         "deDE": "Chars gesegnete Reflexion",
         "esES": "Bendita reflexión de Char",
         "frFR": "Réflexion bénie de Char",
@@ -48719,13 +48719,13 @@
         "jaJP": "シャアの祝福に満ちた回想",
         "ptBR": "Reflexão Abençoada de Char",
         "ruRU": "Благословенное размышление Шар",
-        "zhCN": "查尔的幸运反射"
+        "zhCN": "夏尔的幸福反思"
     },
     {
         "id": 51330,
         "Key": "Char's Hand of Blessed Light",
         "enUS": "Char's Hand of Blessed Light",
-        "zhTW": "查爾的福光之手",
+        "zhTW": "查尔的祝福之光之手",
         "deDE": "Chars Hand des gesegneten Lichts",
         "esES": "La Mano de Luz Bendita de Char",
         "frFR": "La main de Char, une lumière bienfaisante",
@@ -48736,13 +48736,13 @@
         "jaJP": "シャアの祝福の手",
         "ptBR": "Mão de Luz Abençoada de Char ",
         "ruRU": "Рука благословенного света Чар",
-        "zhCN": "查尔的福光之手"
+        "zhCN": "查尔的祝福之光之手"
     },
     {
         "id": 51331,
         "Key": "Char's Carapace",
         "enUS": "Char's Carapace",
-        "zhTW": "查爾的殼甲",
+        "zhTW": "查尔的甲壳",
         "deDE": "Char's Panzer",
         "esES": "Caparazón de Char",
         "frFR": "Carapace de Char",
@@ -48753,13 +48753,13 @@
         "jaJP": "シャアの甲羅",
         "ptBR": "Carapaça de Char",
         "ruRU": "Панцирь Чара",
-        "zhCN": "查尔的壳甲"
+        "zhCN": "查尔的甲壳"
     },
     {
         "id": 51332,
         "Key": "Treasure Hunter",
         "enUS": "Treasure Hunter",
-        "zhTW": "寶藏獵人",
+        "zhTW": "宝藏猎人",
         "deDE": "Schatzsucher",
         "esES": "Cazador de tesoros",
         "frFR": "Chasseur de trésors",
@@ -48776,7 +48776,7 @@
         "id": 51333,
         "Key": "Kingpin's Wrap",
         "enUS": "Kingpin's Wrap",
-        "zhTW": "王者裹腰",
+        "zhTW": "王牌包装",
         "deDE": "Kingpins Wrap",
         "esES": "Envoltura de Kingpin",
         "frFR": "L'enveloppement de Kingpin",
@@ -48787,13 +48787,13 @@
         "jaJP": "キングピンズ・ラップ",
         "ptBR": "Rei",
         "ruRU": "Обертка Кингпина",
-        "zhCN": "王者腰带"
+        "zhCN": "王牌包装"
     },
     {
         "id": 51334,
         "Key": "Kingpin's Greaves",
         "enUS": "Kingpin's Greaves",
-        "zhTW": "王者之脛",
+        "zhTW": "王者之剑",
         "deDE": "Kingpins Beinschienen",
         "esES": "Grebas de Kingpin",
         "frFR": "Les crevettes de Kingpin",
@@ -48804,13 +48804,13 @@
         "jaJP": "キングピンズ・グリーブス",
         "ptBR": "Monarca",
         "ruRU": "Гривы Кингпина",
-        "zhCN": "王者之胫"
+        "zhCN": "王者之剑"
     },
     {
         "id": 51335,
         "Key": "Kingpin's Ire",
         "enUS": "Kingpin's Ire",
-        "zhTW": "王者之怒",
+        "zhTW": "金主的愤怒",
         "deDE": "Königsmörderischer Zorn",
         "esES": "La ira de Kingpin",
         "frFR": "L'Ire de Kingpin",
@@ -48821,13 +48821,13 @@
         "jaJP": "キングピンズ・アイアー",
         "ptBR": "Soberano",
         "ruRU": "Ире Кингпина",
-        "zhCN": "王者之怒"
+        "zhCN": "金主的愤怒"
     },
     {
         "id": 51336,
         "Key": "Kingpin's Signet",
         "enUS": "Kingpin's Signet",
-        "zhTW": "王者之印",
+        "zhTW": "王牌",
         "deDE": "Siegel der Königskette",
         "esES": "Sello de Kingpin",
         "frFR": "Sceau du Kingpin",
@@ -48838,13 +48838,13 @@
         "jaJP": "キングピンズ・シグネット",
         "ptBR": "Magnata",
         "ruRU": "Знак Кингпина",
-        "zhCN": "王者之印"
+        "zhCN": "王牌"
     },
     {
         "id": 51337,
         "Key": "Kingpin's Crown",
         "enUS": "Kingpin's Crown",
-        "zhTW": "王者之冠",
+        "zhTW": "王冠",
         "deDE": "Die Krone des Königszapfens",
         "esES": "Corona de Kingpin",
         "frFR": "La couronne de Kingpin",
@@ -48855,13 +48855,13 @@
         "jaJP": "キングピンズ・クラウン",
         "ptBR": "Coroar",
         "ruRU": "Корона Кингпина",
-        "zhCN": "王者之冠"
+        "zhCN": "王冠"
     },
     {
         "id": 51338,
         "Key": "Kingpin's Blade",
         "enUS": "Kingpin's Blade",
-        "zhTW": "領袖之刃",
+        "zhTW": "王者之刃",
         "deDE": "Kingpins Klinge",
         "esES": "Cuchilla de Kingpin",
         "frFR": "Lame de Kingpin",
@@ -48872,13 +48872,13 @@
         "jaJP": "キングピンズ・ブレード",
         "ptBR": "Chefia",
         "ruRU": "Клинок Кингпина",
-        "zhCN": "领袖之刃"
+        "zhCN": "王者之刃"
     },
     {
         "id": 51339,
         "Key": "Yohann's Savant",
         "enUS": "Yohann's Savant",
-        "zhTW": "亞漢的博學",
+        "zhTW": "Yohann's Savant",
         "deDE": "Yohanns Savant",
         "esES": "Savant de Yohann",
         "frFR": "Le savant de Yohann",
@@ -48889,13 +48889,13 @@
         "jaJP": "ヨハン・サヴァン",
         "ptBR": "Sábio Yohann",
         "ruRU": "Савант Йоханна",
-        "zhCN": "亚汉的博学"
+        "zhCN": "Yohann's Savant"
     },
     {
         "id": 51340,
         "Key": "Wiseman's Cap",
         "enUS": "Wiseman's Cap",
-        "zhTW": "睿者之帽",
+        "zhTW": "怀斯曼帽子",
         "deDE": "Weisenmütze",
         "esES": "Gorra de Wiseman",
         "frFR": "Casquette de Wiseman",
@@ -48906,13 +48906,13 @@
         "jaJP": "ワイズマンズ・キャップ",
         "ptBR": "Boné de Wiseman",
         "ruRU": "Шапка Висмана",
-        "zhCN": "睿者之帽"
+        "zhCN": "怀斯曼帽子"
     },
     {
         "id": 51341,
         "Key": "Sage's Leather",
         "enUS": "Sage's Leather",
-        "zhTW": "聖者皮甲",
+        "zhTW": "圣人皮革",
         "deDE": "Sage's Leather",
         "esES": "Piel de salvia",
         "frFR": "Le cuir de Sage",
@@ -48923,13 +48923,13 @@
         "jaJP": "セージズ・レザー",
         "ptBR": "Couro do Sábio",
         "ruRU": "Кожа Сейджа",
-        "zhCN": "圣者皮甲"
+        "zhCN": "圣人皮革"
     },
     {
         "id": 51342,
         "Key": "Gloves of Knowledge",
         "enUS": "Gloves of Knowledge",
-        "zhTW": "知識手套",
+        "zhTW": "知识手套",
         "deDE": "Handschuhe des Wissens",
         "esES": "Guantes del conocimiento",
         "frFR": "Gants de la connaissance",
@@ -48946,7 +48946,7 @@
         "id": 51343,
         "Key": "Arcane Battlestaff",
         "enUS": "Arcane Battlestaff",
-        "zhTW": "奧術戰杖",
+        "zhTW": "奥术战杖",
         "deDE": "Arkaner Kampfstab",
         "esES": "Bastón de combate arcano",
         "frFR": "Bâton de combat arcanique",
@@ -48963,7 +48963,7 @@
         "id": 51344,
         "Key": "Zhoulomcrist's Dread",
         "enUS": "Zhoulomcrist's Dread",
-        "zhTW": "周洛姆·克里斯特的恐惧",
+        "zhTW": "周洛姆克里斯特的恐惧",
         "deDE": "Zhoulomcrist's Furcht",
         "esES": "Pavor de Zhoulomcrist",
         "frFR": "L'effroi de Zhoulomcrist",
@@ -48974,13 +48974,13 @@
         "jaJP": "ズーロムクリストの恐怖",
         "ptBR": "Veneração de Zhoulomcrist",
         "ruRU": "Ужас Жуломкриста",
-        "zhCN": "周洛姆·克里斯特的恐惧"
+        "zhCN": "周洛姆克里斯特的恐惧"
     },
     {
         "id": 51345,
         "Key": "Unholy Desires",
         "enUS": "Unholy Desires",
-        "zhTW": "邪惡之欲",
+        "zhTW": "邪恶的欲望",
         "deDE": "Unheilige Begierden",
         "esES": "Deseos impíos",
         "frFR": "Désirs impies",
@@ -48991,13 +48991,13 @@
         "jaJP": "穢れた欲望",
         "ptBR": "Desejos Profanos",
         "ruRU": "Нечестивые желания",
-        "zhCN": "邪恶之欲"
+        "zhCN": "邪恶的欲望"
     },
     {
         "id": 51346,
         "Key": "Darkest Wishes",
         "enUS": "Darkest Wishes",
-        "zhTW": "至暗之願",
+        "zhTW": "最黑暗的愿望",
         "deDE": "Dunkelste Wünsche",
         "esES": "Los deseos más oscuros",
         "frFR": "Les souhaits les plus sombres",
@@ -49008,13 +49008,13 @@
         "jaJP": "暗い願い",
         "ptBR": "Desejos Mais Sombrios",
         "ruRU": "Самые темные желания",
-        "zhCN": "至暗之愿"
+        "zhCN": "最黑暗的愿望"
     },
     {
         "id": 51347,
         "Key": "Shadowed Plate",
         "enUS": "Shadowed Plate",
-        "zhTW": "附影之甲",
+        "zhTW": "阴影板",
         "deDE": "Beschattetes Schild",
         "esES": "Placa sombreada",
         "frFR": "Assiette ombragée",
@@ -49025,13 +49025,13 @@
         "jaJP": "シャドー・プレート",
         "ptBR": "Armadura Sombreada",
         "ruRU": "Теневая пластина",
-        "zhCN": "附影之甲"
+        "zhCN": "阴影板"
     },
     {
         "id": 51348,
         "Key": "Draven Coil",
         "enUS": "Draven Coil",
-        "zhTW": "德雷文指環",
+        "zhTW": "德拉文线圈",
         "deDE": "Drafenspule",
         "esES": "Bobina Draven",
         "frFR": "Bobine de Draven",
@@ -49042,13 +49042,13 @@
         "jaJP": "ドレイヴン・コイル",
         "ptBR": "Bobina Draven",
         "ruRU": "Катушка Дрейвена",
-        "zhCN": "德雷文之戒"
+        "zhCN": "德拉文线圈"
     },
     {
         "id": 51349,
         "Key": "The Warlord of Blood",
         "enUS": "The Warlord of Blood",
-        "zhTW": "血腥軍閥",
+        "zhTW": "血腥军阀",
         "deDE": "Der Kriegsherr des Blutes",
         "esES": "El Señor de la Sangre",
         "frFR": "Le seigneur de guerre du sang",
@@ -49065,7 +49065,7 @@
         "id": 51350,
         "Key": "Tortured Soul Gauntlets",
         "enUS": "Tortured Soul Gauntlets",
-        "zhTW": "苦痛的靈魂護手",
+        "zhTW": "折磨灵魂护手",
         "deDE": "Stulpen für gequälte Seelen",
         "esES": "Guanteletes Alma Torturada",
         "frFR": "Gantelets de l'âme torturée",
@@ -49076,13 +49076,13 @@
         "jaJP": "Tortured Soul ガントレット",
         "ptBR": "Luva das Almas Torturada",
         "ruRU": "Перчатки измученной души",
-        "zhCN": "苦痛的灵魂护手"
+        "zhCN": "折磨灵魂护手"
     },
     {
         "id": 51351,
         "Key": "Hell's Torment Greaves",
         "enUS": "Hell's Torment Greaves",
-        "zhTW": "地獄的折磨護脛",
+        "zhTW": "地狱折磨防弹衣",
         "deDE": "Höllenqualen-Gamaschen",
         "esES": "Grebas Tormento Infernal",
         "frFR": "Greaves de la tourmente de l'enfer",
@@ -49093,13 +49093,13 @@
         "jaJP": "ヘルズ・トーメント・グリーヴス",
         "ptBR": "Torres Tormento no Inferno",
         "ruRU": "Hell's Torment Greaves",
-        "zhCN": "地狱的折磨护胫"
+        "zhCN": "地狱折磨防弹衣"
     },
     {
         "id": 51352,
         "Key": "Bloody Visage Helm",
         "enUS": "Bloody Visage Helm",
-        "zhTW": "血腥的幻象面甲",
+        "zhTW": "血色幻象头盔",
         "deDE": "Blutige Visage Helm",
         "esES": "Yelmo Visaje Sangriento",
         "frFR": "Casque Bloody Visage",
@@ -49110,13 +49110,13 @@
         "jaJP": "ブラッディ・ヴィサージュ・ヘルム",
         "ptBR": "Elmo de Visage Sangrento",
         "ruRU": "Шлем Кровавого Визави",
-        "zhCN": "血腥的幻象面甲"
+        "zhCN": "血色幻象头盔"
     },
     {
         "id": 51353,
         "Key": "Vengeance Unleashed",
         "enUS": "Vengeance Unleashed",
-        "zhTW": "爆發的復仇",
+        "zhTW": "复仇释放",
         "deDE": "Entfesselte Rache",
         "esES": "Venganza desatada",
         "frFR": "La vengeance déchaînée",
@@ -49127,13 +49127,13 @@
         "jaJP": "復讐を解き放つ",
         "ptBR": "Soltar Vingança",
         "ruRU": "Развязанная месть",
-        "zhCN": "爆发的复仇"
+        "zhCN": "复仇释放"
     },
     {
         "id": 51354,
         "Key": "Elysian Fields",
         "enUS": "Elysian Fields",
-        "zhTW": "極樂淨土",
+        "zhTW": "极乐世界",
         "deDE": "Elysische Felder",
         "esES": "Campos Elíseos",
         "frFR": "Champs élyséens",
@@ -49144,13 +49144,13 @@
         "jaJP": "エリジアン・フィールズ",
         "ptBR": "Campos Elíseos",
         "ruRU": "Елисейские поля",
-        "zhCN": "极乐净土"
+        "zhCN": "极乐世界"
     },
     {
         "id": 51355,
         "Key": "Death and Decay",
         "enUS": "Death and Decay",
-        "zhTW": "死亡與腐朽",
+        "zhTW": "死亡与腐朽",
         "deDE": "Tod und Verfall",
         "esES": "Muerte y decadencia",
         "frFR": "Mort et décomposition",
@@ -49167,7 +49167,7 @@
         "id": 51356,
         "Key": "Darque Necromancy",
         "enUS": "Darque Necromancy",
-        "zhTW": "達爾克亡靈魔法",
+        "zhTW": "达尔克亡灵魔法",
         "deDE": "Darque Nekromantie",
         "esES": "Darque Necromancy",
         "frFR": "Nécromancie darque",
@@ -49184,7 +49184,7 @@
         "id": 51357,
         "Key": "Dying Curses",
         "enUS": "Dying Curses",
-        "zhTW": "垂死詛咒",
+        "zhTW": "临终诅咒",
         "deDE": "Sterbende Flüche",
         "esES": "Maldiciones moribundas",
         "frFR": "Malédictions de mort",
@@ -49195,13 +49195,13 @@
         "jaJP": "死にゆく呪い",
         "ptBR": "Maldições da Morte",
         "ruRU": "Предсмертные проклятия",
-        "zhCN": "垂死诅咒"
+        "zhCN": "临终诅咒"
     },
     {
         "id": 51358,
         "Key": "Lich's Rites",
         "enUS": "Lich's Rites",
-        "zhTW": "巫妖儀式",
+        "zhTW": "巫师的仪式",
         "deDE": "Die Riten des Lichs",
         "esES": "Ritos del Lich",
         "frFR": "Rites de la liche",
@@ -49212,13 +49212,13 @@
         "jaJP": "リヒトの儀式",
         "ptBR": "Ritos de Lich",
         "ruRU": "Обряды Лича",
-        "zhCN": "巫妖仪式"
+        "zhCN": "巫师的仪式"
     },
     {
         "id": 51359,
         "Key": "Twilight of Evil",
         "enUS": "Twilight of Evil",
-        "zhTW": "邪惡暮光",
+        "zhTW": "邪恶的黄昏",
         "deDE": "Die Dämmerung des Bösen",
         "esES": "El crepúsculo del mal",
         "frFR": "Le crépuscule du mal",
@@ -49229,13 +49229,13 @@
         "jaJP": "悪の黄昏",
         "ptBR": "Crepúsculo do Mal",
         "ruRU": "Сумерки зла",
-        "zhCN": "邪恶暮光"
+        "zhCN": "邪恶的黄昏"
     },
     {
         "id": 51360,
         "Key": "Dark Rituals",
         "enUS": "Dark Rituals",
-        "zhTW": "黑暗儀軌",
+        "zhTW": "黑暗仪式",
         "deDE": "Dunkle Rituale",
         "esES": "Rituales oscuros",
         "frFR": "Rituels obscurs",
@@ -49246,13 +49246,13 @@
         "jaJP": "闇の儀式",
         "ptBR": "Rituais das Trevas",
         "ruRU": "Темные ритуалы",
-        "zhCN": "黑暗仪轨"
+        "zhCN": "黑暗仪式"
     },
     {
         "id": 51361,
         "Key": "Legacy in Blood",
         "enUS": "Legacy in Blood",
-        "zhTW": "血脈傳承",
+        "zhTW": "血脉传承",
         "deDE": "Vermächtnis im Blut",
         "esES": "Legado de sangre",
         "frFR": "L'héritage du sang",
@@ -49269,7 +49269,7 @@
         "id": 51362,
         "Key": "Marhawkman's Disguise",
         "enUS": "Marhawkman's Disguise",
-        "zhTW": "馬哈克曼的僞裝",
+        "zhTW": "马哈克曼的伪装",
         "deDE": "Marhawkman's Verkleidung",
         "esES": "El disfraz de Marhawkman",
         "frFR": "Le déguisement de Marhawkman",
@@ -49286,7 +49286,7 @@
         "id": 51363,
         "Key": "Andariel's Claw",
         "enUS": "Andariel's Claw",
-        "zhTW": "安達莉爾的利爪",
+        "zhTW": "安达利尔之爪",
         "deDE": "Andariels Klaue",
         "esES": "Garra de Andariel",
         "frFR": "La griffe d'Andariel",
@@ -49297,13 +49297,13 @@
         "jaJP": "アンダリエルの爪",
         "ptBR": "Garra de Andariel",
         "ruRU": "Коготь Андариэль",
-        "zhCN": "安达莉尔的利爪"
+        "zhCN": "安达利尔之爪"
     },
     {
         "id": 51364,
         "Key": "Andariel's Hooves",
         "enUS": "Andariel's Hooves",
-        "zhTW": "安達莉爾的蹄子",
+        "zhTW": "安达利尔的蹄子",
         "deDE": "Andariels Hufe",
         "esES": "Pezuñas de Andariel",
         "frFR": "Les sabots d'Andariel",
@@ -49314,13 +49314,13 @@
         "jaJP": "アンダリエルの蹄",
         "ptBR": "Pé de Andariel",
         "ruRU": "Копыта Андариэль",
-        "zhCN": "安达莉尔的蹄子"
+        "zhCN": "安达利尔的蹄子"
     },
     {
         "id": 51365,
         "Key": "Andariel's Mask",
         "enUS": "Andariel's Mask",
-        "zhTW": "安達莉爾的面具",
+        "zhTW": "安达利尔的面具",
         "deDE": "Andariels Maske",
         "esES": "Máscara de Andariel",
         "frFR": "Le masque d'Andariel",
@@ -49331,13 +49331,13 @@
         "jaJP": "アンダリエルの仮面",
         "ptBR": "Máscara de Andariel",
         "ruRU": "Маска Андариэля",
-        "zhCN": "安达莉尔的面具"
+        "zhCN": "安达利尔的面具"
     },
     {
         "id": 51366,
         "Key": "Andariel's Breastbone",
         "enUS": "Andariel's Breastbone",
-        "zhTW": "安達莉爾的胸骨",
+        "zhTW": "安达利尔的胸骨",
         "deDE": "Andariels Brustbein",
         "esES": "Esternón de Andariel",
         "frFR": "Le sternum d'Andariel",
@@ -49348,13 +49348,13 @@
         "jaJP": "アンダリエルの胸骨",
         "ptBR": "Esterno de Andariel",
         "ruRU": "Грудная кость Андариэля",
-        "zhCN": "安达莉尔的胸骨"
+        "zhCN": "安达利尔的胸骨"
     },
     {
         "id": 51367,
         "Key": "t1 Splash Charm",
         "enUS": "ÿc4Collin's Lesser Mightÿc3",
-        "zhTW": "ÿc4科林之力【T1】ÿc3",
+        "zhTW": "ÿc4Collin's Lesser Mightÿc3",
         "deDE": "ÿc4Collins geringere Machtÿc3",
         "esES": "ÿc4Collin's Lesser Mightÿc3",
         "frFR": "ÿc4Collin's Lesser Mightÿc3",
@@ -49365,13 +49365,13 @@
         "jaJP": "ÿc4コリンズ・レッサー・マイトÿc3",
         "ptBR": "ÿc4Poder menor de Collinÿc3",
         "ruRU": "ÿc4Коллин \"Меньшее могущество\" ÿc3",
-        "zhCN": "ÿc4科林之力【T1】ÿc3"
+        "zhCN": "ÿc4Collin's Lesser Mightÿc3"
     },
     {
         "id": 51368,
         "Key": "t2 Splash Charm",
         "enUS": "ÿc4Collin's Minor Mightÿc3",
-        "zhTW": "ÿc4科林的力量【T2】ÿc3",
+        "zhTW": "ÿc4Collin's Minor Mightÿc3",
         "deDE": "ÿc4Collin's Minor Mightÿc3",
         "esES": "ÿc4Collin's Minor Mightÿc3",
         "frFR": "ÿc4Collin's Minor Mightÿc3",
@@ -49382,13 +49382,13 @@
         "jaJP": "ÿc4コリンズのマイナーマイトÿc3",
         "ptBR": "ÿc4Poder menor de Collinÿc3",
         "ruRU": "ÿc4Малое могущество Коллина ÿc3",
-        "zhCN": "ÿc4科林的力量【T2】ÿc3"
+        "zhCN": "ÿc4Collin's Minor Mightÿc3"
     },
     {
         "id": 51369,
         "Key": "t3 Splash Charm",
         "enUS": "ÿc4Collin's Mightÿc3",
-        "zhTW": "ÿc4科林的威力【T3】ÿc3",
+        "zhTW": "ÿc4Collin's Mightÿc3",
         "deDE": "ÿc4Collin's Mightÿc3",
         "esES": "ÿc4Collin's Mightÿc3",
         "frFR": "ÿc4Collin's Mightÿc3",
@@ -49399,13 +49399,13 @@
         "jaJP": "ÿc4コリンズ・マイトÿc3",
         "ptBR": "ÿc4Poder de Collinÿc3",
         "ruRU": "ÿc4Могущество Коллинаÿc3",
-        "zhCN": "ÿc4科林的威力【T3】ÿc3"
+        "zhCN": "ÿc4Collin's Mightÿc3"
     },
     {
         "id": 51370,
         "Key": "t4 Splash Charm",
         "enUS": "ÿc4Collin's Greater Mightÿc3",
-        "zhTW": "ÿc4科林的威能【T4】ÿc3",
+        "zhTW": "ÿc4Collin's Greater Mightÿc3",
         "deDE": "ÿc4Collins größere Machtÿc3",
         "esES": "ÿc4Collin's Greater Mightÿc3",
         "frFR": "ÿc4La plus grande puissance de Collinÿc3",
@@ -49416,13 +49416,13 @@
         "jaJP": "ÿc4コリンのグレーター・マイトÿc3",
         "ptBR": "ÿc4Maior poder de Collinÿc3",
         "ruRU": "ÿc4Большое могущество Коллина ÿc3",
-        "zhCN": "ÿc4科林的威能【T4】ÿc3"
+        "zhCN": "ÿc4Collin's Greater Mightÿc3"
     },
     {
         "id": 51371,
         "Key": "t5 Splash Charm",
         "enUS": "ÿc4Collin's Furyÿc3",
-        "zhTW": "ÿc4科林的憤怒【T5】ÿc3",
+        "zhTW": "ÿc4Collin's Furyÿc3",
         "deDE": "ÿc4Collin's Furyÿc3",
         "esES": "ÿc4Collin's Furyÿc3",
         "frFR": "ÿc4La fureur de Collinÿc3",
@@ -49433,13 +49433,13 @@
         "jaJP": "ÿc4コリンズ・フューリーÿc3",
         "ptBR": "ÿc4Fúria de Collinÿc3",
         "ruRU": "ÿc4Ярость Коллина ÿc3",
-        "zhCN": "ÿc4科林的愤怒【T5】ÿc3"
+        "zhCN": "ÿc4Collin's Furyÿc3"
     },
     {
         "id": 51372,
         "Key": "t6 Splash Charm",
         "enUS": "ÿc4Collin's Empowered Furyÿc3",
-        "zhTW": "ÿc4科林的暴怒【T6】ÿc3",
+        "zhTW": "ÿc4Collin's Empowered Furyÿc3",
         "deDE": "ÿc4Collins ermächtigte Wutÿc3",
         "esES": "ÿc4Collin's Empowered Furyÿc3",
         "frFR": "ÿc4Collin's Empowered Furyÿc3",
@@ -49450,13 +49450,13 @@
         "jaJP": "ÿc4コリンズ・エンパワード・フューリーÿc3",
         "ptBR": "ÿc4Fúria fortalecida de Collinÿc3",
         "ruRU": "ÿc4Вооруженная ярость Коллина ÿc3",
-        "zhCN": "ÿc4科林的暴怒【T6】ÿc3"
+        "zhCN": "ÿc4Collin's Empowered Furyÿc3"
     },
     {
         "id": 51373,
         "Key": "t7 Splash Charm",
         "enUS": "ÿc4Collin's Devastationÿc3",
-        "zhTW": "ÿc4科林的破壞【T7】ÿc3",
+        "zhTW": "ÿc4Collin's Devastationÿc3",
         "deDE": "ÿc4Collins Verwüstungÿc3",
         "esES": "ÿc4Collin's Devastationÿc3",
         "frFR": "ÿc4La dévastation de Collinÿc3",
@@ -49467,13 +49467,13 @@
         "jaJP": "ÿc4コリンズ・デバステーションÿc3",
         "ptBR": "ÿc4Devastação de Collinsÿc3",
         "ruRU": "ÿc4Знание безумцаÿc3",
-        "zhCN": "ÿc4科林的破坏【T7】ÿc3"
+        "zhCN": "ÿc4Collin's Devastationÿc3"
     },
     {
         "id": 51374,
         "Key": "t8 Splash Charm",
         "enUS": "ÿc4Collin's Furious Devastationÿc3",
-        "zhTW": "ÿc4科林的狂怒破壞【T8】ÿc3",
+        "zhTW": "ÿc4Collin's Furious Devastationÿc3",
         "deDE": "ÿc4Collins wütende Verwüstungÿc3",
         "esES": "ÿc4Collin's Furious Devastationÿc3",
         "frFR": "ÿc4Collin's Furious Devastationÿc3",
@@ -49484,13 +49484,13 @@
         "jaJP": "ÿc4コリンの猛烈な破壊ÿc3",
         "ptBR": "ÿc4Collin's Furious Devastationÿc3",
         "ruRU": "ÿc4Яростное опустошение Коллина ÿc3",
-        "zhCN": "ÿc4科林的狂怒破坏【T8】ÿc3"
+        "zhCN": "ÿc4Collin's Furious Devastationÿc3"
     },
     {
         "id": 51375,
-        "Key": "t9 Splash Charm",
+        "Key": "Collin's Destruction",
         "enUS": "ÿc4Collin's Destructionÿc3",
-        "zhTW": "ÿc4科林的毀滅ÿc3",
+        "zhTW": "ÿc4科林的毁灭ÿc3",
         "deDE": "ÿc4Collin's Zerstörungÿc3",
         "esES": "ÿc4Collin's Destructionÿc3",
         "frFR": "ÿc4La destruction de Collinÿc3",
@@ -49552,7 +49552,7 @@
         "jaJP": "ÿcTサファイア",
         "ptBR": "ÿcTSafira",
         "ruRU": "ÿcTсапфир",
-        "zhCN": "ÿcT蓝宝石"
+        "zhCN": "ÿcT无瑕的蓝宝石"
     },
     {
         "id": 51379,
@@ -49569,7 +49569,7 @@
         "jaJP": "ÿcTエメラルド",
         "ptBR": "ÿcTEsmeralda",
         "ruRU": "ÿcTизумруд",
-        "zhCN": "ÿcT绿宝石"
+        "zhCN": "ÿcT的绿宝石"
     },
     {
         "id": 51380,
@@ -49586,7 +49586,7 @@
         "jaJP": "ÿcTダイヤモンド",
         "ptBR": "ÿcTDiamante",
         "ruRU": "ÿcTбриллиант",
-        "zhCN": "ÿcT钻石"
+        "zhCN": "ÿcT的钻石"
     },
     {
         "id": 51381,
@@ -49603,7 +49603,7 @@
         "jaJP": "ÿcTルビー",
         "ptBR": "ÿcTRubi",
         "ruRU": "ÿcTрубин",
-        "zhCN": "ÿcT红宝石"
+        "zhCN": "ÿcT的红宝石"
     },
     {
         "id": 51382,
@@ -49620,13 +49620,13 @@
         "jaJP": "ÿcT頭蓋骨",
         "ptBR": "ÿcTCaveira",
         "ruRU": "ÿcTЧереп",
-        "zhCN": "ÿcT骷髅石"
+        "zhCN": "ÿcT头骨宝石"
     },
     {
         "id": 51383,
         "Key": "1am",
         "enUS": "ÿcTStack: Amethyst",
-        "zhTW": "ÿcT已堆疊：紫寶石",
+        "zhTW": "ÿcTStack：紫水晶",
         "deDE": "ÿcTStack: Amethyst",
         "esES": "ÿcTStack: Amatista",
         "frFR": "ÿcTStack : Améthyste",
@@ -49637,13 +49637,13 @@
         "jaJP": "ÿcTStackアメジスト",
         "ptBR": "ÿcTStack: Ametista",
         "ruRU": "ÿcTStack: Аметист",
-        "zhCN": "ÿcT已堆叠：紫宝石"
+        "zhCN": "ÿcTStack：紫水晶"
     },
     {
         "id": 51384,
         "Key": "1tp",
         "enUS": "ÿcTStack: Topaz",
-        "zhTW": "ÿcT已堆疊：黃寶石",
+        "zhTW": "ÿcTStack：黄玉",
         "deDE": "ÿcTStack: Topas",
         "esES": "ÿcTStack: Topaz",
         "frFR": "ÿcTStack : Topaze",
@@ -49654,13 +49654,13 @@
         "jaJP": "ÿcTトパーズ",
         "ptBR": "ÿcTStack: Topázio",
         "ruRU": "ÿcTStack: Topaz",
-        "zhCN": "ÿcT已堆叠：黄宝石"
+        "zhCN": "ÿcTStack：黄玉"
     },
     {
         "id": 51385,
         "Key": "1sa",
         "enUS": "ÿcTStack: Sapphire",
-        "zhTW": "ÿcT已堆疊：藍寶石",
+        "zhTW": "ÿcTStack：蓝宝石",
         "deDE": "ÿcTStack: Sapphire",
         "esES": "ÿcTStack: Zafiro",
         "frFR": "ÿcTStack : Saphir",
@@ -49671,13 +49671,13 @@
         "jaJP": "ÿcTタックサファイア",
         "ptBR": "ÿcTStack: Safira",
         "ruRU": "ÿcTStack: Сапфир",
-        "zhCN": "ÿcT已堆叠：蓝宝石"
+        "zhCN": "ÿcTStack：蓝宝石"
     },
     {
         "id": 51386,
         "Key": "1em",
         "enUS": "ÿcTStack: Emerald",
-        "zhTW": "ÿcT已堆疊：綠寶石",
+        "zhTW": "ÿcTStack：绿宝石",
         "deDE": "ÿcTStack: Smaragd",
         "esES": "ÿcTStack: Esmeralda",
         "frFR": "ÿcTStack : Émeraude",
@@ -49688,13 +49688,13 @@
         "jaJP": "ÿcTStackエメラルド",
         "ptBR": "ÿcTStack: Esmeralda",
         "ruRU": "ÿcTStack: Изумруд",
-        "zhCN": "ÿcT已堆叠：绿宝石"
+        "zhCN": "ÿcTStack：绿宝石"
     },
     {
         "id": 51387,
         "Key": "1di",
         "enUS": "ÿcTStack: Diamond",
-        "zhTW": "ÿcT已堆疊：鑽石",
+        "zhTW": "ÿcTStack：钻石",
         "deDE": "ÿcTStack: Diamant",
         "esES": "ÿcTStack: Diamante",
         "frFR": "ÿcTStack : Diamant",
@@ -49705,13 +49705,13 @@
         "jaJP": "ÿcTSタックダイヤモンド",
         "ptBR": "ÿcTStack: Diamante",
         "ruRU": "ÿcTStack: Алмаз",
-        "zhCN": "ÿcT已堆叠：钻石"
+        "zhCN": "ÿcTStack：钻石"
     },
     {
         "id": 51388,
         "Key": "1rb",
         "enUS": "ÿcTStack: Ruby",
-        "zhTW": "ÿcT已堆疊: 紅寶石",
+        "zhTW": "ÿcTStack: Ruby",
         "deDE": "ÿcTStack: Ruby",
         "esES": "ÿcTStack: Ruby",
         "frFR": "ÿcTStack : Ruby",
@@ -49722,13 +49722,13 @@
         "jaJP": "ÿcTルビー",
         "ptBR": "ÿcTStack: Ruby",
         "ruRU": "ÿcTStack: Ruby",
-        "zhCN": "ÿcT已堆叠: 红宝石"
+        "zhCN": "ÿcTStack: Ruby"
     },
     {
         "id": 51389,
         "Key": "1sk",
         "enUS": "ÿcTStack: Skull",
-        "zhTW": "ÿcT已堆疊：骷髏石",
+        "zhTW": "ÿcTStack：骷髅",
         "deDE": "ÿcTStack: Schädel",
         "esES": "ÿcTStack: Cráneo",
         "frFR": "ÿcTStack : Crâne",
@@ -49739,13 +49739,13 @@
         "jaJP": "ÿcT鋲：スカル",
         "ptBR": "ÿcTStack: Crânio",
         "ruRU": "ÿcTStack: Череп",
-        "zhCN": "ÿcT已堆叠：骷髅石"
+        "zhCN": "ÿcTStack：骷髅"
     },
     {
         "id": 51390,
         "Key": "Spinel Facet",
         "enUS": "ÿc4Spinel Facet",
-        "zhTW": "ÿc4尖晶刻面",
+        "zhTW": "ÿc4Spinel Facet",
         "deDE": "ÿc4Spinel-Facette",
         "esES": "ÿc4Faceta Espinela",
         "frFR": "ÿc4Facette de l'épingle",
@@ -49756,13 +49756,13 @@
         "jaJP": "ÿc4スピネルファセット",
         "ptBR": "ÿc4Face Safira",
         "ruRU": "ÿc4Спинельная фасетка",
-        "zhCN": "ÿc4尖晶刻面"
+        "zhCN": "ÿc4Spinel Facet"
     },
     {
         "id": 51391,
         "Key": "oos",
         "enUS": "ÿc3Orb of Socketing",
-        "zhTW": "ÿc3鑲嵌之球",
+        "zhTW": "ÿc3鏤孔寶珠",
         "deDE": "ÿc3Sockelungsorb",
         "esES": "ÿc3Orbe de Engarzado",
         "frFR": "ÿc3Orbe d’emboîtement",
@@ -49773,13 +49773,13 @@
         "jaJP": "ÿc3ソケット化のオーブ",
         "ptBR": "ÿc3Orbe de Engaste",
         "ruRU": "ÿc3Сфера Насечки",
-        "zhCN": "ÿc3镶嵌之球"
+        "zhCN": "ÿc3镶孔宝珠"
     },
     {
         "id": 51392,
         "Key": "ooc",
         "enUS": "ÿcLOrb of Conversion",
-        "zhTW": "ÿcL轉換之球[轉暗金]",
+        "zhTW": "ÿcL轉換寶珠",
         "deDE": "ÿcLUmwandlungsorb",
         "esES": "ÿcLOrbe de Conversión",
         "frFR": "ÿcLOrbe de Conversion",
@@ -49790,13 +49790,13 @@
         "jaJP": "ÿcL変換のオーブ",
         "ptBR": "ÿcLOrbe de Conversão",
         "ruRU": "ÿcLСфера Преобразования",
-        "zhCN": "ÿcL转换之球[转暗金]"
+        "zhCN": "ÿcL转换宝珠"
     },
     {
         "id": 51393,
         "Key": "Adamantine Links",
         "enUS": "Adamantine Links",
-        "zhTW": "金剛之鏈",
+        "zhTW": "金刚石链接",
         "deDE": "Adamantine Links",
         "esES": "Enlaces adamantinos",
         "frFR": "Liens Adamantine",
@@ -49807,13 +49807,13 @@
         "jaJP": "アダマンタイン・リンク",
         "ptBR": "Links de Adamantina",
         "ruRU": "Адамантиновые ссылки",
-        "zhCN": "金刚之链"
+        "zhCN": "金刚石链接"
     },
     {
         "id": 51394,
         "Key": "oosDescription",
         "enUS": "ÿc4up to that item type's max\na random number of sockets,\nCube with an item to add",
-        "zhTW": "ÿc4不超過該裝備的最大鑲孔數\n裝備獲得隨機鑲孔數\n與裝備一同放入Cube轉化",
+        "zhTW": "ÿc4隨機數量的插槽，\n最多可達該物品類型的上限，\n與物品放入方塊以添加",
         "deDE": "ÿc4bis zum Maximum des jeweiligen Gegenstandstyps\neine zufällige Anzahl an Sockeln,\nMit einem Gegenstand im Würfel kombinieren, um hinzuzufügen",
         "esES": "ÿc4hasta el máximo de ese tipo de objeto\nun número aleatorio de huecos,\nCubos con un objeto para añadir",
         "frFR": "ÿc4jusqu'au maximum de ce type d'objet\nun nombre aléatoire de châsses,\nUtilisez le Cube avec un objet pour ajouter",
@@ -49824,13 +49824,13 @@
         "jaJP": "ÿc4そのアイテムタイプの最大まで\nランダムなソケット数、\n追加するにはアイテムと一緒にキューブで使用",
         "ptBR": "ÿc4até o máximo desse tipo de item\num número aleatório de engastes,\nColoque no Cubo com um item para adicionar",
         "ruRU": "ÿc4до максимума для данного типа предмета\nслучайное количество гнезд,\nСовместите с предметом в Кубе для добавления",
-        "zhCN": "ÿc4不超过该装备的最大镶孔数\n装备获得随机镶孔数\n与物品一同放入Cube转化"
+        "zhCN": "ÿc4随机数量的插槽，\n最高为该物品类型上限，\n与物品放进方块可添加"
     },
     {
         "id": 51395,
         "Key": "oocDescription",
         "enUS": "ÿc4to upgrade it to Unique\nCube with a Rare item",
-        "zhTW": "ÿc4 裝備升級为暗金版\n與稀有裝備一同放入Cube轉化",
+        "zhTW": "ÿc4將其升級為唯一\n與稀有物品放入方塊",
         "deDE": "ÿc4um es zu einem Einzigartigen aufzuwerten\nWürfle mit einem seltenen Gegenstand",
         "esES": "ÿc4para mejorarlo a Único\nCubos con un objeto raro",
         "frFR": "ÿc4pour l'améliorer en Unique\nUtilisez le Cube avec un objet Rare",
@@ -49841,7 +49841,7 @@
         "jaJP": "ÿc4ユニークにアップグレードするために\nレアアイテムと一緒にキューブで使用",
         "ptBR": "ÿc4para atualizar para Único\nColoque no Cubo com um item raro",
         "ruRU": "ÿc4для улучшения до Уникального\nСовместите с редким предметом в Кубе",
-        "zhCN": "ÿc4 装备升级为暗金版\n与稀有物品一同放入Cube转化"
+        "zhCN": "ÿc4升级为唯一物品\n与稀有物品放进方块"
     },
     {
         "id": 51396,
@@ -49864,7 +49864,7 @@
         "id": 51397,
         "Key": "ooa",
         "enUS": "ÿcAOrb of Assemblage",
-        "zhTW": "ÿcA集聚之球",
+        "zhTW": "ÿcA組裝寶珠",
         "deDE": "ÿcAVersammlungs-Orb",
         "esES": "ÿcAOrbe de Ensamblaje",
         "frFR": "ÿcAOrbe d’Assemblage",
@@ -49875,13 +49875,13 @@
         "jaJP": "ÿcAアセンブリのオーブ",
         "ptBR": "ÿcAOrbe de Montagem",
         "ruRU": "ÿcAСфера Сборки",
-        "zhCN": "ÿcA集聚之球"
+        "zhCN": "ÿcA组装宝珠"
     },
     {
         "id": 51398,
         "Key": "ooaDescription",
         "enUS": "ÿc4to upgrade it to Set\nCube with a Rare item",
-        "zhTW": "ÿc4裝備升級为套裝版\n與稀有裝備一同放入Cube轉化",
+        "zhTW": "ÿc4將其升級為套裝\n與稀有物品合成立方",
         "deDE": "ÿc4um es zu einem Set aufzuwerten\nWürfle mit einem seltenen Gegenstand",
         "esES": "ÿc4para mejorarlo a Conjunto\nCúbalo con un objeto raro",
         "frFR": "ÿc4pour l’améliorer en Ensemble\nTransmutez avec un objet rare",
@@ -49892,13 +49892,13 @@
         "jaJP": "ÿc4セットにアップグレードするには\nレアアイテムとキューブで合成",
         "ptBR": "ÿc4para aprimorar para Conjunto\nTransmute com um item raro",
         "ruRU": "ÿc4чтобы улучшить до набора\nСоедините с редким предметом в Кубе",
-        "zhCN": "ÿc4装备升级为套装版\n与稀有物品一同放入Cube转化"
+        "zhCN": "ÿc4升级为套装\n与稀有物品在方块中合成"
     },
     {
         "id": 51399,
         "Key": "gemStackDescription",
         "enUS": "ÿc4Stack + Gem = Merge\nStack = Unstack 1 Gem\nCube Recipes:",
-        "zhTW": "ÿc4寶石袋 + 寶石（可多個）= 合并\n寶石袋 = 提取 1 个寶石\nCube公式：",
+        "zhTW": "ÿc4堆疊 + 寶石 = 合併\n堆疊 = 分解 1 顆寶石\n合成立方配方：",
         "deDE": "ÿc4Stapel + Edelstein = Zusammenführen\nStapel = 1 Edelstein entstapeln\nWürfelrezepte:",
         "esES": "ÿc4Pila + Gema = Combinar\nPila = Separar 1 Gema\nRecetas de Cubo:",
         "frFR": "ÿc4Pile + Gemme = Fusion\nPile = Détacher 1 gemme\nRecettes du Cube :",
@@ -49909,13 +49909,13 @@
         "jaJP": "ÿc4スタック＋ジェム＝合成\nスタック＝ジェム1個分離\nキューブレシピ：",
         "ptBR": "ÿc4Pilha + Gema = Fundir\nPilha = Separar 1 Gema\nReceitas do Cubo:",
         "ruRU": "ÿc4Стек + самоцвет = Объединить\nСтек = Разделить 1 самоцвет\nРецепты куба:",
-        "zhCN": "ÿc4宝石袋 + 宝石（可多个） = 合并\n堆栈 = 提取 1 个宝石\nCube公式："
+        "zhCN": "ÿc4堆叠+宝石=合并\n堆叠=分拆1颗宝石\n方块配方："
     },
     {
         "id": 51400,
         "Key": "runeStackDescription",
         "enUS": "ÿc4ID Tome + Stack = Downgrade\nTP Tome + Stack = Upgrade\nStack + Rune = Merge\nStack = Unstack 1 Rune\nCube Recipes:",
-        "zhTW": "ÿc4鑒定書 + 符文堆 = 低1級符文（1換1）\n回城書 + 符文堆 = 高1級符文（2換1）\n符文堆 + 符文 = 合并\n符文堆 = 提取 1 個符文\nCube公式：",
+        "zhTW": "ÿc4鑑定之書 + 堆疊 = 降級\n傳送之書 + 堆疊 = 升級\n堆疊 + 符文 = 合併\n堆疊 = 分解 1 顆符文\n合成立方配方：",
         "deDE": "ÿc4ID-Buch + Stapel = Herabstufen\nTP-Buch + Stapel = Aufwerten\nStapel + Rune = Zusammenführen\nStapel = 1 Rune entstapeln\nWürfelrezepte:",
         "esES": "ÿc4Tomo de ID + Pila = Degradar\nTomo de TP + Pila = Mejorar\nPila + Runa = Combinar\nPila = Separar 1 Runa\nRecetas de Cubo:",
         "frFR": "ÿc4Tome d’ID + Pile = Dégrader\nTome de TP + Pile = Améliorer\nPile + Rune = Fusion\nPile = Détacher 1 rune\nRecettes du Cube :",
@@ -49926,13 +49926,13 @@
         "jaJP": "ÿc4鑑定書+スタック＝ダウングレード\nTP書+スタック＝アップグレード\nスタック＋ルーン＝合成\nスタック＝ルーン1個分離\nキューブレシピ：",
         "ptBR": "ÿc4Tomo de ID + Pilha = Rebaixar\nTomo de TP + Pilha = Subir\nPilha + Runa = Fundir\nPilha = Separar 1 Runa\nReceitas do Cubo:",
         "ruRU": "ÿc4Том ИД + стек = Понизить\nТом ТП + стек = Улучшить\nСтек + руна = Объединить\nСтек = Разделить 1 руну\nРецепты куба:",
-        "zhCN": "ÿc4鉴定书 + 符文堆 = 低1级符文（1换1）\n回城书 + 符文堆 = 高1级符文（2换1）\n符文堆 + 符文 = 合并\n符文堆 = 提取 1 个符文\nCube公式："
+        "zhCN": "ÿc4鉴定之书+堆叠=降级\n传送之书+堆叠=升级\n堆叠+符文=合并\n堆叠=分拆1颗符文\n方块配方："
     },
     {
         "id": 51401,
         "Key": "keyGrabberDescription",
         "enUS": "ÿc4to retrieve a Key \n Cube with the Keychain",
-        "zhTW": "ÿc4提取一把鑰匙\n 與鑰匙串一起放入Cube轉化",
+        "zhTW": "ÿc4取回鑰匙\n與鑰匙圈一起放入立方體",
         "deDE": "ÿc4um einen Schlüssel zu erhalten\nWürfle mit dem Schlüsselbund",
         "esES": "ÿc4para recuperar una llave\nCubo con el llavero",
         "frFR": "ÿc4pour récupérer une clé\nUtilisez la clé avec le Porte-clés dans le Cube",
@@ -49943,13 +49943,13 @@
         "jaJP": "ÿc4キーを取り出すには\nキーチェーンと一緒にキューブで合成",
         "ptBR": "ÿc4para recuperar uma chave\nCubra com o chaveiro",
         "ruRU": "ÿc4чтобы получить ключ\nКубируйте с брелком для ключей",
-        "zhCN": "ÿc4提取一把钥匙\n 与钥匙串一起放入Cube转化"
+        "zhCN": "ÿc4取回钥匙\n与钥匙链一起放入方块"
     },
     {
         "id": 51402,
         "Key": "gemGrabberDescription",
         "enUS": "ÿc4to retrieve a gem \n Cube with the Gem Bag",
-        "zhTW": "ÿc4提取一個寶石\n 與寶石袋一起放入Cube轉化",
+        "zhTW": "ÿc4取回寶石\n與寶石袋一起放入立方體",
         "deDE": "ÿc4um einen Edelstein zu erhalten\nWürfle mit dem Edelsteinsäckchen",
         "esES": "ÿc4para recuperar una gema\nCubo con la bolsa de gemas",
         "frFR": "ÿc4pour récupérer une gemme\nUtilisez le Sac de Gemmes dans le Cube",
@@ -49960,13 +49960,13 @@
         "jaJP": "ÿc4ジェムを取り出すには\nジェムバッグと一緒にキューブで合成",
         "ptBR": "ÿc4para recuperar uma gema\nCubra com o saco de gemas",
         "ruRU": "ÿc4чтобы получить самоцвет\nКубируйте с мешком самоцветов",
-        "zhCN": "ÿc4提取一個宝石\n 与宝石袋一起放入Cube转化"
+        "zhCN": "ÿc4取回宝石\n与宝石袋一起放入方块"
     },
     {
         "id": 51403,
         "Key": "inferiorGemDescription",
         "enUS": "ÿcU--------------------\nCube with gem bag to add a gem credit\nDoes not work in recipes\nObsolete gem\n--------------------",
-        "zhTW": "ÿcU--------------------\n與寶石袋一起放入Cube轉化可添加寶石纍積值\n不可用於公式\n过时的寶石\n--------------------",
+        "zhTW": "ÿcU--------------------\n與寶石袋一起放入立方體以增加寶石點數\n無法用於合成配方\n過時的寶石\n--------------------",
         "deDE": "ÿcU--------------------\nWürfle mit dem Edelsteinsäckchen, um ein Edelstein-Guthaben hinzuzufügen\nFunktioniert nicht in Rezepten\nVeralteter Edelstein\n--------------------",
         "esES": "ÿcU--------------------\nCubo con bolsa de gemas para añadir crédito de gema\nNo funciona en recetas\nGema obsoleta\n--------------------",
         "frFR": "ÿcU--------------------\nUtilisez le Cube avec un Sac de Gemmes pour ajouter un crédit de gemme\nNe fonctionne pas dans les recettes\nGemme obsolète\n--------------------",
@@ -49977,13 +49977,13 @@
         "jaJP": "ÿcU--------------------\nジェムバッグと一緒にキューブで使うとジェムクレジットを追加\nレシピでは使えません\n旧式のジェム\n--------------------",
         "ptBR": "ÿcU--------------------\nCubra com o saco de gemas para adicionar crédito de gema\nNão funciona em receitas\nGema obsoleta\n--------------------",
         "ruRU": "ÿcU--------------------\nКубируйте с мешком самоцветов, чтобы добавить кредит самоцвета\nНе работает в рецептах\nУстаревший самоцвет\n--------------------",
-        "zhCN": "ÿcU--------------------\n与宝石袋一起放入Cube转化可添加宝石累积值\n不可用于公式\n过时的宝石\n--------------------"
+        "zhCN": "ÿcU--------------------\n与宝石袋一起放入方块以添加宝石积分\n无法用于合成配方\n过时的宝石\n--------------------"
     },
     {
         "id": 51404,
         "Key": "Spring Facet",
         "enUS": "ÿc4Spring Facet",
-        "zhTW": "ÿc4春之刻面",
+        "zhTW": "ÿc4春之面",
         "deDE": "ÿc4Frühlingsfacet",
         "esES": "ÿc4Faceta de Primavera",
         "frFR": "ÿc4Facette de Printemps",
@@ -49994,13 +49994,13 @@
         "jaJP": "ÿc4春の面",
         "ptBR": "ÿc4Faceta da Primavera",
         "ruRU": "ÿc4Весенняя грань",
-        "zhCN": "ÿc4春之刻面"
+        "zhCN": "ÿc4春之面"
     },
     {
         "id": 51405,
         "Key": "Winter Facet",
         "enUS": "ÿc4Winter Facet",
-        "zhTW": "ÿc4冬之刻面",
+        "zhTW": "ÿc4冬之面",
         "deDE": "ÿc4Winterfacet",
         "esES": "ÿc4Faceta de Invierno",
         "frFR": "ÿc4Facette d'Hiver",
@@ -50011,13 +50011,13 @@
         "jaJP": "ÿc4冬の面",
         "ptBR": "ÿc4Faceta do Inverno",
         "ruRU": "ÿc4Зимняя грань",
-        "zhCN": "ÿc4冬之刻面"
+        "zhCN": "ÿc4冬之面"
     },
     {
         "id": 51406,
         "Key": "Summer Facet",
         "enUS": "ÿc4Summer Facet",
-        "zhTW": "ÿc4夏之刻面",
+        "zhTW": "ÿc4夏之面",
         "deDE": "ÿc4Sommerfacet",
         "esES": "ÿc4Faceta de Verano",
         "frFR": "ÿc4Facette d'Été",
@@ -50028,13 +50028,13 @@
         "jaJP": "ÿc4夏の面",
         "ptBR": "ÿc4Faceta do Verão",
         "ruRU": "ÿc4Летняя грань",
-        "zhCN": "ÿc4夏之刻面"
+        "zhCN": "ÿc4夏之面"
     },
     {
         "id": 51407,
         "Key": "Autumn Facet",
         "enUS": "ÿc4Autumn Facet",
-        "zhTW": "ÿc4秋之刻面",
+        "zhTW": "ÿc4秋之面",
         "deDE": "ÿc4Herbstfacet",
         "esES": "ÿc4Faceta de Otoño",
         "frFR": "ÿc4Facette d'Automne",
@@ -50045,13 +50045,13 @@
         "jaJP": "ÿc4秋の面",
         "ptBR": "ÿc4Faceta do Outono",
         "ruRU": "ÿc4Осенняя грань",
-        "zhCN": "ÿc4秋之刻面"
+        "zhCN": "ÿc4秋之面"
     },
     {
         "id": 51408,
         "Key": "Thunder Facet",
         "enUS": "ÿc4Thunder Facet",
-        "zhTW": "ÿc4雷之刻面",
+        "zhTW": "ÿc4雷之面",
         "deDE": "ÿc4Donnerfacet",
         "esES": "ÿc4Faceta de Trueno",
         "frFR": "ÿc4Facette de Tonnerre",
@@ -50062,13 +50062,13 @@
         "jaJP": "ÿc4雷の面",
         "ptBR": "ÿc4Faceta do Trovão",
         "ruRU": "ÿc4Громовая грань",
-        "zhCN": "ÿc4雷之刻面"
+        "zhCN": "ÿc4雷之面"
     },
     {
         "id": 51409,
         "Key": "Rime Facet",
         "enUS": "ÿc4Rime Facet",
-        "zhTW": "ÿc4霧凇刻面",
+        "zhTW": "ÿc4霜之面",
         "deDE": "ÿc4Reiffacet",
         "esES": "ÿc4Faceta de Escarcha",
         "frFR": "ÿc4Facette de Givre",
@@ -50079,13 +50079,13 @@
         "jaJP": "ÿc4霜の面",
         "ptBR": "ÿc4Faceta da Geada",
         "ruRU": "ÿc4Инейная грань",
-        "zhCN": "ÿc4雾凇刻面"
+        "zhCN": "ÿc4霜之面"
     },
     {
         "id": 51410,
         "Key": "Burnt Facet",
         "enUS": "ÿc4Burnt Facet",
-        "zhTW": "ÿc4灼燒刻面",
+        "zhTW": "ÿc4燒之面",
         "deDE": "ÿc4Verbranntes Facet",
         "esES": "ÿc4Faceta Quemada",
         "frFR": "ÿc4Facette Brûlée",
@@ -50096,13 +50096,13 @@
         "jaJP": "ÿc4焼けた面",
         "ptBR": "ÿc4Faceta Queimada",
         "ruRU": "ÿc4Обожженная грань",
-        "zhCN": "ÿc4灼烧刻面"
+        "zhCN": "ÿc4烧之面"
     },
     {
         "id": 51411,
         "Key": "Toxic Facet",
         "enUS": "ÿc4Toxic Facet",
-        "zhTW": "ÿc4劇毒刻面",
+        "zhTW": "ÿc4毒之面",
         "deDE": "ÿc4Giftfacet",
         "esES": "ÿc4Faceta Tóxica",
         "frFR": "ÿc4Facette Toxique",
@@ -50113,7 +50113,7 @@
         "jaJP": "ÿc4毒の面",
         "ptBR": "ÿc4Faceta Tóxica",
         "ruRU": "ÿc4Ядовитая грань",
-        "zhCN": "ÿc4剧毒刻面"
+        "zhCN": "ÿc4毒之面"
     },
     {
         "id": 51412,
@@ -50136,7 +50136,7 @@
         "id": 51413,
         "Key": "Dreadwall",
         "enUS": "Dreadwall",
-        "zhTW": "恐懼之墻",
+        "zhTW": "恐惧墙",
         "deDE": "Dreadwall",
         "esES": "Dreadwall",
         "frFR": "Mur d'effroi",
@@ -50147,13 +50147,13 @@
         "jaJP": "ドレッドウォール",
         "ptBR": "Dreadwall",
         "ruRU": "Дредволл",
-        "zhCN": "恐惧之墙"
+        "zhCN": "恐惧墙"
     },
     {
         "id": 51414,
         "Key": "Summon Armor",
         "enUS": "Summon Armor",
-        "zhTW": "召喚盔甲",
+        "zhTW": "召唤盔甲",
         "deDE": "Rüstung beschwören",
         "esES": "Invocar armadura",
         "frFR": "Invoquer une armure",
@@ -50170,7 +50170,7 @@
         "id": 51415,
         "Key": "1ka",
         "enUS": "ÿc8Stack: Orb of Corruption",
-        "zhTW": "ÿc8已堆疊：腐化之球",
+        "zhTW": "ÿc8堆疊：腐化寶珠",
         "deDE": "ÿc8Stapel: Kugel der Verderbnis",
         "esES": "ÿc8Montón: Orbe de Corrupción",
         "frFR": "ÿc8Pile : Orbe de corruption",
@@ -50181,13 +50181,13 @@
         "jaJP": "ÿc8スタック：堕落のオーブ",
         "ptBR": "ÿc8Pilha: Orbe de Corrupção",
         "ruRU": "ÿc8Стопка: Сфера порчи",
-        "zhCN": "ÿc8已堆叠：腐化之球"
+        "zhCN": "ÿc8堆叠：腐化宝珠"
     },
     {
         "id": 51416,
         "Key": "1os",
         "enUS": "ÿc8Stack: Orb of Socketing",
-        "zhTW": "ÿc8已堆疊：鑲嵌之球",
+        "zhTW": "ÿc8堆疊：鑲孔寶珠",
         "deDE": "ÿc8Stapel: Sockel-Kugel",
         "esES": "ÿc8Montón: Orbe de Engarzado",
         "frFR": "ÿc8Pile : Orbe d'emboîtement",
@@ -50198,13 +50198,13 @@
         "jaJP": "ÿc8スタック：ソケット付与のオーブ",
         "ptBR": "ÿc8Pilha: Orbe de Engaste",
         "ruRU": "ÿc8Стопка: Сфера инкрустации",
-        "zhCN": "ÿc8已堆叠：镶嵌之球"
+        "zhCN": "ÿc8堆叠：开孔宝珠"
     },
     {
         "id": 51417,
         "Key": "1oc",
         "enUS": "ÿc8Stack: Orb of Conversion",
-        "zhTW": "ÿc8已堆疊：轉換之球",
+        "zhTW": "ÿc8堆疊：轉換寶珠",
         "deDE": "ÿc8Stapel: Umwandlungs-Kugel",
         "esES": "ÿc8Montón: Orbe de Conversión",
         "frFR": "ÿc8Pile : Orbe de conversion",
@@ -50215,13 +50215,13 @@
         "jaJP": "ÿc8スタック：変換のオーブ",
         "ptBR": "ÿc8Pilha: Orbe de Conversão",
         "ruRU": "ÿc8Стопка: Сфера превращения",
-        "zhCN": "ÿc8已堆叠：转换之球"
+        "zhCN": "ÿc8堆叠：转化宝珠"
     },
     {
         "id": 51418,
         "Key": "1oa",
         "enUS": "ÿc8Stack: Orb of Assemblage",
-        "zhTW": "ÿc8已堆疊：集聚之球",
+        "zhTW": "ÿc8堆疊：組合寶珠",
         "deDE": "ÿc8Stapel: Verbindungs-Kugel",
         "esES": "ÿc8Montón: Orbe de Ensamblaje",
         "frFR": "ÿc8Pile : Orbe d’assemblage",
@@ -50232,13 +50232,13 @@
         "jaJP": "ÿc8スタック：アセンブリーオーブ",
         "ptBR": "ÿc8Pilha: Orbe de Montagem",
         "ruRU": "ÿc8Стопка: Сфера соединения",
-        "zhCN": "ÿc8已堆叠：集聚之球"
+        "zhCN": "ÿc8堆叠：组合宝珠"
     },
     {
         "id": 51419,
         "Key": "1oi",
         "enUS": "ÿc8Stack: Orb of Infusion",
-        "zhTW": "ÿc8已堆疊：灌注之球",
+        "zhTW": "ÿc8堆疊：灌注寶珠",
         "deDE": "ÿc8Stapel: Infusions-Kugel",
         "esES": "ÿc8Montón: Orbe de Infusión",
         "frFR": "ÿc8Pile : Orbe d’infusion",
@@ -50249,13 +50249,13 @@
         "jaJP": "ÿc8スタック：インフュージョンオーブ",
         "ptBR": "ÿc8Pilha: Orbe de Infusão",
         "ruRU": "ÿc8Стопка: Сфера наложения",
-        "zhCN": "ÿc8已堆叠：灌注之球"
+        "zhCN": "ÿc8堆叠：灌注宝珠"
     },
     {
         "id": 51420,
         "Key": "orbStackDescription",
         "enUS": "ÿc4Stack + Orb = Merge\nStack = Unstack 1 Orb\nCube Recipes:",
-        "zhTW": "ÿc4能量球組 + 單個能量球 = 合并\n能量球組 = 提取 1 个能量球\nCube公式：",
+        "zhTW": "ÿc4堆疊 + 寶珠 = 合併\n堆疊 = 拆分 1 顆寶珠\n赫拉迪姆方塊配方：",
         "deDE": "ÿc4Stapel + Kugel = Verschmelzen\nStapel = 1 Kugel entnehmen\nWürfelrezepte:",
         "esES": "ÿc4Montón + Orbe = Unir\nMontón = Separar 1 Orbe\nRecetas del Cubo:",
         "frFR": "ÿc4Pile + Orbe = Fusionner\nPile = Séparer 1 Orbe\nRecettes du Cube :",
@@ -50266,13 +50266,13 @@
         "jaJP": "ÿc4スタック＋オーブ＝合成\nスタック＝オーブ1個を分離\nキューブレシピ：",
         "ptBR": "ÿc4Pilha + Orbe = Mesclar\nPilha = Separar 1 Orbe\nReceitas do Cubo:",
         "ruRU": "ÿc4Стопка + Сфера = Объединить\nСтопка = Разделить 1 сферу\nРецепты Куба:",
-        "zhCN": "ÿc4能量球组 + 单个能量球 = 合并\n能量球组 = 提取 1 个能量球\nCube公式："
+        "zhCN": "ÿc4堆叠 + 宝珠 = 合并\n堆叠 = 拆分 1 个宝珠\n赫拉迪姆方块配方："
     },
     {
         "id": 51421,
         "Key": "ooi",
         "enUS": "ÿcROrb of Infusion",
-        "zhTW": "ÿcR灌注之球",
+        "zhTW": "ÿcR灌注之寶珠",
         "deDE": "ÿcRInfusionskugel",
         "esES": "ÿcROrbe de infusión",
         "frFR": "ÿcROrbe d’infusion",
@@ -50283,13 +50283,13 @@
         "jaJP": "ÿcRインフュージョンオーブ",
         "ptBR": "ÿcROrbe de Infusão",
         "ruRU": "ÿcRСфера внедрения",
-        "zhCN": "ÿcR灌注之球"
+        "zhCN": "ÿcR灌注之宝珠"
     },
     {
         "id": 51422,
         "Key": "ooiDescription",
         "enUS": "ÿc4to upgrade it to Rare\nor Magic Jewelry\nCube with a White Item",
-        "zhTW": "ÿc4将其升級为稀有\n與白色物品或魔法首飾一同放入Cube轉化",
+        "zhTW": "ÿc4將其升級為稀有或魔法首飾\n與白色物品放入方塊",
         "deDE": "ÿc4um es zu seltenem oder magischem Schmuck aufzuwerten\nKombiniere mit einem weißen Gegenstand im Würfel",
         "esES": "ÿc4para mejorarlo a raro o joyería mágica\nCubos con un objeto blanco",
         "frFR": "ÿc4pour l'améliorer en bijou rare ou magique\nTransmutez avec un objet blanc",
@@ -50300,13 +50300,13 @@
         "jaJP": "ÿc4レアまたはマジックジュエリーにアップグレード\n白アイテムとキューブで合成",
         "ptBR": "ÿc4para aprimorar para Joia Rara ou Mágica\nCubos com um item branco",
         "ruRU": "ÿc4для улучшения до редкого или магического украшения\nКуб с белым предметом",
-        "zhCN": "ÿc4将其升级为稀有\n与白色物品或魔法首饰一同放入Cube转化"
+        "zhCN": "ÿc4升级为稀有或魔法首饰\n与白色物品放入方块"
     },
     {
         "id": 51423,
         "Key": "Quiver of Amplified Slaying",
         "enUS": "Quiver of Amplified Slaying",
-        "zhTW": "放大杀戮之箭袋",
+        "zhTW": "放大杀戮之箭筒",
         "deDE": "Köcher der verstärkten Tötung",
         "esES": "Carcaj de matanza amplificado",
         "frFR": "Carquois d'assassinat amplifié",
@@ -50317,13 +50317,13 @@
         "jaJP": "増幅された殺しの矢筒",
         "ptBR": "Aljava de Caça Amplificada",
         "ruRU": "Колчан усиленного истребления",
-        "zhCN": "放大杀戮之箭袋"
+        "zhCN": "放大杀戮之箭筒"
     },
     {
         "id": 51424,
         "Key": "Quiver of Resistance Slaying",
         "enUS": "Quiver of Resistance Slaying",
-        "zhTW": "穿抗杀戮之箭袋",
+        "zhTW": "抵抗者之剑",
         "deDE": "Köcher des Widerstands Tötung",
         "esES": "Carcaj de la Resistencia",
         "frFR": "Carquois de la résistance",
@@ -50334,13 +50334,13 @@
         "jaJP": "抵抗退治の矢筒",
         "ptBR": "Aljava de Caça à Resistência",
         "ruRU": "Колчан истребления сопротивления",
-        "zhCN": "穿抗杀戮之箭袋"
+        "zhCN": "抵抗者之剑"
     },
     {
         "id": 51425,
         "Key": "Bolt Case of Amplified Slaying",
         "enUS": "Bolt Case of Amplified Slaying",
-        "zhTW": "放大杀戮之矢袋",
+        "zhTW": "放大杀戮的螺栓案例",
         "deDE": "Bolzenfall der verstärkten Tötung",
         "esES": "Caso del perno de la matanza amplificada",
         "frFR": "L'affaire des boulons de l'assassinat amplifié",
@@ -50351,13 +50351,13 @@
         "jaJP": "増幅された殺しのボルト事件",
         "ptBR": "Caso Bolt de matança amplificada",
         "ruRU": "Дело о болтах для усиленного истребления",
-        "zhCN": "放大杀戮之矢袋"
+        "zhCN": "放大杀戮的螺栓案例"
     },
     {
         "id": 51426,
         "Key": "Bolt Case of Resistance Slaying",
         "enUS": "Bolt Case of Resistance Slaying",
-        "zhTW": "抵抗杀戮之矢袋",
+        "zhTW": "击毙抵抗分子的螺栓案例",
         "deDE": "Bolzenfall der Widerstandstötung",
         "esES": "Caso del perno de la resistencia",
         "frFR": "Cas d'assassinat de résistants",
@@ -50368,13 +50368,13 @@
         "jaJP": "レジスタンス殺しのボルト事件",
         "ptBR": "Caso Bolt de assassinato de resistentes",
         "ruRU": "Дело о болтах для истребления сопротивляющихся",
-        "zhCN": "抵抗杀戮之矢袋"
+        "zhCN": "击毙抵抗分子的螺栓案例"
     },
     {
         "id": 51427,
         "Key": "1oe",
         "enUS": "ÿc8Stack: Orb of Shadows",
-        "zhTW": "ÿc8已堆疊：陰影之球",
+        "zhTW": "ÿc8堆疊：暗影寶珠",
         "deDE": "ÿc8Stapel: Schattenkugel",
         "esES": "ÿc8Montón: Orbe de las Sombras",
         "frFR": "ÿc8Pile : Orbe des Ombres",
@@ -50385,13 +50385,13 @@
         "jaJP": "ÿc8スタック：シャドウオーブ",
         "ptBR": "ÿc8Pilha: Orbe das Sombras",
         "ruRU": "ÿc8Стопка: Сфера Теней",
-        "zhCN": "ÿc8已堆叠：阴影之球"
+        "zhCN": "ÿc8堆叠：暗影宝珠"
     },
     {
         "id": 51428,
         "Key": "ooe",
         "enUS": "ÿc;Orb of Shadows",
-        "zhTW": "ÿc;陰影之球",
+        "zhTW": "ÿc;暗影寶珠",
         "deDE": "ÿc;Schattenkugel",
         "esES": "ÿc;Orbe de las Sombras",
         "frFR": "ÿc;Orbe des Ombres",
@@ -50402,13 +50402,13 @@
         "jaJP": "ÿc;シャドウオーブ",
         "ptBR": "ÿc;Orbe das Sombras",
         "ruRU": "ÿc;Сфера Теней",
-        "zhCN": "ÿc;阴影之球"
+        "zhCN": "ÿc;暗影宝珠"
     },
     {
         "id": 51429,
         "Key": "ooeDescription",
         "enUS": "ÿc4to make it Ethereal\nCube with an item",
-        "zhTW": "ÿc4使其轉爲無形\n與裝備一起放入Cube轉化",
+        "zhTW": "ÿc4使其變為無形\n與物品一起放入魔方",
         "deDE": "ÿc4Um es ätherisch zu machen\nMit einem Gegenstand in den Würfel legen",
         "esES": "ÿc4Para hacerlo etéreo\nCubra con un objeto",
         "frFR": "ÿc4Pour le rendre éthéré\nTransmutez avec un objet",
@@ -50419,13 +50419,13 @@
         "jaJP": "ÿc4エセリアル化するには\nアイテムと一緒にキューブに入れる",
         "ptBR": "ÿc4Para torná-lo Etéreo\nCubra com um item",
         "ruRU": "ÿc4Чтобы сделать его эфирным\nПоместите с предметом в куб",
-        "zhCN": "ÿc4使其转为无形\n与装备一起放入Cube转化"
+        "zhCN": "ÿc4使其成为无形\n与物品一起放入方块"
     },
     {
         "id": 51430,
         "Key": "GemBagDescription",
         "enUS": "ÿc4when crafting new items\nUsed as Gem reagent\n\nBag + Grabber = Retrieve Gem\n Bag + Assorted Gems = Add Gems\nCube Recipes:\n\nÿc5A seemingly bottomless bag...",
-        "zhTW": "ÿc4可作爲寶石添加物品\n製作新物品時\n\n寶石袋 + 提取器 = 取出寶石\n 寶石袋 + 各种寶石 = 添加寶石\nCube公式：\n\nÿc5看似無底的袋子...",
+        "zhTW": "ÿc4製作新物品時\n作為寶石材料使用\n\n寶石袋 + 抓取器 = 取回寶石\n寶石袋 + 各類寶石 = 添加寶石\n魔方合成：\n\nÿc5一個看似無底的袋子……",
         "deDE": "ÿc4Beim Herstellen neuer Gegenstände\nWird als Edelstein-Zutat verwendet\n\nBeutel + Greifer = Edelstein entnehmen\nBeutel + Verschiedene Edelsteine = Edelsteine hinzufügen\nWürfelrezepte:\n\nÿc5Ein scheinbar bodenloser Beutel ...",
         "esES": "ÿc4al crear nuevos objetos\nSe usa como reactivo de gema\n\nBolsa + Recogedor = Recuperar gema\nBolsa + Gemas variadas = Añadir gemas\nRecetas del cubo:\n\nÿc5Una bolsa aparentemente sin fondo...",
         "frFR": "ÿc4lors de l'artisanat d'objets\nUtilisé comme réactif de gemme\n\nSac + Ramasseur = Récupérer une gemme\nSac + Gemmes assorties = Ajouter des gemmes\nRecettes du cube :\n\nÿc5Un sac apparemment sans fond...",
@@ -50436,13 +50436,13 @@
         "jaJP": "ÿc4新しいアイテムの作成時に\nジェム試薬として使用\n\nバッグ + グラバー = ジェム回収\nバッグ + 各種ジェム = ジェム追加\nキューブレシピ：\n\nÿc5底なしのバッグのようだ……",
         "ptBR": "ÿc4ao criar novos itens\nUsado como reagente de Gema\n\nBolsa + Grabber = Recuperar Gema\nBolsa + Gemas Diversas = Adicionar Gemas\nReceitas do Cubo:\n\nÿc5Uma bolsa aparentemente sem fundo...",
         "ruRU": "ÿc4при создании новых предметов\nИспользуется как реагент для камней\n\nМешок + Граббер = Достать камень\nМешок + Разные камни = Добавить камни\nРецепты Куба:\n\nÿc5На вид — бездонный мешок…",
-        "zhCN": "ÿc4可作为宝石添加物\n制作新物品时\n\n宝石袋 + 提取器 = 取出宝石\n 宝石袋 + 各种宝石 = 添加宝石\nCube公式：\n\nÿc5看似无底的袋子..."
+        "zhCN": "ÿc4用于打造新物品时\n作为宝石材料\n\n宝袋 + 抓取器 = 取回宝石\n宝袋 + 各类宝石 = 添加宝石\n方块合成：\n\nÿc5一个看似无底的袋子……"
     },
     {
         "id": 51431,
         "Key": "HateKeyDescription",
         "enUS": "ÿc5Hatred always survives.\nI am eternal, creature.",
-        "zhTW": "ÿc5仇恨永存。\n我是永恆的，生靈。",
+        "zhTW": "ÿc5仇恨永存。\n我是永恒的，生灵。",
         "deDE": "ÿc5Der Hass überlebt immer.\nIch bin ewig, Kreatur.",
         "esES": "ÿc5El odio siempre sobrevive.\nSoy eterno, criatura.",
         "frFR": "ÿc5La haine survit toujours.\nJe suis éternel, créature.",
@@ -50459,7 +50459,7 @@
         "id": 51432,
         "Key": "TerrorKeyDescription",
         "enUS": "ÿc5Not even death can save you from me.",
-        "zhTW": "ÿc5 即使死亡也無法將你從我身邊帶走。",
+        "zhTW": "ÿc5 即使死亡也无法将你从我身边拯救出来。",
         "deDE": "ÿc5Nicht einmal der Tod kann dich vor mir retten.",
         "esES": "ÿc5Ni siquiera la muerte puede salvarte de mí.",
         "frFR": "ÿc5Pas même la mort ne peut te sauver de moi.",
@@ -50470,13 +50470,13 @@
         "jaJP": "ÿc5死さえも私からあなたを救うことはできない。",
         "ptBR": "ÿc5 Nem mesmo a morte pode salvá-lo de mim.",
         "ruRU": "ÿc5 Даже смерть не спасет тебя от меня.",
-        "zhCN": "ÿc5 即使死亡也无法将你从我身边带走。"
+        "zhCN": "ÿc5 即使死亡也无法将你从我身边拯救出来。"
     },
     {
         "id": 51433,
         "Key": "DestructionKeyDescription",
         "enUS": "ÿc5which will make me whole.\nalways searching for that,\nI have walked the earth,",
-        "zhTW": "ÿc5讓我圓滿的東西\n一直在尋找那個\n我走遍大地",
+        "zhTW": "ÿc5 which will make me whole.\n一直在寻找、\n我一直在寻找",
         "deDE": "ÿc5 die mich ganz machen wird.\nIch bin immer auf der Suche danach,\nhabe ich die Erde durchwandert,",
         "esES": "ÿc5que me hará completo.\nsiempre buscando eso,\nhe caminado por la tierra,",
         "frFR": "ÿc5qui me rendra entier.\nJe suis toujours à la recherche de cela,\nj'ai parcouru la terre,",
@@ -50487,13 +50487,13 @@
         "jaJP": "ÿc5私を完全にする。\nいつもそれを探している、\n私は地球を歩いてきた、",
         "ptBR": "ÿc5 que me tornará completo.\nEstou sempre procurando por isso,\nEu andei pela Terra,",
         "ruRU": "ÿc5 что сделает меня целым.\nЯ всегда в поиске,\nя ходил по земле,",
-        "zhCN": "ÿc5让我圆满的東西\n一直在寻找那个\n我走遍大地"
+        "zhCN": "ÿc5 which will make me whole.\n一直在寻找、\n我一直在寻找"
     },
     {
         "id": 51434,
         "Key": "Maadi's Paradox",
         "enUS": "Maadi's Paradox",
-        "zhTW": "馬迪的悖論",
+        "zhTW": "马迪悖论",
         "deDE": "Das Paradox von Maadi",
         "esES": "La paradoja de Maadi",
         "frFR": "Le paradoxe de Maadi",
@@ -50504,13 +50504,13 @@
         "jaJP": "マーディのパラドックス",
         "ptBR": "Paradoxo de Maadi",
         "ruRU": "Парадокс Маади",
-        "zhCN": "马迪的悖论"
+        "zhCN": "马迪悖论"
     },
     {
         "id": 51435,
         "Key": "Maadi's Silence",
         "enUS": "Maadi's Silence",
-        "zhTW": "馬迪的沉默",
+        "zhTW": "马迪的沉默",
         "deDE": "Das Schweigen von Maadi",
         "esES": "El silencio de Maadi",
         "frFR": "Le silence de Maadi",
@@ -50527,7 +50527,7 @@
         "id": 51436,
         "Key": "Maadi's Vision",
         "enUS": "Maadi's Vision",
-        "zhTW": "馬迪的願景",
+        "zhTW": "马迪的愿景",
         "deDE": "Die Vision von Maadi",
         "esES": "La visión de Maadi",
         "frFR": "La vision de Maadi",
@@ -50544,7 +50544,7 @@
         "id": 51437,
         "Key": "Maadi's Spirit",
         "enUS": "Maadi's Spirit",
-        "zhTW": "馬迪的精神",
+        "zhTW": "马迪精神",
         "deDE": "Der Geist von Maadi",
         "esES": "El espíritu de Maadi",
         "frFR": "L'esprit de Maadi",
@@ -50555,13 +50555,13 @@
         "jaJP": "マーディのスピリット",
         "ptBR": "O espírito de Maadi",
         "ruRU": "Дух Маади",
-        "zhCN": "马迪的精神"
+        "zhCN": "马迪精神"
     },
     {
         "id": 51438,
         "Key": "Maadi's Torch",
         "enUS": "Maadi's Torch",
-        "zhTW": "馬迪的火炬",
+        "zhTW": "马迪的火炬",
         "deDE": "Die Fackel von Maadi",
         "esES": "Antorcha de Maadi",
         "frFR": "Le flambeau de Maadi",
@@ -50595,7 +50595,7 @@
         "id": 51440,
         "Key": "mfp",
         "enUS": "ÿcLMagic Find Potion",
-        "zhTW": "ÿcLMF 藥水",
+        "zhTW": "ÿcL尋寶藥水",
         "deDE": "ÿcLMagiefundtrank",
         "esES": "ÿcLPoción de hallazgo mágico",
         "frFR": "ÿcLPotion de découverte magique",
@@ -50606,13 +50606,13 @@
         "jaJP": "ÿcLマジックファインドポーション",
         "ptBR": "ÿcLPoção de Encontrar Magia",
         "ruRU": "ÿcLЗелье нахождения магии",
-        "zhCN": "ÿcLMF 药水"
+        "zhCN": "ÿcL寻宝药水"
     },
     {
         "id": 51441,
         "Key": "PotionMagicFindDesc",
         "enUS": "ÿc4only the duration stacks\n+150% Magic Find for 30 seconds",
-        "zhTW": "ÿc4只叠加持續时间\n+150%MF，持續30秒",
+        "zhTW": "ÿc4只叠加持续时间\n+150%魔法发现，持续30秒",
         "deDE": "ÿc4nur die Dauer stapelt sich\n+150% Magiefindung für 30 Sekunden",
         "esES": "ÿc4sólo la duración se acumula\n+150% Hallazgo mágico durante 30 segundos",
         "frFR": "ÿc4seule la durée s'empile\n+150% de découverte magique pendant 30 secondes",
@@ -50623,13 +50623,13 @@
         "jaJP": "ÿc4持続時間のみスタック\n30秒間450%の魔法発見率",
         "ptBR": "ÿc4apenas a duração acumula\n+150% de Magic Find por 30 segundos",
         "ruRU": "ÿc4 только продолжительность стакается\n+150% Магического обретения на 30 секунд",
-        "zhCN": "ÿc4只叠加持续时间\n+150%MF，持续30秒"
+        "zhCN": "ÿc4只叠加持续时间\n+150%魔法发现，持续30秒"
     },
     {
         "id": 51442,
         "Key": "xpp",
         "enUS": "ÿcLExperience Potion",
-        "zhTW": "ÿcL经验藥水",
+        "zhTW": "ÿcL經驗藥水",
         "deDE": "ÿcLErfahrungstrank",
         "esES": "ÿcLPoción de experiencia",
         "frFR": "ÿcLPotion d'expérience",
@@ -50646,7 +50646,7 @@
         "id": 51443,
         "Key": "PotionExperienceDesc",
         "enUS": "ÿc4only the duration stacks\n+250% Experience for 30 seconds",
-        "zhTW": "ÿc4只叠加持續时间\n+250%經驗獲取，持續30秒",
+        "zhTW": "ÿc4只叠加持续时间\n+250%经验值，持续30秒",
         "deDE": "ÿc4nur die Dauer stapelt sich\n+250% Erfahrung für 30 Sekunden",
         "esES": "ÿc4sólo la duración se acumula\n+250% Experiencia durante 30 segundos",
         "frFR": "ÿc4seule la durée s'empile\n+250% Expérience pendant 30 secondes",
@@ -50657,13 +50657,13 @@
         "jaJP": "ÿc4持続時間のみスタック\n30秒間250%の経験値",
         "ptBR": "ÿc4apenas a duração acumula\n+250% de experiência por 30 segundos",
         "ruRU": "ÿc4 только продолжительность стакается\n+250% опыта на 30 секунд",
-        "zhCN": "ÿc4只叠加持续时间\n+250%经验获取，持续30秒"
+        "zhCN": "ÿc4只叠加持续时间\n+250%经验值，持续30秒"
     },
     {
         "id": 51444,
         "Key": "fsp",
         "enUS": "ÿcEFire Sunder Potion",
-        "zhTW": "ÿcE火免破除藥水",
+        "zhTW": "ÿcE火焰瓦解藥水",
         "deDE": "ÿcEFeuer-Zerschmetterungstrank",
         "esES": "ÿcEPoción Rompedora de Fuego",
         "frFR": "ÿcEPotion de fracture du feu",
@@ -50674,13 +50674,13 @@
         "jaJP": "ÿcEファイア・サンダーポーション",
         "ptBR": "ÿcEPoção de Ruptura do Fogo",
         "ruRU": "ÿcEЗелье огненного разлома",
-        "zhCN": "ÿcE火免破除药水"
+        "zhCN": "ÿcE火焰瓦解药水"
     },
     {
         "id": 51445,
         "Key": "PotionFireSunderDesc",
         "enUS": "ÿc4only the duration stacks\nSunder Fire for 30 seconds",
-        "zhTW": "ÿc4只叠加持續时间\n破除火免30秒",
+        "zhTW": "ÿc4只有持续时间会叠加\n火下30秒",
         "deDE": "ÿc4nur die Dauer stapelt sich\nUnter Feuer für 30 Sekunden",
         "esES": "ÿc4Sólo la duración se acumula.\nBajo Fuego durante 30 segundos",
         "frFR": "ÿc4Seule la durée s'empile\nSous le feu pendant 30 secondes",
@@ -50691,13 +50691,13 @@
         "jaJP": "ÿc4持続時間のみスタック\n30秒間炎に包まれる",
         "ptBR": "ÿc4apenas a duração acumula\nSob fogo por 30 segundos",
         "ruRU": "ÿc4только продолжительность стакается\nПод огнем на 30 секунд",
-        "zhCN": "ÿc4只叠加持续时间\n破除火免30秒"
+        "zhCN": "ÿc4只有持续时间会叠加\n火下30秒"
     },
     {
         "id": 51446,
         "Key": "csp",
         "enUS": "ÿcFCold Sunder Potion",
-        "zhTW": "ÿcF冰免破除药水",
+        "zhTW": "ÿcF冷破藥水",
         "deDE": "ÿcFKältespalter-Trank",
         "esES": "ÿcFPoción de Ruptura de Frío",
         "frFR": "ÿcFPotion de Fracture de froid",
@@ -50708,13 +50708,13 @@
         "jaJP": "ÿcFコールドサンダーポーション",
         "ptBR": "ÿcFPoção de Quebra Gelo",
         "ruRU": "ÿcFЗелье ледяного разлома",
-        "zhCN": "ÿcF冰免破除药水"
+        "zhCN": "ÿcF冷破药水"
     },
     {
         "id": 51447,
         "Key": "PotionColdSunderDesc",
         "enUS": "ÿc4only the duration stacks\nSunder Cold for 30 seconds",
-        "zhTW": "ÿc4只叠加持續时间\n破除冰免 30 秒",
+        "zhTW": "ÿc4只有持续时间会叠加\n低温持续 30 秒",
         "deDE": "ÿc4nur die Dauer stapelt sich\nUnter Kälte für 30 Sekunden",
         "esES": "ÿc4Sólo la duración se acumula.\nSunder Cold durante 30 segundos",
         "frFR": "ÿc4Seule la durée se cumule\nSous le froid pendant 30 secondes",
@@ -50725,13 +50725,13 @@
         "jaJP": "ÿc4持続時間のみスタック\n30秒間の風邪",
         "ptBR": "ÿc4apenas a duração acumula\nSunder Cold por 30 segundos",
         "ruRU": "ÿc4 Только продолжительность стакается\nПод холодом на 30 секунд",
-        "zhCN": "ÿc4只叠加持续时间\n破除冰免 30 秒"
+        "zhCN": "ÿc4只有持续时间会叠加\n低温持续 30 秒"
     },
     {
         "id": 51448,
         "Key": "lsp",
         "enUS": "ÿcRLightning Sunder Potion",
-        "zhTW": "ÿcR電免破除藥水",
+        "zhTW": "ÿcR閃電破藥水",
         "deDE": "ÿcRBlitzspalter-Trank",
         "esES": "ÿcRPoción de Ruptura de Rayo",
         "frFR": "ÿcRPotion de Fracture de foudre",
@@ -50742,13 +50742,13 @@
         "jaJP": "ÿcRライトニングサンダーポーション",
         "ptBR": "ÿcRPoção de Quebra Raio",
         "ruRU": "ÿcRЗелье молниеносного разлома",
-        "zhCN": "ÿcR电免破除药水"
+        "zhCN": "ÿcR闪电破药水"
     },
     {
         "id": 51449,
         "Key": "PotionLightningSunderDesc",
         "enUS": "ÿc4only the duration stacks\nSunder Lightning for 30 seconds",
-        "zhTW": "ÿc4只叠加持續时间\n破除電免 30 秒",
+        "zhTW": "ÿc4只有持续时间会叠加\n闪电下30秒",
         "deDE": "ÿc4nur die Dauer stapelt sich\nUnter Blitzschlag für 30 Sekunden",
         "esES": "ÿc4sólo la duración se acumula\nSunder Lightning durante 30 segundos",
         "frFR": "ÿc4Seule la durée s'empile\nSous la foudre pendant 30 secondes",
@@ -50759,13 +50759,13 @@
         "jaJP": "ÿc4持続時間のみスタック\n30秒間雷の下",
         "ptBR": "ÿc4apenas a duração acumula\nSob um raio por 30 segundos",
         "ruRU": "ÿc4только продолжительность стакается\nПод молнией на 30 секунд",
-        "zhCN": "ÿc4只叠加持续时间\n破除电免 30 秒"
+        "zhCN": "ÿc4只有持续时间会叠加\n闪电下30秒"
     },
     {
         "id": 51450,
         "Key": "psp",
         "enUS": "ÿcAPoison Sunder Potion",
-        "zhTW": "ÿcA毒免破除藥水",
+        "zhTW": "ÿcA毒素破藥水",
         "deDE": "ÿcAGiftspalter-Trank",
         "esES": "ÿcAPoción de Ruptura de Veneno",
         "frFR": "ÿcAPotion de Fracture de poison",
@@ -50776,13 +50776,13 @@
         "jaJP": "ÿcAポイズンサンダーポーション",
         "ptBR": "ÿcAPoção de Quebra Veneno",
         "ruRU": "ÿcAЗелье ядовитого разлома",
-        "zhCN": "ÿcA毒免破除药水"
+        "zhCN": "ÿcA毒素破药水"
     },
     {
         "id": 51451,
         "Key": "PotionPoisonSunderDesc",
         "enUS": "ÿc4only the duration stacks\nSunder Poison for 30 seconds",
-        "zhTW": "ÿc4只叠加持續时间\n破除毒免 30 秒",
+        "zhTW": "ÿc4只有持续时间会叠加\n中毒 30 秒",
         "deDE": "ÿc4nur die Dauer stapelt sich\nVergiftet für 30 Sekunden",
         "esES": "ÿc4Sólo la duración se acumula.\nVeneno durante 30 segundos",
         "frFR": "ÿc4Seule la durée s'empile\nSous Poison pendant 30 secondes",
@@ -50793,13 +50793,13 @@
         "jaJP": "ÿc4持続時間のみスタック\n30秒間毒状態になる",
         "ptBR": "ÿc4apenas a duração acumula\nSob veneno por 30 segundos",
         "ruRU": "ÿc4только продолжительность стакается\nПод ядом на 30 секунд",
-        "zhCN": "ÿc4只叠加持续时间\n破除毒免 30 秒"
+        "zhCN": "ÿc4只有持续时间会叠加\n中毒 30 秒"
     },
     {
         "id": 51452,
         "Key": "msp",
         "enUS": "ÿcLMagic Sunder Potion",
-        "zhTW": "ÿcL魔免破除藥水",
+        "zhTW": "ÿcL魔法破藥水",
         "deDE": "ÿcLMagiespalter-Trank",
         "esES": "ÿcLPoción de Ruptura Mágica",
         "frFR": "ÿcLPotion de Fracture magique",
@@ -50810,13 +50810,13 @@
         "jaJP": "ÿcLマジックサンダーポーション",
         "ptBR": "ÿcLPoção de Quebra Mágica",
         "ruRU": "ÿcLЗелье магического разлома",
-        "zhCN": "ÿcL魔免破除药水"
+        "zhCN": "ÿcL魔法破药水"
     },
     {
         "id": 51453,
         "Key": "PotionMagicSunderDesc",
         "enUS": "ÿc4only the duration stacks\nSunder Magic for 30 seconds",
-        "zhTW": "ÿc4只叠加持續时间\n破除魔免 30 秒",
+        "zhTW": "ÿc4只有持续时间会叠加\n4潜行魔法30秒",
         "deDE": "ÿc4nur die Dauer stapelt sich\nUnter Magie für 30 Sekunden",
         "esES": "ÿc4sólo la duración se acumula\nBajo Magia durante 30 segundos",
         "frFR": "ÿc4Seule la durée s'empile\nSous la magie pendant 30 secondes",
@@ -50827,13 +50827,13 @@
         "jaJP": "ÿc4持続時間のみスタック\nサンダー・マジック 30秒",
         "ptBR": "ÿc4apenas a duração acumula\nSunder Magic por 30 segundos",
         "ruRU": "ÿc4только продолжительность складывается\nПод магией на 30 секунд",
-        "zhCN": "ÿc4只叠加持续时间\n破除魔免 30 秒"
+        "zhCN": "ÿc4只有持续时间会叠加\n潜行魔法30秒"
     },
     {
         "id": 51454,
         "Key": "php",
         "enUS": "ÿcKPhysical Sunder Potion",
-        "zhTW": "ÿcK物免破除藥水",
+        "zhTW": "ÿcK物理破藥水",
         "deDE": "ÿcKPhysispalter-Trank",
         "esES": "ÿcKPoción de Ruptura Física",
         "frFR": "ÿcKPotion de Fracture physique",
@@ -50844,13 +50844,13 @@
         "jaJP": "ÿcKフィジカルサンダーポーション",
         "ptBR": "ÿcKPoção de Quebra Física",
         "ruRU": "ÿcKЗелье физического разлома",
-        "zhCN": "ÿcK物免破除药水"
+        "zhCN": "ÿcK物理破药水"
     },
     {
         "id": 51455,
         "Key": "PotionPhysicalSunderDesc",
         "enUS": "ÿc4only the duration stacks\nSunder Physical for 30 seconds",
-        "zhTW": "ÿc4只叠加持續时间\n破除物免 30 秒",
+        "zhTW": "ÿc4只叠加持续时间\n物理伤害持续 30 秒",
         "deDE": "ÿc4nur die Dauer stapelt sich\nUnter physisch für 30 Sekunden",
         "esES": "ÿc4sólo la duración se acumula\nFísico durante 30 segundos",
         "frFR": "ÿc4Seule la durée s'empile\nSous physique pendant 30 secondes",
@@ -50861,7 +50861,7 @@
         "jaJP": "ÿc4持続時間のみスタック\n物理30秒以下",
         "ptBR": "ÿc4apenas a duração acumula\nSub Físico por 30 segundos",
         "ruRU": "ÿc4только продолжительность стакается\nПод физическим воздействием на 30 секунд",
-        "zhCN": "ÿc4只叠加持续时间\n破除物免 30 秒"
+        "zhCN": "ÿc4只叠加持续时间\n物理伤害持续 30 秒"
     },
     {
         "id": 51456,
@@ -50884,7 +50884,7 @@
         "id": 51457,
         "Key": "Obsidian Beacon",
         "enUS": "ÿc4Obsidian Beaconÿc1",
-        "zhTW": "ÿc4黑曜石火炬ÿc1",
+        "zhTW": "ÿc4黑曜石燈塔ÿc1",
         "deDE": "ÿc4Obsidian-Leuchtfeuerÿc1",
         "esES": "ÿc4Baliza de Obsidianaÿc1",
         "frFR": "ÿc4Balise d'obsidienneÿc1",
@@ -50895,13 +50895,13 @@
         "jaJP": "ÿc4オブシディアンビーコンÿc1",
         "ptBR": "ÿc4Farol de Obsidianaÿc1",
         "ruRU": "ÿc4Обсидиановый Маякÿc1",
-        "zhCN": "ÿc4黑曜石火炬ÿc1"
+        "zhCN": "ÿc4黑曜石灯塔ÿc1"
     },
     {
         "id": 51458,
         "Key": "The Raven's Nest",
         "enUS": "The Raven's Nest",
-        "zhTW": "烏鴉的巢穴",
+        "zhTW": "乌鸦的巢穴",
         "deDE": "Das Nest des Raben",
         "esES": "El nido del cuervo",
         "frFR": "Le nid de corbeau",
@@ -50918,7 +50918,7 @@
         "id": 51459,
         "Key": "The Raven's Talons",
         "enUS": "The Raven's Talons",
-        "zhTW": "烏鴉的利爪",
+        "zhTW": "乌鸦的利爪",
         "deDE": "Die Krallen des Raben",
         "esES": "Las garras del cuervo",
         "frFR": "Les serres du corbeau",
@@ -50935,7 +50935,7 @@
         "id": 51460,
         "Key": "The Raven's Wing",
         "enUS": "The Raven's Wing",
-        "zhTW": "烏鴉之翼",
+        "zhTW": "乌鸦之翼",
         "deDE": "Der Flügel des Raben",
         "esES": "El ala del cuervo",
         "frFR": "L'aile du corbeau",
@@ -50952,7 +50952,7 @@
         "id": 51461,
         "Key": "The Raven's Feathers",
         "enUS": "The Raven's Feathers",
-        "zhTW": "烏鴉的羽毛",
+        "zhTW": "乌鸦的羽毛",
         "deDE": "Die Federn des Raben",
         "esES": "Las plumas del cuervo",
         "frFR": "Les plumes du corbeau",
@@ -50969,7 +50969,7 @@
         "id": 51462,
         "Key": "The Raven's Beak",
         "enUS": "The Raven's Beak",
-        "zhTW": "烏鴉的喙",
+        "zhTW": "乌鸦的喙",
         "deDE": "Der Schnabel des Raben",
         "esES": "El pico del cuervo",
         "frFR": "Le bec du corbeau",
@@ -50986,7 +50986,7 @@
         "id": 51463,
         "Key": "The Raven's Feet",
         "enUS": "The Raven's Feet",
-        "zhTW": "烏鴉之足",
+        "zhTW": "乌鸦的脚",
         "deDE": "Die Füße des Raben",
         "esES": "Los pies del cuervo",
         "frFR": "Les pieds du corbeau",
@@ -50997,13 +50997,13 @@
         "jaJP": "カラスの足",
         "ptBR": "Os pés do corvo",
         "ruRU": "Ноги ворона",
-        "zhCN": "乌鸦之足"
+        "zhCN": "乌鸦的脚"
     },
     {
         "id": 51464,
         "Key": "Tools of Vindication",
         "enUS": "Tools of Vindication",
-        "zhTW": "復仇的工具",
+        "zhTW": "平反工具",
         "deDE": "Werkzeuge der Rechtfertigung",
         "esES": "Herramientas de reivindicación",
         "frFR": "Outils de revendication",
@@ -51014,13 +51014,13 @@
         "jaJP": "正当性を証明する道具",
         "ptBR": "Ferramentas de reivindicação",
         "ruRU": "Инструменты виндикации",
-        "zhCN": "复仇的工具"
+        "zhCN": "平反工具"
     },
     {
         "id": 51465,
         "Key": "Hand of the Vindicator",
         "enUS": "Hand of the Vindicator",
-        "zhTW": "復仇者之手",
+        "zhTW": "复仇者之手",
         "deDE": "Die Hand des Vindicators",
         "esES": "Mano del Vindicador",
         "frFR": "Main du Vindicateur",
@@ -51037,7 +51037,7 @@
         "id": 51466,
         "Key": "Bulwark of the Vindicator",
         "enUS": "Bulwark of the Vindicator",
-        "zhTW": "復仇者堡壘",
+        "zhTW": "复仇者堡垒",
         "deDE": "Bollwerk des Vindicator",
         "esES": "Baluarte del Vindicador",
         "frFR": "Le rempart du Vindicateur",
@@ -51054,7 +51054,7 @@
         "id": 51467,
         "Key": "Belt of the Vindicator",
         "enUS": "Belt of the Vindicator",
-        "zhTW": "復仇者腰帶",
+        "zhTW": "复仇者腰带",
         "deDE": "Gürtel des Vindicator",
         "esES": "Cinturón del Vindicador",
         "frFR": "Ceinture du Vindicator",
@@ -51071,7 +51071,7 @@
         "id": 51468,
         "Key": "Valknut",
         "enUS": "ÿc4Valknut",
-        "zhTW": "ÿc4瓦爾-諾特",
+        "zhTW": "ÿc4女武神結",
         "deDE": "ÿc4Valknut",
         "esES": "ÿc4Valknut",
         "frFR": "ÿc4Valknut",
@@ -51082,13 +51082,13 @@
         "jaJP": "ÿc4ヴァルクヌート",
         "ptBR": "ÿc4Valknut",
         "ruRU": "ÿc4Валькнут",
-        "zhCN": "ÿc4瓦尔-诺特"
+        "zhCN": "ÿc4女武神结"
     },
     {
         "id": 51469,
         "Key": "Triskelion",
         "enUS": "ÿc4Triskelion",
-        "zhTW": "ÿc4三聯一體",
+        "zhTW": "ÿc4三螺旋",
         "deDE": "ÿc4Triskelion",
         "esES": "ÿc4Triskelion",
         "frFR": "ÿc4Triskèle",
@@ -51099,7 +51099,7 @@
         "jaJP": "ÿc4トリスケリオン",
         "ptBR": "ÿc4Triskelion",
         "ruRU": "ÿc4Трискелион",
-        "zhCN": "ÿc4三联一体"
+        "zhCN": "ÿc4三螺旋"
     },
     {
         "id": 51470,
@@ -51122,7 +51122,7 @@
         "id": 51471,
         "Key": "Conclave of Elements",
         "enUS": "ÿc4Conclave of Elements",
-        "zhTW": "ÿc4元素密會",
+        "zhTW": "ÿc4元素會議",
         "deDE": "ÿc4Konklave der Elemente",
         "esES": "ÿc4Cónclave de los Elementos",
         "frFR": "ÿc4Conclave des Éléments",
@@ -51133,13 +51133,13 @@
         "jaJP": "ÿc4エレメントの集会",
         "ptBR": "ÿc4Conclave dos Elementos",
         "ruRU": "ÿc4Конклав Стихий",
-        "zhCN": "ÿc4元素密会"
+        "zhCN": "ÿc4元素议会"
     },
     {
         "id": 51472,
         "Key": "mpa",
         "enUS": "ÿc4Mephisto's Animus",
-        "zhTW": "ÿc4墨菲斯托的敵意",
+        "zhTW": "ÿc4墨菲斯托的靈魂",
         "deDE": "ÿc4Mephistos Animus",
         "esES": "ÿc4Ánima de Mefisto",
         "frFR": "ÿc4Animus de Méphisto",
@@ -51150,13 +51150,13 @@
         "jaJP": "ÿc4メフィストのアニムス",
         "ptBR": "ÿc4Animus de Mefisto",
         "ruRU": "ÿc4Анимус Мефисто",
-        "zhCN": "ÿc4墨菲斯托的敌意"
+        "zhCN": "ÿc4墨菲斯托的灵魂"
     },
     {
         "id": 51473,
         "Key": "blc",
         "enUS": "ÿc4Baal's Calamity",
-        "zhTW": "ÿc4巴爾的災厄",
+        "zhTW": "ÿc4巴尔的灾难",
         "deDE": "ÿc4Baals Verderben",
         "esES": "ÿc4La Calamidad de Baal",
         "frFR": "ÿc4Calamité de Baal",
@@ -51167,13 +51167,13 @@
         "jaJP": "ÿc4バールの災厄",
         "ptBR": "ÿc4Calamidade de Baal",
         "ruRU": "ÿc4Бедствие Баала",
-        "zhCN": "ÿc4巴尔的灾厄"
+        "zhCN": "ÿc4巴尔的灾难"
     },
     {
         "id": 51474,
         "Key": "dia",
         "enUS": "ÿc4Diablo's Ire",
-        "zhTW": "ÿc4迪亞波羅的怒火",
+        "zhTW": "ÿc4迪亚波罗的愤怒",
         "deDE": "ÿc4Diablos Zorn",
         "esES": "ÿc4La Ira de Diablo",
         "frFR": "ÿc4Colère de Diablo",
@@ -51184,7 +51184,7 @@
         "jaJP": "ÿc4ディアブロの怒り",
         "ptBR": "ÿc4Ira de Diablo",
         "ruRU": "ÿc4Гнев Диабло",
-        "zhCN": "ÿc4迪亚波罗的怒火"
+        "zhCN": "ÿc4迪亚波罗的愤怒"
     },
     {
         "id": 51475,
@@ -51207,7 +51207,7 @@
         "id": 51476,
         "Key": "jwp",
         "enUS": "ÿc4Jewel Pliers",
-        "zhTW": "ÿc4珠宝钳",
+        "zhTW": "ÿc4宝石钳",
         "deDE": "ÿc4Juwelzange",
         "esES": "ÿc4Alicates para joyas",
         "frFR": "ÿc4Pince à bijoux",
@@ -51218,7 +51218,7 @@
         "jaJP": "ÿc4ジュエルプライヤー",
         "ptBR": "ÿc4Alicate para joias",
         "ruRU": "ÿc4Клещи для драгоценностей",
-        "zhCN": "ÿc4珠宝钳"
+        "zhCN": "ÿc4宝石钳"
     },
     {
         "id": 51477,
@@ -51234,8 +51234,8 @@
         "plPL": "Zwraca runy po użyciu\nSłuży do usuwania słów runicznych",
         "ptBR": "Devolve Runas ao ser usado\nUsado para desfazer Runewords",
         "ruRU": "Возвращает руны после использования\nИспользуется для развоплощения рунных слов",
-        "zhCN": "使用后取出已镶嵌的符文\n用于解除符文之语",
-        "zhTW": "使用後取出已鑲嵌的符文\n用於解除符文之語"
+        "zhCN": "使用时返回符文\n用于解除符文",
+        "zhTW": "使用时返回符文\n用于解除符文"
     },
     {
         "id": 51478,
@@ -51251,14 +51251,14 @@
         "plPL": "ÿcENie działa na słowach runicznych\nÿc0z broni i zbroi\nZwraca przedmioty z gniazdami",
         "ptBR": "ÿcEDe não funciona com Runewords\nÿc0de armas e armaduras\nRetorna itens com soquete",
         "ruRU": "ÿcED Не работает на рунных словах\nÿc0из оружия и доспехов\nВозвращает сокетные предметы",
-        "zhCN": "ÿcE对符文之语无效\n取出已镶嵌物品\nÿc0从镶嵌后的武器/盔甲",
-        "zhTW": "ÿcE對符文之語無效\nÿc0取出已鑲嵌物品\n從鑲嵌后的武器/盔甲"
+        "zhCN": "ÿcE对符文无效\nÿc0从武器和盔甲\n返回插口物品",
+        "zhTW": "ÿcE对符文无效\nÿc0从武器和盔甲\n返回插口物品"
     },
     {
         "id": 51479,
         "Key": "dwd",
         "enUS": "ÿc0Divine White Dye",
-        "zhTW": "ÿc0神聖白色染料",
+        "zhTW": "ÿc0神圣白色染料",
         "deDE": "ÿc0Divine White Farbstoff",
         "esES": "ÿc0Tinte Blanco Divino",
         "frFR": "ÿc0Divine White Dye",
@@ -51275,7 +51275,7 @@
         "id": 51480,
         "Key": "abd",
         "enUS": "ÿc5Abyssal Black Dye",
-        "zhTW": "ÿc5深淵黑色染料",
+        "zhTW": "ÿc5深渊黑染料",
         "deDE": "ÿc5Abyssal Schwarzer Farbstoff",
         "esES": "ÿc5Tinte Negro Abisal",
         "frFR": "ÿc5Texte noir abyssal",
@@ -51286,13 +51286,13 @@
         "jaJP": "ÿc5アビスブラック染料",
         "ptBR": "ÿc5Corante Preto Abissal",
         "ruRU": "ÿc5Abyssal Black Dye",
-        "zhCN": "ÿc5深渊黑色染料"
+        "zhCN": "ÿc5深渊黑染料"
     },
     {
         "id": 51481,
         "Key": "bdd",
         "enUS": "ÿc3Ancient Blue Dye",
-        "zhTW": "ÿc3遠古蓝色染料",
+        "zhTW": "ÿc3古代蓝色染料",
         "deDE": "ÿc3Altblauer Farbstoff",
         "esES": "ÿc3Antiguo tinte azul",
         "frFR": "ÿc3La teinture bleue ancienne",
@@ -51303,13 +51303,13 @@
         "jaJP": "ÿc3古代ブルー染料",
         "ptBR": "ÿc3Corante azul antigo",
         "ruRU": "ÿc3Древний синий краситель",
-        "zhCN": "ÿc3远古蓝色染料"
+        "zhCN": "ÿc3古代蓝色染料"
     },
     {
         "id": 51482,
         "Key": "ird",
         "enUS": "ÿcEInfernal Red Dye",
-        "zhTW": "ÿcE地狱红色染料",
+        "zhTW": "ÿcE无间红染料",
         "deDE": "ÿcEInfernalischer roter Farbstoff",
         "esES": "ÿcETinte rojo infernal",
         "frFR": "ÿcETeinture rouge infernale",
@@ -51320,13 +51320,13 @@
         "jaJP": "ÿcEインファナル・レッド・ダイ",
         "ptBR": "ÿcEInfernal Red Dye",
         "ruRU": "ÿcEИнфернальный красный краситель",
-        "zhCN": "ÿcE地狱红色染料"
+        "zhCN": "ÿcE无间红染料"
     },
     {
         "id": 51483,
         "Key": "ngd",
         "enUS": "ÿcANahantu Green Dye",
-        "zhTW": "ÿcA那瓦特绿色染料",
+        "zhTW": "ÿcANahantu绿色染料",
         "deDE": "ÿcANahantu Grüner Farbstoff",
         "esES": "ÿcANahantu Tinte Verde",
         "frFR": "ÿcANahantu Green Dye",
@@ -51337,13 +51337,13 @@
         "jaJP": "ÿcAカナハントゥ・グリーン染料",
         "ptBR": "ÿcANahantu Green Dye",
         "ruRU": "ÿcAЗеленый краситель Nahantu",
-        "zhCN": "ÿcA那瓦特绿色染料"
+        "zhCN": "ÿcANahantu绿色染料"
     },
     {
         "id": 51484,
         "Key": "cyd",
         "enUS": "ÿcRCaldeum Yellow Dye",
-        "zhTW": "ÿcR卡爾蒂姆黃色染料",
+        "zhTW": "ÿcR卡爾蒂姆黃染料",
         "deDE": "ÿcRCaldeumgelbe Farbe",
         "esES": "ÿcRTinte amarillo de Caldeum",
         "frFR": "ÿcRTeinture jaune de Caldeum",
@@ -51354,13 +51354,13 @@
         "jaJP": "ÿcRカルデウムの黄色染料",
         "ptBR": "ÿcRTintura Amarela de Caldeum",
         "ruRU": "ÿcRЖелтый краситель Калдея",
-        "zhCN": "ÿcR卡尔蒂姆黄色染料"
+        "zhCN": "ÿcR卡尔蒂姆黄染料"
     },
     {
         "id": 51485,
         "Key": "ryd",
         "enUS": "ÿc;Royal Purple Dye",
-        "zhTW": "ÿc;皇家紫色染料",
+        "zhTW": "ÿc;皇家紫染料",
         "deDE": "ÿc;Königliche Purpurfarbe",
         "esES": "ÿc;Tinte púrpura real",
         "frFR": "ÿc;Teinture pourpre royale",
@@ -51377,7 +51377,7 @@
         "id": 51486,
         "Key": "hod",
         "enUS": "ÿc8Herald Orange Dye",
-        "zhTW": "ÿc8先驅者橙色染料",
+        "zhTW": "ÿc8先驅者橙染料",
         "deDE": "ÿc8Heroldorange Farbe",
         "esES": "ÿc8Tinte naranja del heraldo",
         "frFR": "ÿc8Teinture orange du héraut",
@@ -51388,13 +51388,13 @@
         "jaJP": "ÿc8伝令使いのオレンジ染料",
         "ptBR": "ÿc8Tintura Laranja do Arauto",
         "ruRU": "ÿc8Оранжевый краситель Глашатая",
-        "zhCN": "ÿc8先驱者橙色染料"
+        "zhCN": "ÿc8先驱者橙染料"
     },
     {
         "id": 51487,
         "Key": "drm",
         "enUS": "ÿcGMiraculous Dye Remover",
-        "zhTW": "ÿcG神奇的染色去除劑",
+        "zhTW": "ÿcG神奇的去染劑",
         "deDE": "ÿcGWundersamer Farbentferner",
         "esES": "ÿcGQuitatinte milagroso",
         "frFR": "ÿcGDissolvant miraculeux",
@@ -51405,13 +51405,13 @@
         "jaJP": "ÿcG奇跡の染料除去剤",
         "ptBR": "ÿcGRemovedor de Tintura Milagroso",
         "ruRU": "ÿcGЧудесный растворитель красителей",
-        "zhCN": "ÿcG神奇的染色去除剂"
+        "zhCN": "ÿcG神奇的去染剂"
     },
     {
         "id": 51488,
         "Key": "WhiteDyeDescription",
         "enUS": "ÿcImaterial it is applied to impossible to soil.\nThis mysterious mixture seems to make any\nÿc4------------------------------\nTransmute with Weapon, Armor, Helm or Shield",
-        "zhTW": "ÿcI材料無法被弄髒\n这种神秘的混合物似乎能让任何\nÿc4------------------------------\n與武器、盔甲、頭盔或盾牌一起轉化",
+        "zhTW": "ÿcI这种神秘的混合物似乎能让任何\nÿc4------------------------------\n用武器、盔甲、头盔或盾牌转化",
         "deDE": "ÿcIMaterial, auf das es aufgetragen wird, unmöglich zu Boden.\nDiese geheimnisvolle Mischung scheint jede\nÿc4------------------------------\nTransmutieren mit Waffe, Rüstung, Helm oder Schild",
         "esES": "ÿcImaterial al que se aplica imposible de ensuciar.\nEsta misteriosa mezcla parece hacer que cualquier\nÿc4------------------------------\nTransmutar con Arma, Armadura, Yelmo o Escudo",
         "frFR": "ÿcIle matériau sur lequel il est appliqué ne peut pas se transformer en sol.\nCe mélange mystérieux semble rendre n'importe quel\nÿc4------------------------------\nTransmute with Weapon, Armor, Helm or Shield (Transmuter avec une arme, une armure, un heaume ou un bouclier)",
@@ -51422,13 +51422,13 @@
         "jaJP": "ÿcI土に塗ることは不可能である。\nこの不思議な混合物は、どのような\nÿc4------------------------------\n武器、鎧、兜、盾で変身させる。",
         "ptBR": "ÿcIO material ao qual ela é aplicada é impossível de ser aplicado ao solo.\nEssa mistura misteriosa parece fazer com que qualquer\nÿc4------------------------------\nTransmutar com arma, armadura, elmo ou escudo",
         "ruRU": "ÿcIматериал, на который он наносится, невозможно почву.\nЭта загадочная смесь, кажется, делает любую\nÿc4------------------------------\nТрансмутировать оружие, доспехи, шлем или щит",
-        "zhCN": "ÿcI材料无法被弄脏\n这种神秘的混合物似乎能让任何\nÿc4------------------------------\n与武器、盔甲、頭盔或盾牌一起转化"
+        "zhCN": "ÿcI这种神秘的混合物似乎能让任何\nÿc4------------------------------\n用武器、盔甲、头盔或盾牌转化"
     },
     {
         "id": 51489,
         "Key": "BlackDyeDescription",
         "enUS": "ÿcIvery light that touches it.\nwhen exposed to the sun, drinking in the\nThe inky blackness seems to grow even darker\nÿc4------------------------------\nTransmute with Weapon, Armor, Helm or Shield",
-        "zhTW": "ÿcI在最光亮処啜飲就能觸摸到它\n当暴露在陽光下時，\n墨一般的黑色似乎變得更黑了\nÿc4------------------------------\n與武器、盔甲、頭盔或盾牌一起轉化",
+        "zhTW": "ÿcIvery light that touches it.\n当暴露在阳光下时，喝\n墨一般的黑似乎变得更黑了\nÿc4------------------------------\n用武器、盔甲、头盔或盾牌转化",
         "deDE": "ÿcIJedes Licht, das es berührt.\nwenn es der Sonne ausgesetzt ist und das Licht aufsaugt.\nDie tiefe Schwärze scheint noch dunkler zu werden\nÿc4------------------------------\nTransmutieren mit Waffe, Rüstung, Helm oder Schild",
         "esES": "ÿcICada luz que lo toca.\ncuando se expone al sol, bebiendo\nLa negrura tinta parece volverse aún más oscura\nÿc4------------------------------\nTransmutar con Arma, Armadura, Yelmo o Escudo",
         "frFR": "ÿcIToute lumière qui l'effleure.\nlorsqu'il est exposé au soleil, en buvant l'eau de la piscine.\nLe noir d'encre semble devenir encore plus sombre.\nÿc4------------------------------\nTransmute with Weapon, Armor, Helm or Shield (Transmuter avec une arme, une armure, un heaume ou un bouclier)",
@@ -51439,13 +51439,13 @@
         "jaJP": "ÿcI触れるすべての光。\n太陽の光を浴びると\n漆黒の闇がさらに濃くなっていくようだ。\nÿc4------------------------------\n武器・鎧・兜・盾で変身させる",
         "ptBR": "ÿcIToda luz que o toca.\nquando exposto ao sol, bebendo a luz do sol.\nA escuridão parece ficar ainda mais escura\nÿc4------------------------------\nTransmutar com arma, armadura, elmo ou escudo",
         "ruRU": "ÿcIКаждый свет, который его касается.\nКогда он находится под лучами солнца, впитывая\nНепроглядная чернота, кажется, становится еще темнее.\nÿc4------------------------------\nТрансмутировать с помощью оружия, брони, шлема или щита",
-        "zhCN": "ÿcI在最光亮处啜饮就能触摸到它\n当暴露在阳光下时，\n墨一般的黑色似乎变得更黑了\nÿc4------------------------------\n与武器、盔甲、頭盔或盾牌一起转化"
+        "zhCN": "ÿcIvery light that touches it.\n当暴露在阳光下时，喝\n墨一般的黑似乎变得更黑了\nÿc4------------------------------\n用武器、盔甲、头盔或盾牌转化"
     },
     {
         "id": 51490,
         "Key": "BlueDyeDescription",
         "enUS": "ÿcIhis entire wardrobe this color on a dare.\nThe Almighty Ondal once dyed\nÿc4------------------------------\nTransmute with Weapon, Armor, Helm or Shield",
-        "zhTW": "ÿcI染成这种大膽的顔色。\n全能的奧達爾经將他的整個衣櫃\nÿc4------------------------------\n與武器、盔甲、頭盔或盾牌一起轉化",
+        "zhTW": "ÿcI他的整个衣柜这种颜色的大胆。\n全能的奥达尔曾经染过\nÿc4------------------------------\n用武器、盔甲、头盔或盾牌转化",
         "deDE": "ÿcISeine gesamte Garderobe in dieser Farbe zu färben, war eine Mutprobe.\nDer Allmächtige Ondal färbte einst\nÿc4------------------------------\nTransmutieren mit Waffe, Rüstung, Helm oder Schild",
         "esES": "ÿcITodo su guardarropa de este color en un desafío.\nEl Todopoderoso Ondal tiñó una vez\nÿc4------------------------------\nTransmutar con Arma, Armadura, Casco o Escudo",
         "frFR": "ÿcIToute sa garde-robe est de cette couleur, par défi.\nLe tout-puissant Ondal a un jour teinté\nÿc4------------------------------\nTransmuter avec Arme, Armure, Casque ou Bouclier",
@@ -51456,13 +51456,13 @@
         "jaJP": "ÿcIあえてこの色にした。\n全能のオンダルはかつて\nÿc4------------------------------\n武器・鎧・兜・盾で変身させる",
         "ptBR": "ÿcITodo o seu guarda-roupa dessa cor em um desafio.\nO todo-poderoso Ondal uma vez tingiu\nÿc4------------------------------\nTransmutar com arma, armadura, capacete ou escudo",
         "ruRU": "ÿcIИ весь его гардероб стал такого цвета, как только он осмелился.\nВсемогущий Ондал однажды покрасил\nÿc4------------------------------\nТрансмутировать с помощью оружия, доспехов, шлема или щита",
-        "zhCN": "ÿcI染成这种大胆的顔色。\n全能的奥达尔曾经将他的整个衣柜\nÿc4------------------------------\n与武器、盔甲、頭盔或盾牌一起转化"
+        "zhCN": "ÿcI他的整个衣柜这种颜色的大胆。\n全能的奥达尔曾经染过\nÿc4------------------------------\n用武器、盔甲、头盔或盾牌转化"
     },
     {
         "id": 51491,
         "Key": "RedDyeDescription",
         "enUS": "ÿcIseeming to flicker with bright crimson hellfire.\nThe bottle is warm to the touch,\nÿc4------------------------------\nTransmute with Weapon, Armor, Helm or Shield",
-        "zhTW": "ÿcI似乎閃爍着明亮的深紅色地獄之火。\n瓶子觸手溫熱、\nÿc4------------------------------\n與武器、盔甲、頭盔或盾牌一起轉化",
+        "zhTW": "ÿcI似乎闪烁着明亮的深红色地狱之火。\n瓶子触手温热、\nÿc4------------------------------\n用武器、盔甲、头盔或盾牌转化",
         "deDE": "ÿcIEs scheint, als würde ein helles, karminrotes Höllenfeuer flackern.\nDie Flasche fühlt sich warm an,\nÿc4------------------------------\nTransmutieren mit Waffe, Rüstung, Helm oder Schild",
         "esES": "ÿcIParece parpadear con un brillante fuego infernal carmesí.\nLa botella está caliente al tacto,\nÿc4------------------------------\nTransmuta con Arma, Armadura, Yelmo o Escudo",
         "frFR": "ÿcIElle semble scintiller d'un feu d'enfer cramoisi.\nLa bouteille est chaude au toucher,\nÿc4------------------------------\nTransmute with Weapon, Armor, Helm or Shield (Transmuter avec une arme, une armure, un heaume ou un bouclier)",
@@ -51473,13 +51473,13 @@
         "jaJP": "ÿcI鮮やかな深紅の地獄の炎が揺らめいているように見える。\nボトルを触ると温かい、\nÿc4------------------------------\n武器、鎧、兜、盾で変身させる。",
         "ptBR": "ÿcIParecendo tremeluzir com um fogo infernal carmesim brilhante.\nO frasco é quente ao toque,\nÿc4------------------------------\nTransmutar com arma, armadura, elmo ou escudo",
         "ruRU": "ÿcIКажется, что он мерцает ярким багровым адским пламенем.\nФлакон теплый на ощупь,\nÿc4------------------------------\nТрансмутировать с помощью оружия, брони, шлема или щита",
-        "zhCN": "ÿcIÿc似乎闪烁着明亮的深红色地狱之火。\n瓶子触手温热、\nÿc4------------------------------\n与武器、盔甲、頭盔或盾牌一起转化"
+        "zhCN": "ÿcIÿc似乎闪烁着明亮的深红色地狱之火。\n瓶子触手温热、\nÿc4------------------------------\n用武器、盔甲、头盔或盾牌转化"
     },
     {
         "id": 51492,
         "Key": "GreenDyeDescription",
         "enUS": "ÿcIunwanted attention...\nBest blend in to avoid\na dangerous place for an outsider.\nThe dense jungles of Nahantu are\nÿc4------------------------------\nTransmute with Weapon, Armor, Helm or Shield",
-        "zhTW": "ÿcI以避免不必要的注意...\n最好融入其中\n對外來者來說是個危險的地方。\n那瓦特茂密的叢林\nÿc4------------------------------\n與武器、盔甲、頭盔或盾牌一起轉化",
+        "zhTW": "ÿcI那漢圖茂密的叢林\n對外來者來說是個危險的地方。\n最好融入其中\n以避免不必要的注意...\nÿc4------------------------------\n與武器、盔甲、頭盔或盾牌進行轉化",
         "deDE": "ÿcIDie dichten Dschungel von Nahantu sind\nein gefährlicher Ort für Außenstehende.\nAm besten unauffällig bleiben,\num keine Aufmerksamkeit zu erregen...\nÿc4------------------------------\nTransmutiere mit Waffe, Rüstung, Helm oder Schild",
         "esES": "ÿcILas densas selvas de Nahantu son\nun lugar peligroso para los forasteros.\nMejor mezclarse para evitar\natención no deseada...\nÿc4------------------------------\nTransmutar con Arma, Armadura, Yelmo o Escudo",
         "frFR": "ÿcILes jungles denses de Nahantu sont\nun endroit dangereux pour un étranger.\nMieux vaut se fondre dans la masse pour éviter\nune attention indésirable...\nÿc4------------------------------\nTransmuter avec Arme, Armure, Heaume ou Bouclier",
@@ -51490,13 +51490,13 @@
         "jaJP": "ÿcIナハントゥの深い密林は\n部外者にとって危険な場所。\n余計な注目を避けるため、\n周囲に溶け込むのが得策だ...\nÿc4------------------------------\n武器、防具、兜、または盾と変成",
         "ptBR": "ÿcIAs densas selvas de Nahantu são\num lugar perigoso para forasteiros.\nMelhor se misturar para evitar\natenção indesejada...\nÿc4------------------------------\nTransmutar com Arma, Armadura, Elmo ou Escudo",
         "ruRU": "ÿcIГустые джунгли Наханту –\nопасное место для чужаков.\nЛучше слиться с окружением,\nчтобы избежать нежелательного внимания...\nÿc4------------------------------\nПреобразовать с оружием, доспехами, шлемом или щитом",
-        "zhCN": "ÿcI以避免不必要的注意...\n最好融入其中\n对外来者来说是个危险的地方。\n那瓦特茂密的丛林\nÿc4------------------------------\n与武器、盔甲、頭盔或盾牌一起转化"
+        "zhCN": "ÿcI那汉图茂密的丛林\n对外来者来说是个危险的地方。\n最好融入其中\n以避免不必要的注意...\nÿc4------------------------------\n与武器、盔甲、头盔或盾牌进行转化"
     },
     {
         "id": 51493,
         "Key": "YellowDyeDescription",
         "enUS": "ÿcIused strictly by Caldeum's nobility.\nboiling oil to create a rare pigment\nFlecks of gold are melted into\nÿc4------------------------------\nTransmute with Weapon, Armor, Helm or Shield",
-        "zhTW": "ÿcI僅供卡爾蒂姆貴族使用。\n製成稀有顏料，\n將金屑融化在沸油中\nÿc4------------------------------\n與武器、盔甲、頭盔或盾牌一起轉化",
+        "zhTW": "ÿcI將金屑融化在沸油中\n製成稀有顏料，\n僅供卡爾蒂姆貴族使用。\nÿc4------------------------------\n與武器、盔甲、頭盔或盾牌進行轉化",
         "deDE": "ÿcIGoldflocken werden in siedendes Öl eingeschmolzen,\num ein seltenes Pigment herzustellen,\ndas ausschließlich vom Adel Caldeums verwendet wird.\nÿc4------------------------------\nTransmutiere mit Waffe, Rüstung, Helm oder Schild",
         "esES": "ÿcIEscamas de oro se funden en\naceite hirviendo para crear un pigmento raro,\nusado estrictamente por la nobleza de Caldeum.\nÿc4------------------------------\nTransmutar con Arma, Armadura, Yelmo o Escudo",
         "frFR": "ÿcIDes paillettes d'or sont fondues dans\nde l'huile bouillante pour créer un pigment rare,\nutilisé exclusivement par la noblesse de Caldeum.\nÿc4------------------------------\nTransmuter avec Arme, Armure, Heaume ou Bouclier",
@@ -51507,13 +51507,13 @@
         "jaJP": "ÿcI金の粉を沸騰した油に溶かして\n希少な顔料を作り出す。\nカルデウムの貴族だけが使用を許される。\nÿc4------------------------------\n武器、防具、兜、または盾と変成",
         "ptBR": "ÿcIFlocos de ouro são derretidos em\nóleo fervente para criar um pigmento raro,\nusado exclusivamente pela nobreza de Caldeum.\nÿc4------------------------------\nTransmutar com Arma, Armadura, Elmo ou Escudo",
         "ruRU": "ÿcIЗолотые хлопья плавятся в\nкипящем масле, создавая редкий пигмент,\nиспользуемый исключительно знатью Калдея.\nÿc4------------------------------\nПреобразовать с оружием, доспехами, шлемом или щитом",
-        "zhCN": "ÿcI仅供卡尔蒂姆贵族使用。\n制成稀有颜料，\n将金屑融化在沸油中\nÿc4------------------------------\n与武器、盔甲、頭盔或盾牌一起转化"
+        "zhCN": "ÿcI将金屑融化在沸油中\n制成稀有颜料，\n仅供卡尔蒂姆贵族使用。\nÿc4------------------------------\n与武器、盔甲、头盔或盾牌进行转化"
     },
     {
         "id": 51494,
         "Key": "PurpleDyeDescription",
         "enUS": "ÿcIoutside of the Royal Family.\nforbidden to all citizens of Kingsport\nFor many years the color purple was\nÿc4------------------------------\nTransmute with Weapon, Armor, Helm or Shield",
-        "zhTW": "ÿcI王港的所有市民都禁止使用紫色。\n除了王室成員外，\n多年以來，\nÿc4------------------------------\n與武器、盔甲、頭盔或盾牌一起轉化",
+        "zhTW": "ÿcI多年以來，\n除了王室成員外，\n王港的所有市民都禁止使用紫色。\nÿc4------------------------------\n與武器、盔甲、頭盔或盾牌進行轉化",
         "deDE": "ÿcIViele Jahre lang war die Farbe Purpur\nallen Bürgern von Kingsport außerhalb\nder königlichen Familie verboten.\nÿc4------------------------------\nTransmutiere mit Waffe, Rüstung, Helm oder Schild",
         "esES": "ÿcIDurante muchos años, el color púrpura\nestaba prohibido para todos los ciudadanos\nde Puerto Real fuera de la Familia Real.\nÿc4------------------------------\nTransmutar con Arma, Armadura, Yelmo o Escudo",
         "frFR": "ÿcIPendant de nombreuses années, la couleur pourpre\nétait interdite à tous les citoyens de Port-Royal\nen dehors de la Famille Royale.\nÿc4------------------------------\nTransmuter avec Arme, Armure, Heaume ou Bouclier",
@@ -51524,13 +51524,13 @@
         "jaJP": "ÿcI長年にわたり、紫色は\n王族以外のキングスポートの\n市民すべてに禁止されていた。\nÿc4------------------------------\n武器、防具、兜、または盾と変成",
         "ptBR": "ÿcIPor muitos anos, a cor púrpura\nera proibida para todos os cidadãos\nde Porto Real fora da Família Real.\nÿc4------------------------------\nTransmutar com Arma, Armadura, Elmo ou Escudo",
         "ruRU": "ÿcIДолгие годы пурпурный цвет\nбыл запрещен всем жителям Кингспорта,\nкроме членов королевской семьи.\nÿc4------------------------------\nПреобразовать с оружием, доспехами, шлемом или щитом",
-        "zhCN": "ÿcI王港的所有市民都禁止使用紫色。\n除了王室成员外，\n多年以来，\nÿc4------------------------------\n与武器、盔甲、頭盔或盾牌一起转化"
+        "zhCN": "ÿcI多年以来，\n除了王室成员外，\n王港的所有市民都禁止使用紫色。\nÿc4------------------------------\n与武器、盔甲、头盔或盾牌进行转化"
     },
     {
         "id": 51495,
         "Key": "OrangeDyeDescription",
         "enUS": "ÿcIHerald's colors for their armor.\ngreat Cathedral of Light, favor the\nThe Burnt Knights, an offshoot of the once\nÿc4------------------------------\nTransmute with Weapon, Armor, Helm or Shield",
-        "zhTW": "ÿcI使用先驅者的顏色。\n分支，喜歡在盔甲上\n灼燒騎士是光輝大教堂的\nÿc4------------------------------\n與武器、盔甲、頭盔或盾牌一起轉化",
+        "zhTW": "ÿcI焦騎士是光輝大教堂的\n分支，喜歡在盔甲上\n使用先驅者的顏色。\nÿc4------------------------------\n與武器、盔甲、頭盔或盾牌進行轉化",
         "deDE": "ÿcIDie Verbrannten Ritter, ein Ableger der einst\ngroßen Kathedrale des Lichts, bevorzugen die\nFarben des Herolds für ihre Rüstung.\nÿc4------------------------------\nTransmutiere mit Waffe, Rüstung, Helm oder Schild",
         "esES": "ÿcILos Caballeros Quemados, una rama de la antigua\ngrande Catedral de la Luz, favorecen los\ncolores del Heraldo para su armadura.\nÿc4------------------------------\nTransmutar con Arma, Armadura, Yelmo o Escudo",
         "frFR": "ÿcILes Chevaliers Brûlés, une branche de la jadis\ngrande Cathédrale de la Lumière, favorisent les\ncouleurs du Héraut pour leur armure.\nÿc4------------------------------\nTransmuter avec Arme, Armure, Heaume ou Bouclier",
@@ -51541,13 +51541,13 @@
         "jaJP": "ÿcI焼け落ちた騎士団は、かつての偉大なる\n光の大聖堂の分派で、その鎧に\n伝令使いの色を好む。\nÿc4------------------------------\n武器、防具、兜、または盾と変成",
         "ptBR": "ÿcIOs Cavaleiros Queimados, uma ramificação da outrora\ngrande Catedral da Luz, favorecem as\ncores do Arauto para sua armadura.\nÿc4------------------------------\nTransmutar com Arma, Armadura, Elmo ou Escudo",
         "ruRU": "ÿcIОпаленные рыцари, ответвление некогда\nвеликого Собора Света, предпочитают\nцвета Глашатая для своих доспехов.\nÿc4------------------------------\nПреобразовать с оружием, доспехами, шлемом или щитом",
-        "zhCN": "ÿcI使用先驱者的颜色。\n分支，喜欢在盔甲上\n灼烧骑士是光辉大教堂的\nÿc4------------------------------\n与武器、盔甲、頭盔或盾牌一起转化"
+        "zhCN": "ÿcI焦骑士是光辉大教堂的\n分支，喜欢在盔甲上\n使用先驱者的颜色。\nÿc4------------------------------\n与武器、盔甲、头盔或盾牌进行转化"
     },
     {
         "id": 51496,
         "Key": "DyeRemoverDescription",
         "enUS": "ÿc1Warning: Do Not Drink.\n\nÿcIand tastes great!\nthat removes stains, cures rotfoot\nThe miraculous, mystical tonic\nÿc4---------------------------\nTransmute with an item to remove its dye",
-        "zhTW": "ÿc1警告：請勿飲用。\n\nÿcI而且味道好極了！\n去除污漬，治療腐足，\n神奇的神秘藥水，\nÿc4---------------------------\n與物品一起轉化以移除染色",
+        "zhTW": "ÿc1警告：請勿飲用。\n\nÿcI而且味道好極了！\n去除污漬，治療腐足，\n神奇的神秘藥水，\nÿc4---------------------------\n與物品進行轉化以移除染料",
         "deDE": "ÿc1Warnung: Nicht trinken.\n\nÿcIund schmeckt großartig!\nder Flecken entfernt, Fußfäule heilt\nDas wundersame, mystische Tonikum,\nÿc4---------------------------\nTransmutiere mit einem Gegenstand, um seine Färbung zu entfernen",
         "esES": "ÿc1Advertencia: No Beber.\n\nÿcI¡y sabe genial!\nque elimina manchas, cura el pie podrido\nEl tónico milagroso y místico\nÿc4---------------------------\nTransmutar con un objeto para eliminar su tinte",
         "frFR": "ÿc1Attention : Ne Pas Boire.\n\nÿcIet a un goût délicieux !\nqui élimine les taches, guérit le pied pourri\nLe tonique miraculeux et mystique\nÿc4---------------------------\nTransmuter avec un objet pour enlever sa teinture",
@@ -51558,7 +51558,7 @@
         "jaJP": "ÿc1警告：飲まないでください。\n\nÿcIしかも美味しい！\nシミを落とし、腐れ足を治す\n奇跡的な神秘の強壮剤、\nÿc4---------------------------\nアイテムと変成して染料を除去",
         "ptBR": "ÿc1Aviso: Não Beba.\n\nÿcIe tem um ótimo sabor!\nque remove manchas, cura pé podre\nO tônico milagroso e místico\nÿc4---------------------------\nTransmutar com um item para remover sua tintura",
         "ruRU": "ÿc1Внимание: Не Пить.\n\nÿcIи отлично на вкус!\nудаляющий пятна, лечащий гниль ступней\nЧудесный, мистический тоник,\nÿc4---------------------------\nПреобразовать с предметом, чтобы удалить его краситель",
-        "zhCN": "ÿc1警告：请勿饮用。\n\nÿcI而且味道好极了！\n去除污渍，治疗腐足，\n神奇的神秘药水，\nÿc4---------------------------\n与物品一起转化以移除染色"
+        "zhCN": "ÿc1警告：请勿饮用。\n\nÿcI而且味道好极了！\n去除污渍，治疗腐足，\n神奇的神秘药水，\nÿc4---------------------------\n与物品进行转化以移除染料"
     },
     {
         "id": 51497,
@@ -51581,7 +51581,7 @@
         "id": 51498,
         "Key": "Panda's Pelt",
         "enUS": "Panda's Pelt",
-        "zhTW": "熊貓的皮帽",
+        "zhTW": "熊貓的毛皮",
         "deDE": "Pandafell",
         "esES": "Piel del Panda",
         "frFR": "Pelage du Panda",
@@ -51592,7 +51592,7 @@
         "jaJP": "パンダの毛皮",
         "ptBR": "Pelagem do Panda",
         "ruRU": "Шкура панды",
-        "zhCN": "熊猫的皮帽"
+        "zhCN": "熊猫的毛皮"
     },
     {
         "id": 51499,
@@ -51615,7 +51615,7 @@
         "id": 51500,
         "Key": "Panda's Coat",
         "enUS": "Panda's Jacket",
-        "zhTW": "熊貓的外袍",
+        "zhTW": "熊貓的外套",
         "deDE": "Pandajacke",
         "esES": "Chaqueta del Panda",
         "frFR": "Veste du Panda",
@@ -51626,7 +51626,7 @@
         "jaJP": "パンダのジャケット",
         "ptBR": "Casaco do Panda",
         "ruRU": "Куртка панды",
-        "zhCN": "熊猫的外衣"
+        "zhCN": "熊猫的外套"
     },
     {
         "id": 51501,
@@ -51683,7 +51683,7 @@
         "id": 51504,
         "Key": "Bolt Case of Pestilence",
         "enUS": "Bolt Case of Pestilence",
-        "zhTW": "瘟疫弩盒",
+        "zhTW": "瘟疫弩矢盒",
         "deDE": "Bolzenkasten der Pestilenz",
         "esES": "Caja de virotes de Pestilencia",
         "frFR": "Boîte de carreaux de Pestilence",
@@ -51694,7 +51694,7 @@
         "jaJP": "ペスティレンスのボルトケース",
         "ptBR": "Estojo de Virolas da Peste",
         "ruRU": "Коробка Болтов Мора",
-        "zhCN": "瘟疫弩盒"
+        "zhCN": "瘟疫弩矢盒"
     },
     {
         "id": 51505,
@@ -51717,7 +51717,7 @@
         "id": 51506,
         "Key": "1gc",
         "enUS": "ÿcTGem Cluster",
-        "zhTW": "ÿcT寶石晶簇",
+        "zhTW": "ÿcT寶石簇",
         "deDE": "ÿcTEdelstein-Cluster",
         "esES": "ÿcTRacimo de gemas",
         "frFR": "ÿcTGrappe de gemmes",
@@ -51728,13 +51728,13 @@
         "jaJP": "ÿcTジェムクラスター",
         "ptBR": "ÿcTGrupo de gemas",
         "ruRU": "ÿcTСкопление самоцветов",
-        "zhCN": "ÿcT宝石晶簇"
+        "zhCN": "ÿcT宝石簇"
     },
     {
         "id": 51507,
         "Key": "1gc_desc",
         "enUS": "ÿc4Bag + Cluster = 20-30 Gems\nCube Recipe:\n\nÿcKa scintillating cluster of gems",
-        "zhTW": "ÿc4寶石袋 + 寶石晶簇 = 20-30 顆寶石\nCube公式：\n\nÿcK一簇閃爍的寶石",
+        "zhTW": "ÿc4袋子 + 寶石簇 = 20-30 顆寶石\n赫拉迪克方塊公式：\n\nÿcK一簇閃爍的寶石",
         "deDE": "ÿc4Beutel + Cluster = 20–30 Edelsteine\nWürfelrezept:\n\nÿcKEin schillernder Edelstein-Cluster",
         "esES": "ÿc4Bolsa + Racimo = 20-30 gemas\nReceta del cubo:\n\nÿcKUn racimo centelleante de gemas",
         "frFR": "ÿc4Sac + Grappe = 20 à 30 gemmes\nRecette du cube :\n\nÿcKUne grappe scintillante de gemmes",
@@ -51745,6 +51745,6 @@
         "jaJP": "ÿc4袋 + クラスター = 宝石20～30個\nキューブレシピ：\n\nÿcKきらめく宝石のかたまり",
         "ptBR": "ÿc4Saco + Grupo = 20–30 gemas\nReceita do cubo:\n\nÿcKUm grupo cintilante de gemas",
         "ruRU": "ÿc4Мешок + Скопление = 20–30 самоцветов\nРецепт куба:\n\nÿcKСверкающее скопление самоцветов",
-        "zhCN": "ÿc4宝石袋 + 宝石晶簇 = 20-30 颗宝石\nCube公式：\n\nÿcK一簇闪耀的宝石"
+        "zhCN": "ÿc4袋子 + 宝石簇 = 20-30 颗宝石\n赫拉迪克方块配方：\n\nÿcK一簇闪耀的宝石"
     }
 ]


### PR DESCRIPTION
- Adds new sprites to existing unique charms. These sprites can be repurposed in the future for new charms or other items.

- Updates the inventory sound of some charms to fit their appearances.

- All included charms have new JSON reference files (copied from the standard small charm). Flippy and ground models are functional.

- Updated some index names of certain charms so they could be more easily referenced through _uniqueitems.txt_. This meant changing some strings in _local/lng/strings/item-names.json_. However, no text displayed to the player has changed.


<img width="397" height="407" alt="Screenshot_806" src="https://github.com/user-attachments/assets/aeae2616-ab96-4524-83f6-715801b0b808" />


From left to right:

**Small Charms**
Collin's Destruction, Peacemaker, Autumn's Avatar, Argo's Anchor, Remembrance of Glory

**Large Charms**
Valknut, Life & Death, Throne of Power, Ogre King's Bowl

**Grand Charms**
Nightshade, Triskelion, Gheed's Fortune, Web of Wyrd, Conclave of Elements, Queen's Call


