### PR TITLE
fix: correct Standard of Heroes off-screen slot in materials stash tab

### DIFF
--- a/data/global/ui/layouts/bankexpansionlayouthd.json
+++ b/data/global/ui/layouts/bankexpansionlayouthd.json
@@ -678,7 +678,7 @@
                                 {
                     "type": "AdvancedStashSlotWidget", "name": "std",
                     "fields": {
-                        "rect": { "width": 98, "height": 98, "x": 310, "y": 242844 },
+                        "rect": { "width": 98, "height": 98, "x": 310, "y": 384 },
 						"itemCode": "std"
                     }
                 },


### PR DESCRIPTION
## Summary
- Fix Standard of Heroes disappearing when placed in stash
- The `AdvancedStashSlotWidget` for `std` in `bankexpansionlayouthd.json` had `y: 242844`, placing it far off-screen
- Changed `y` to `384` to align with the rejuvenation potion row (`rvs`/`rvl`)

## Root Cause
When placing Standard of Heroes in the stash, the game routes it to the materials tab (since `std` has `type: key` and a matching `AdvancedStashSlotWidget`). The slot's `y: 242844` coordinate renders it off-screen, making the item invisible and inaccessible.

The controller layout (`controller/bankexpansionlayouthd.json`) already has a correct value (`y: 415`). Only the KB/M layout was affected.

## Change
| File | Before | After |
|---|---|---|
| `data/global/ui/layouts/bankexpansionlayouthd.json` | `y: 242844` | `y: 384` |

Fixes #1035
