### PR TITLE
Apply rune name translations on mod info tab

### DIFF
--- a/data/global/ui/layouts/modinfo_runetablehd.json
+++ b/data/global/ui/layouts/modinfo_runetablehd.json
@@ -130,7 +130,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "El (1)",
+                                            "text": "@r01L (1)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 100, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -188,7 +188,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Eld (2)",
+                                            "text": "@r02L (2)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -246,7 +246,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Tir (3)",
+                                            "text": "@r03L (3)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -304,7 +304,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Nef (4)",
+                                            "text": "@r04L (4)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -362,7 +362,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Eth (5)",
+                                            "text": "@r05L (5)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -420,7 +420,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Ith (6)",
+                                            "text": "@r06L (6)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -478,7 +478,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Tal (7)",
+                                            "text": "@r07L (7)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -536,7 +536,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Ral (8)",
+                                            "text": "@r08L (8)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -594,7 +594,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Ort (9)",
+                                            "text": "@r09L (9)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -652,7 +652,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Thul (10)",
+                                            "text": "@r10L (10)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -710,7 +710,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Amn (11)",
+                                            "text": "@r11L (11)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -768,7 +768,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Sol (12)",
+                                            "text": "@r12L (12)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -826,7 +826,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Shael (13)",
+                                            "text": "@r13L (13)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -884,7 +884,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Dol (14)",
+                                            "text": "@r14L (14)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -942,7 +942,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Hel (15)",
+                                            "text": "@r15L (15)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1000,7 +1000,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Io (16)",
+                                            "text": "@r16L (16)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1058,7 +1058,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Lum (17)",
+                                            "text": "@r17L (17)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1116,7 +1116,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Ko (18)",
+                                            "text": "@r18L (18)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1174,7 +1174,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Fal (19)",
+                                            "text": "@r19L (19)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1232,7 +1232,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Lem (20)",
+                                            "text": "@r20L (20)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1290,7 +1290,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Pul (21)",
+                                            "text": "@r21L (21)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1348,7 +1348,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Um (22)",
+                                            "text": "@r22L (22)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1406,7 +1406,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Mal (23)",
+                                            "text": "@r23L (23)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1464,7 +1464,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Ist (24)",
+                                            "text": "@r24L (24)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1522,7 +1522,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Gul (25)",
+                                            "text": "@r25L (25)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1580,7 +1580,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Vex (26)",
+                                            "text": "@r26L (26)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1638,7 +1638,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Ohm (27)",
+                                            "text": "@r27L (27)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1696,7 +1696,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Lo (28)",
+                                            "text": "@r28L (28)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1754,7 +1754,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Sur (29)",
+                                            "text": "@r29L (29)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1812,7 +1812,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Ber (30)",
+                                            "text": "@r30L (30)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1870,7 +1870,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Jah (31)",
+                                            "text": "@r31L (31)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1928,7 +1928,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Cham (32)",
+                                            "text": "@r32L (32)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }
@@ -1986,7 +1986,7 @@
                                     {
                                         "type": "TextBoxWidget", "name": "Rune Name",
                                         "fields": {
-                                            "text": "Zod (33)",
+                                            "text": "@r33L (33)",
                                             "style": "$StyleSettingsText",
                                             "rect": {"width" : 120, "height": 100, "x":0,  "y": 50 }
                                         }


### PR DESCRIPTION
we cannot use `rXX` key. these have `color` tag.
another key `rXXL` only have plain text

----

these rune names is defined in `item-runes.json` similarly gem names & gem strings of `item-names.json`

I also know #1096 PR. IDK this strings are safe or not in other regions.. only tested with korean.

<img width="826" height="694" alt="D2R_TNfSsiDmOT" src="https://github.com/user-attachments/assets/a6915934-a90e-4b6c-9b09-f53f30554d0e" />
