### PR TITLE
KOR translation: Blinded by Faith

### DIFF
--- a/data/local/lng/strings/item-names.json
+++ b/data/local/lng/strings/item-names.json
@@ -54714,7 +54714,7 @@
         "esES": "Cegado por la Fe",
         "frFR": "Aveuglé par la Foi",
         "itIT": "Accecato dalla Fede",
-        "koKR": "신앙에 눈멀다",
+        "koKR": "눈먼 자로 이끄는 믿음",
         "plPL": "Oślepiony Wiarą",
         "esMX": "Cegado por la Fe",
         "jaJP": "信仰により盲目となる",


### PR DESCRIPTION
this item has multiple options
- 맹신 (blind faith; imo it's wrong translation)
- 눈먼 자의 믿음/신념 (faith of blinded; imo it also wrong translation)
- 눈먼 자로 이끄는 믿음 (faith which leads to be blinded)
- 눈먼 자로 만드는 믿음 (faith witch makes to be blinded)

`눈먼 자로` can replace `맹목으로` or `맹인으로` but nobody care this.

an item makes char to be blinded (reduce light radius), but it gives buffs. so, `price of faith` is `blinded`

I want to assign a name that explains this boring thing.

old translation is good for me. just it finished with `verb` so I feel it's not an item name.