### PR TITLE
fix: restore catnip preferred icon colors

### DIFF
--- a/data/hd/global/ui/hireables/WarImp.lowend.sprite
+++ b/data/hd/global/ui/hireables/WarImp.lowend.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0982961596730000996cdbd6be94a96371ab96f206720a06e175d17e0ce4fdc
+oid sha256:e29936689311fbcb3d95d85a34c694ac31e8a0ea22ddef15f442ba29eeed66aa
 size 14440

--- a/data/hd/global/ui/hireables/WarImp.sprite
+++ b/data/hd/global/ui/hireables/WarImp.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:51cd65d46de212eaa221102a163c369bb510fd2d12290f7c45d6eb4b3890a96b
+oid sha256:32c9f38a6960804422a9b115e7485de65ef1335e66fabc80d727bdfedafc8006
 size 57640


### PR DESCRIPTION
<img width="365" height="136" alt="image" src="https://github.com/user-attachments/assets/d33a20ac-573d-45c4-935b-9c12d3266543" />
