### PR TITLE
Update paladin_state_machine.json

### DIFF
--- a/data/hd/character/player/paladin/paladin_state_machine.json
+++ b/data/hd/character/player/paladin/paladin_state_machine.json
@@ -3435,7 +3435,7 @@
                     "hth_skill1"
                 ],
                 "bow": [
-                    "bow_skill1"
+                    "bow_attack2"
                 ],
                 "1hs": [
                     "1hs_skill1"


### PR DESCRIPTION
Fix state machine for 2h weapons.

I think paladin is weird and that their A1 animation sometimes uses A2 for some stupid reason. Since shield throw stole A2 animation, there probably is no corresponding animation for skill1 with 2h which is the shield bash animation

See also below that were accidentally pushed straight to trunk
                "stf": [
                    "stf_attack2"
                ],
                "2hs": [
                    "2hs_attack2"
                ],
                "2ht": [
                    "2ht_attack2"
                ],
                "xbw": [
                    "xbw_attack2"